### PR TITLE
Role Catalog: Global Roles, slug shadowing, attach-don't-mint (#47, #50)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,34 @@ _Avoid_: tenant, workspace, organization
 A supported operating mode in which the team feature is disabled and the installation is single-tenant. Must be as safe and as fully tested as the default mode.
 _Avoid_: single-tenant mode, no-teams
 
+**Global Admin**:
+A user with instance-level administrative status. Transcends the tenant boundary: sees and manages all teams and all users, and may enter any team without being a member. Distinct from a Super Admin, whose power is confined to one team.
+_Avoid_: super admin, root user, owner
+
+**Super Admin**:
+A role-level grant of every permission within the single team where the role is held. Says nothing about other teams.
+_Avoid_: global admin, admin (ambiguous)
+
+**Global Role**:
+A role defined once for the whole instance, available in every team. The set of global roles is the **Role Catalog**. Only Global Admins define global roles.
+_Avoid_: shared role, default role
+
+**Team Role**:
+A role defined by a team, existing only within that team. Team super admins manage their team's roles.
+_Avoid_: custom role, local role
+
+**Shadowing**:
+When a team defines a role with the same slug as a global role, the team's definition replaces the global one inside that team; other teams are unaffected. Deleting the shadow falls back to the global definition. A role's identity within a team is its slug.
+_Avoid_: overriding (ambiguous), forking
+
+**Membership**:
+A user's belonging to a team, always with exactly one role in that team. Global Admins entering a team they don't belong to are visiting, not members.
+_Avoid_: association, assignment
+
+**Invitation**:
+A single-use, expiring, role-carrying offer of team Membership addressed to an email. Accepting attaches the existing user with that email, or registers a new one, into the team with the carried role.
+_Avoid_: invite link, signup token
+
 **Resource Editor**:
 A local-development tool for editing resource definitions from the browser. Not a production feature; it only exists in local environments.
 _Avoid_: admin builder, schema editor

--- a/database/migrations/consolidate_per_team_admin_roles.php.stub
+++ b/database/migrations/consolidate_per_team_admin_roles.php.stub
@@ -1,0 +1,117 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Attach-don't-mint upgrade (best-effort, pre-release posture per ADR 0003).
+ *
+ * Older installs minted a per-team `admin` role for every team and pointed the
+ * creator's Membership at it. The Role Catalog model instead shares a single
+ * global `admin` role (team_id = null). This migration consolidates the
+ * *untouched* per-team admin rows into that global role — remapping their
+ * Memberships (user_role.role_id) — then deletes the now-orphaned per-team row.
+ *
+ * "Untouched" means a default row nobody customized: slug `admin`, super_admin
+ * true, name `Admin`, and an empty permission set. Customized rows (renamed,
+ * permissions set, or super_admin turned off) are deliberately left in place —
+ * they become Team Roles that Shadow the global `admin` by slug.
+ *
+ * Guards:
+ *  - Teams-off installs (no `roles.team_id` / `user_role.team_id` column) are a
+ *    strict no-op: there is a single flat catalog, nothing to consolidate.
+ *  - Fresh installs (no per-team admin rows) are a strict no-op.
+ *  - The migration never touches the global row (team_id = null).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Teams-off mode has a single flat catalog: no team scoping columns, so
+        // there is nothing to consolidate. Strict no-op.
+        if (! Schema::hasTable('roles') || ! Schema::hasTable('user_role')) {
+            return;
+        }
+
+        if (! Schema::hasColumn('roles', 'team_id') || ! Schema::hasColumn('user_role', 'team_id')) {
+            return;
+        }
+
+        // Find the untouched per-team admin rows (team_id set, default shape).
+        $candidates = DB::table('roles')
+            ->whereNotNull('team_id')
+            ->where('slug', 'admin')
+            ->where('super_admin', true)
+            ->where('name', 'Admin')
+            ->get();
+
+        $untouched = $candidates->filter(fn ($role) => $this->hasEmptyPermissions($role->permissions ?? null));
+
+        if ($untouched->isEmpty()) {
+            // Nothing to consolidate — fresh install or already migrated.
+            return;
+        }
+
+        // Ensure the shared global admin role exists, using the same defaults as
+        // RoleCatalogSeeder. Created directly via the query builder so team_id
+        // stays null (the Role model's saving hook would otherwise re-team it).
+        $globalAdminId = $this->ensureGlobalAdminId();
+
+        foreach ($untouched as $role) {
+            // Remap every Membership that points at this per-team admin row to
+            // the shared global role. The pivot's team_id already records the
+            // team, so access is preserved.
+            DB::table('user_role')
+                ->where('role_id', $role->id)
+                ->update(['role_id' => $globalAdminId]);
+
+            // The per-team admin row is now orphaned; remove it.
+            DB::table('roles')->where('id', $role->id)->delete();
+        }
+    }
+
+    private function ensureGlobalAdminId(): int
+    {
+        $existing = DB::table('roles')
+            ->whereNull('team_id')
+            ->where('slug', 'admin')
+            ->first();
+
+        if ($existing) {
+            return (int) $existing->id;
+        }
+
+        return (int) DB::table('roles')->insertGetId([
+            'name' => 'Admin',
+            'slug' => 'admin',
+            'description' => 'Admin can perform everything.',
+            'super_admin' => true,
+            'permissions' => json_encode([]),
+            'team_id' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * A permission set counts as empty (untouched) when it is null, an empty
+     * string, or decodes to an empty array/object.
+     *
+     * @param  mixed  $permissions
+     */
+    private function hasEmptyPermissions($permissions): bool
+    {
+        if ($permissions === null || $permissions === '') {
+            return true;
+        }
+
+        if (is_array($permissions)) {
+            return $permissions === [];
+        }
+
+        $decoded = json_decode((string) $permissions, true);
+
+        return empty($decoded);
+    }
+};

--- a/docs/adr/0005-role-catalog-slug-shadowing.md
+++ b/docs/adr/0005-role-catalog-slug-shadowing.md
@@ -49,3 +49,7 @@ keeps Membership rows immutable and makes catalog edits O(1) and atomic.
 - The merged, de-duplicated Roles index and the role pickers that present the
   resolved catalog in the UI are out of scope here (tracked separately); this ADR
   covers only identity and check-time resolution.
+- Moving existing per-team admin rows onto the shared global `admin` role ships as
+  a best-effort consolidation migration — a deliberate, narrow exception to ADR
+  0003's "no upgrade machinery" stance, justified by the pre-release posture and
+  decided in the parent spec (#45).

--- a/docs/adr/0005-role-catalog-slug-shadowing.md
+++ b/docs/adr/0005-role-catalog-slug-shadowing.md
@@ -1,0 +1,51 @@
+# Role identity is its slug, and Shadowing resolves at check time
+
+Roles in the catalog are either **Global Roles** (`roles.team_id = null`, defined
+once for the instance) or **Team Roles** (`roles.team_id` set, defined by one
+team). A team **Shadows** a Global Role by creating a Team Role with the same
+slug. We resolve which definition applies **by slug, at permission-check time**,
+rather than by rewriting Membership pivot rows when a Shadow is created or
+deleted.
+
+A Membership (`user_role`: `user_id`, `role_id`, `team_id`) records the team a
+user belongs to and the role slug they hold there. When we evaluate that
+Membership we resolve the slug within the team: if the team owns a role with that
+slug (a Shadow), it wins; otherwise the Global Role with that slug applies. In
+Teams-off mode there is a single flat catalog, so the Global Role simply is the
+role. All of this funnels through one seam — `Role::resolveForTeam(string $slug,
+?int $teamId)` — with `User::cachedRoles()` memoizing the resolved set per team
+context and invalidating via a catalog version that bumps on every role write,
+so a Shadow created or deleted mid-request still takes effect immediately.
+
+We considered the alternative of **re-pointing Membership rows** when a Shadow is
+created (rewrite `user_role.role_id` to the Team Role) and again when it is
+deleted (rewrite back to the Global Role). We rejected it: it makes creating or
+deleting a role a bulk write across every affected Membership, it races with
+concurrent Membership changes, it loses the distinction between "assigned the
+catalog role" and "assigned a specific row", and a half-applied rewrite leaves
+permissions in an inconsistent state. Treating the slug as the role's identity
+keeps Membership rows immutable and makes catalog edits O(1) and atomic.
+
+## Consequences
+
+- The slug is a role's identity **within a team context**. `unique(slug, team_id)`
+  (Teams-on) and `unique(slug)` (Teams-off) enforce one definition per scope, and
+  a Team Role may deliberately share a slug with a Global Role — that is a Shadow,
+  not a conflict.
+- Creating or deleting a Shadow changes permission outcomes instantly for every
+  member holding that slug, with no data migration and no pivot rewrite.
+- Permission checks (`hasPermissionTo`, `hasPermission`, `isSuperAdmin`,
+  `hasRole`, `hasAnyRole`) all read through `User::cachedRoles()`, which resolves
+  each Membership through the seam. Resolution deliberately bypasses `TeamScope`
+  (via `withoutGlobalScopes`) so a Global Role is visible even though it carries
+  no `team_id`.
+- Permission sets are normalized in exactly one place (`User::normalizePermissions`),
+  so a set persisted as a cast array or as a JSON string behaves identically. The
+  previous ad-hoc `json_decode` "temporary fix" in `hasPermissionTo` is removed.
+- The base catalog (`admin` Super Admin + `user`) is seeded by
+  `Aura\Base\Database\Seeders\RoleCatalogSeeder`, invoked from the install command
+  after migrations, in both Teams-on and Teams-off mode. Tests that need the
+  catalog invoke the same seeder, so they exercise the real seeding path.
+- The merged, de-duplicated Roles index and the role pickers that present the
+  resolved catalog in the UI are out of scope here (tracked separately); this ADR
+  covers only identity and check-time resolution.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1158,7 +1158,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Aura\\Base\\Resources\\User\:\:\$current_team_id\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 4
 			path: src/Resources/User.php
 
 		-

--- a/src/AuraServiceProvider.php
+++ b/src/AuraServiceProvider.php
@@ -215,7 +215,7 @@ class AuraServiceProvider extends PackageServiceProvider
             ->hasViews('aura')
             ->hasAssets()
             ->hasRoutes('web')
-            ->hasMigrations(['create_aura_tables'])
+            ->hasMigrations(['create_aura_tables', 'consolidate_per_team_admin_roles'])
             ->runsMigrations()
             ->hasCommands([
                 InstallConfigCommand::class,

--- a/src/AuraServiceProvider.php
+++ b/src/AuraServiceProvider.php
@@ -20,6 +20,7 @@ use Aura\Base\Commands\PublishCommand;
 use Aura\Base\Commands\TransferFromPostsToCustomTable;
 use Aura\Base\Commands\TransformTableToResource;
 use Aura\Base\Commands\UpdateSchemaFromMigration;
+use Aura\Base\Database\Seeders\RoleCatalogSeeder;
 use Aura\Base\Facades\Aura;
 use Aura\Base\Livewire\Attachment\Index as AttachmentIndex;
 use Aura\Base\Livewire\AttachmentDetails;
@@ -256,6 +257,11 @@ class AuraServiceProvider extends PackageServiceProvider
 
                         if ($command->confirm('Do you want to run the migrations?', true)) {
                             $command->call('migrate');
+
+                            // Seed the base Role Catalog (admin + user Global Roles)
+                            // so a fresh install works in both Teams-on and
+                            // Teams-off mode without hand-seeding. Idempotent.
+                            RoleCatalogSeeder::seed();
                         }
 
                         if ($command->confirm('Do you want to create a user?', true)) {

--- a/src/Commands/MakeUser.php
+++ b/src/Commands/MakeUser.php
@@ -46,14 +46,9 @@ class MakeUser extends Command
 
             $user->forceFill(['current_team_id' => $team->id])->save();
         } else {
-            // Reuse the seeded admin Global Role (Teams-off has a unique slug
-            // constraint), creating it only if the catalog was not seeded.
-            $role = Role::firstOrCreate(['slug' => 'admin'], [
-                'name' => 'Admin',
-                'description' => 'Admin can perform everything.',
-                'super_admin' => true,
-                'permissions' => [],
-            ]);
+            // Reuse the seeded admin Global Role, self-healing it from the shared
+            // catalog defaults if the catalog was not seeded.
+            $role = Role::firstOrCreateCatalogRole('admin');
 
             // This bootstrap command creates the first administrator, so attach
             // the role directly instead of going through delegated role editing.

--- a/src/Commands/MakeUser.php
+++ b/src/Commands/MakeUser.php
@@ -46,10 +46,10 @@ class MakeUser extends Command
 
             $user->forceFill(['current_team_id' => $team->id])->save();
         } else {
-            // Create an Admin role without team association
-            $role = Role::create([
+            // Reuse the seeded admin Global Role (Teams-off has a unique slug
+            // constraint), creating it only if the catalog was not seeded.
+            $role = Role::firstOrCreate(['slug' => 'admin'], [
                 'name' => 'Admin',
-                'slug' => 'admin',
                 'description' => 'Admin can perform everything.',
                 'super_admin' => true,
                 'permissions' => [],

--- a/src/Database/Seeders/RoleCatalogSeeder.php
+++ b/src/Database/Seeders/RoleCatalogSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Aura\Base\Database\Seeders;
 
+use Aura\Base\Resources\Role;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -37,11 +38,11 @@ class RoleCatalogSeeder extends Seeder
 
         $hasTeamColumn = Schema::hasColumn('roles', 'team_id');
 
-        static::seedRole('admin', 'Admin', 'Admin can perform everything.', true, $hasTeamColumn);
-        static::seedRole('user', 'User', 'Default role with minimal permissions.', false, $hasTeamColumn);
+        static::seedRole('admin', $hasTeamColumn);
+        static::seedRole('user', $hasTeamColumn);
     }
 
-    protected static function seedRole(string $slug, string $name, string $description, bool $superAdmin, bool $hasTeamColumn): void
+    protected static function seedRole(string $slug, bool $hasTeamColumn): void
     {
         $exists = DB::table('roles')
             ->where('slug', $slug)
@@ -52,12 +53,16 @@ class RoleCatalogSeeder extends Seeder
             return;
         }
 
+        // Shared catalog defaults, so the seeded rows and the self-healed rows
+        // (Role::firstOrCreateCatalogRole) stay identical.
+        $defaults = Role::catalogDefaults($slug);
+
         $row = [
-            'name' => $name,
-            'slug' => $slug,
-            'description' => $description,
-            'super_admin' => $superAdmin,
-            'permissions' => json_encode([]),
+            'name' => $defaults['name'],
+            'slug' => $defaults['slug'],
+            'description' => $defaults['description'],
+            'super_admin' => $defaults['super_admin'],
+            'permissions' => json_encode($defaults['permissions']),
             'created_at' => now(),
             'updated_at' => now(),
         ];

--- a/src/Database/Seeders/RoleCatalogSeeder.php
+++ b/src/Database/Seeders/RoleCatalogSeeder.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Aura\Base\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Seeds the two Global Roles that make up the base Role Catalog.
+ *
+ * A fresh install — in either Teams-on or Teams-off mode — must have an `admin`
+ * (Super Admin) and a `user` Global Role so that registration and team creation
+ * work without hand-seeding. Global Roles carry team_id = null (Teams-on) or are
+ * simply the only rows (Teams-off). The seeder is idempotent so it is safe to run
+ * from the install migration, the install command, or a database seed.
+ */
+class RoleCatalogSeeder extends Seeder
+{
+    public function run(): void
+    {
+        static::seed();
+    }
+
+    /**
+     * The Global Roles the package guarantees on a fresh install.
+     *
+     * Order matters: `admin` is seeded first so it keeps the lowest id, which
+     * preserves the long-standing "the admin role is the first role" assumption
+     * in Teams-off installs.
+     */
+    public static function seed(): void
+    {
+        if (! Schema::hasTable('roles')) {
+            return;
+        }
+
+        $hasTeamColumn = Schema::hasColumn('roles', 'team_id');
+
+        static::seedRole('admin', 'Admin', 'Admin can perform everything.', true, $hasTeamColumn);
+        static::seedRole('user', 'User', 'Default role with minimal permissions.', false, $hasTeamColumn);
+    }
+
+    protected static function seedRole(string $slug, string $name, string $description, bool $superAdmin, bool $hasTeamColumn): void
+    {
+        $exists = DB::table('roles')
+            ->where('slug', $slug)
+            ->when($hasTeamColumn, fn ($query) => $query->whereNull('team_id'))
+            ->exists();
+
+        if ($exists) {
+            return;
+        }
+
+        $row = [
+            'name' => $name,
+            'slug' => $slug,
+            'description' => $description,
+            'super_admin' => $superAdmin,
+            'permissions' => json_encode([]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+
+        if ($hasTeamColumn) {
+            $row['team_id'] = null;
+        }
+
+        DB::table('roles')->insert($row);
+    }
+}

--- a/src/Fields/Roles.php
+++ b/src/Fields/Roles.php
@@ -121,9 +121,7 @@ class Roles extends AdvancedSelect implements PreloadsTableDisplay
             // shared Global Roles (team_id = null) from the catalog. Roles owned
             // by another team stay unassignable, so cross-team injection is still
             // refused. (The super_admin escalation guard below is unchanged.)
-            $assignableRoles->where(function ($query) use ($teamId) {
-                $query->where('team_id', $teamId)->orWhereNull('team_id');
-            });
+            $assignableRoles->visibleToTeam($teamId);
         }
 
         $requestedRoles = $assignableRoles->whereKey($roleIds)->get();

--- a/src/Fields/Roles.php
+++ b/src/Fields/Roles.php
@@ -70,7 +70,13 @@ class Roles extends AdvancedSelect implements PreloadsTableDisplay
             $roles = $row->getRelation('roles');
 
             if (config('aura.teams')) {
-                $roles = $roles->where('team_id', $row->getAttribute('current_team_id'))->values();
+                // Filter by the Membership pivot's team_id so Global Roles (held
+                // via a Membership but carrying team_id = null on the role row)
+                // are kept for the row's current team.
+                $currentTeamId = $row->getAttribute('current_team_id');
+                $roles = $roles
+                    ->filter(fn ($role) => optional($role->pivot)->team_id == $currentTeamId)
+                    ->values();
             }
 
             $row->setTableDisplayValue($slug, $roles);
@@ -80,7 +86,11 @@ class Roles extends AdvancedSelect implements PreloadsTableDisplay
     public function relationship($model, $field)
     {
         if (config('aura.teams')) {
-            return $model->roles()->where('roles.team_id', $model->current_team_id);
+            // A user's roles in a team are resolved through the Membership pivot,
+            // not the role row's team_id. Filtering on roles.team_id would drop
+            // Global Roles (team_id = null) the user holds via a Membership, e.g.
+            // the shared global admin role. Filter on the pivot's team_id instead.
+            return $model->roles()->wherePivot('team_id', $model->current_team_id);
         }
 
         return $model->roles();
@@ -106,7 +116,14 @@ class Roles extends AdvancedSelect implements PreloadsTableDisplay
         if (config('aura.teams')) {
             $teamId = $post->current_team_id ?? optional(auth()->user())->current_team_id;
             $currentRoles->wherePivot('team_id', $teamId);
-            $assignableRoles->where('team_id', $teamId);
+
+            // Assignable roles are the current team's own Team Roles plus the
+            // shared Global Roles (team_id = null) from the catalog. Roles owned
+            // by another team stay unassignable, so cross-team injection is still
+            // refused. (The super_admin escalation guard below is unchanged.)
+            $assignableRoles->where(function ($query) use ($teamId) {
+                $query->where('team_id', $teamId)->orWhereNull('team_id');
+            });
         }
 
         $requestedRoles = $assignableRoles->whereKey($roleIds)->get();

--- a/src/Http/Controllers/Auth/RegisteredUserController.php
+++ b/src/Http/Controllers/Auth/RegisteredUserController.php
@@ -66,9 +66,15 @@ class RegisteredUserController extends Controller
 
             $user->save();
 
-            $role = $team->roles->first();
+            // Attach-don't-mint: the registrant becomes Super Admin of their new
+            // team via the shared global `admin` role rather than a per-team admin
+            // row. The team is created before login, so the Team `created` hook's
+            // auth-guarded attach does not run here — assign the role explicitly
+            // through the Roles field. The helper self-heals the Global Role when
+            // the catalog was never seeded.
+            $adminRole = app(config('aura.resources.role'))::firstOrCreateGlobalAdmin();
 
-            $user->update(['roles' => [$role->id]]);
+            $user->update(['roles' => [$adminRole->id]]);
         } else {
             // no aura.teams
             $request->validate([

--- a/src/Http/Controllers/Auth/RegisteredUserController.php
+++ b/src/Http/Controllers/Auth/RegisteredUserController.php
@@ -89,7 +89,10 @@ class RegisteredUserController extends Controller
                 'password' => Hash::make($request->password),
             ]);
 
-            $role = app(config('aura.resources.role'))::where('slug', 'user')->firstOrFail();
+            // Self-heal the default `user` catalog role so registration works on
+            // a bare `migrate` install where the seeder never ran, instead of
+            // throwing on a missing row.
+            $role = app(config('aura.resources.role'))::firstOrCreateCatalogRole('user');
 
             $user->update(['roles' => [$role->id]]);
         }

--- a/src/Http/Controllers/Auth/TeamInvitationController.php
+++ b/src/Http/Controllers/Auth/TeamInvitationController.php
@@ -40,9 +40,7 @@ class TeamInvitationController extends Controller
             // access. The Membership records the team via the pivot regardless.
             $role = Role::withoutGlobalScopes()
                 ->whereKey($invitation->role)
-                ->where(function ($query) use ($team) {
-                    $query->where('team_id', $team->id)->orWhereNull('team_id');
-                })
+                ->visibleToTeam($team->id)
                 ->firstOrFail();
 
             $user->roles()->attach($role->id, ['team_id' => $team->id]);

--- a/src/Http/Controllers/Auth/TeamInvitationController.php
+++ b/src/Http/Controllers/Auth/TeamInvitationController.php
@@ -34,9 +34,15 @@ class TeamInvitationController extends Controller
         abort_unless(is_string($userEmail) && strcasecmp($userEmail, $invitation->email) === 0, 403);
 
         if (! $user->teams()->whereKey($team->id)->exists()) {
+            // The invitation may carry a Team Role owned by this team or a shared
+            // Global Role (team_id = null). Accept either, but still refuse a role
+            // owned by a different team so invitations cannot inject cross-team
+            // access. The Membership records the team via the pivot regardless.
             $role = Role::withoutGlobalScopes()
                 ->whereKey($invitation->role)
-                ->where('team_id', $team->id)
+                ->where(function ($query) use ($team) {
+                    $query->where('team_id', $team->id)->orWhereNull('team_id');
+                })
                 ->firstOrFail();
 
             $user->roles()->attach($role->id, ['team_id' => $team->id]);

--- a/src/Models/Scopes/TeamScope.php
+++ b/src/Models/Scopes/TeamScope.php
@@ -2,6 +2,7 @@
 
 namespace Aura\Base\Models\Scopes;
 
+use Aura\Base\Resources\Role;
 use Aura\Base\Resources\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -78,11 +79,8 @@ class TeamScope implements Scope
             // (team_id = null). The merged/de-duplicated Roles UI is handled
             // elsewhere; here we only make Global Roles visible at the query
             // layer. Shadow resolution itself goes through Role::resolveForTeam.
-            if ($model->getTable() === 'roles') {
-                $builder->where(function ($query) use ($currentTeamId) {
-                    $query->where('roles.team_id', $currentTeamId)
-                        ->orWhereNull('roles.team_id');
-                });
+            if ($model instanceof Role) {
+                $model->scopeVisibleToTeam($builder, $currentTeamId);
 
                 self::$applying = false;
 

--- a/src/Models/Scopes/TeamScope.php
+++ b/src/Models/Scopes/TeamScope.php
@@ -73,6 +73,22 @@ class TeamScope implements Scope
                 return;
             }
 
+            // Roles resolve against the Role Catalog: within a team, queries see
+            // both the team's own Team Roles and the shared Global Roles
+            // (team_id = null). The merged/de-duplicated Roles UI is handled
+            // elsewhere; here we only make Global Roles visible at the query
+            // layer. Shadow resolution itself goes through Role::resolveForTeam.
+            if ($model->getTable() === 'roles') {
+                $builder->where(function ($query) use ($currentTeamId) {
+                    $query->where('roles.team_id', $currentTeamId)
+                        ->orWhereNull('roles.team_id');
+                });
+
+                self::$applying = false;
+
+                return;
+            }
+
             // For all other models, filter by team_id
             $builder->where($model->getTable().'.team_id', $currentTeamId);
 

--- a/src/Resources/Role.php
+++ b/src/Resources/Role.php
@@ -65,6 +65,50 @@ class Role extends Resource
         GenerateAllResourcePermissions::dispatch();
     }
 
+    /**
+     * Ensure the shared global `admin` Global Role exists and return it.
+     *
+     * This backs the "attach-don't-mint" model: team creation and registration
+     * attach the creator to this single Super Admin Global Role (team_id = null)
+     * instead of minting a per-team admin row. It self-heals installs whose
+     * catalog was never seeded (bare `migrate`, or the test harness, which does
+     * not run aura:install), using the same defaults as RoleCatalogSeeder.
+     *
+     * The row is written with saveQuietly() so the InitialPostFields saving hook
+     * — which auto-assigns the current team's id whenever team_id is not set —
+     * does not silently re-team the Global Role. The catalog version is bumped
+     * explicitly since quiet writes fire no model events.
+     */
+    public static function firstOrCreateGlobalAdmin(): self
+    {
+        $role = static::withoutGlobalScopes()
+            ->where('slug', 'admin')
+            ->whereNull('team_id')
+            ->first();
+
+        if ($role) {
+            return $role;
+        }
+
+        // team_id is passed explicitly (it is fillable) so the row is written as
+        // a Global Role. saveQuietly() skips the InitialPostFields saving hook,
+        // which would otherwise re-team it to the current team.
+        $role = static::withoutGlobalScopes()->newModelInstance([
+            'name' => 'Admin',
+            'slug' => 'admin',
+            'description' => 'Admin can perform everything.',
+            'super_admin' => true,
+            'permissions' => [],
+            'team_id' => null,
+        ]);
+
+        $role->saveQuietly();
+
+        User::bumpRoleCatalogVersion();
+
+        return $role;
+    }
+
     public static function getFields()
     {
         return [

--- a/src/Resources/Role.php
+++ b/src/Resources/Role.php
@@ -160,6 +160,51 @@ class Role extends Resource
         return $this->hasMany(Meta::class, 'post_id');
     }
 
+    /**
+     * Resolve the effective role for a given slug within a team context.
+     *
+     * This is the single Role Catalog resolution seam. Shadowing is resolved by
+     * slug at check time: when a team owns a role with the given slug (a Shadow),
+     * that Team Role wins; otherwise the Global Role (team_id = null) applies.
+     * In Teams-off mode there is only one scope, so the Global Role is the role.
+     *
+     * Membership pivot rows are never rewritten — creating or deleting a Shadow
+     * changes the resolved role (and therefore permission outcomes) instantly.
+     *
+     * @param  string  $slug  The role slug that identifies the role within a team.
+     * @param  int|null  $teamId  The team context to resolve within (null = global/Teams-off).
+     */
+    public static function resolveForTeam(string $slug, ?int $teamId = null): ?self
+    {
+        // Bypass TeamScope (and any other global scopes) so both the current
+        // team's rows and the global (team_id = null) rows are considered.
+        $base = static::withoutGlobalScopes();
+
+        // Teams-off mode: the roles table has no team_id column, so there is a
+        // single flat catalog. The global role simply is the role.
+        if (! config('aura.teams')) {
+            return (clone $base)->where('slug', $slug)->first();
+        }
+
+        // Teams-on: a Team Role (Shadow) wins over the Global Role by slug.
+        if ($teamId !== null) {
+            $teamRole = (clone $base)
+                ->where('slug', $slug)
+                ->where('team_id', $teamId)
+                ->first();
+
+            if ($teamRole) {
+                return $teamRole;
+            }
+        }
+
+        // Fall back to the Global Role definition.
+        return (clone $base)
+            ->where('slug', $slug)
+            ->whereNull('team_id')
+            ->first();
+    }
+
     public function teams(): BelongsToMany
     {
         return $this->belongsToMany(Team::class, 'user_role')
@@ -188,5 +233,16 @@ class Role extends Resource
 
         return $this->belongsToMany(User::class, 'user_role')
             ->withTimestamps();
+    }
+
+    protected static function booted()
+    {
+        parent::booted();
+
+        // Any catalog write (including creating or deleting a Shadow) bumps the
+        // Role Catalog version so every user's resolved-roles memo recomputes on
+        // its next permission check — instant shadow effect, no per-call queries.
+        static::saved(fn () => User::bumpRoleCatalogVersion());
+        static::deleted(fn () => User::bumpRoleCatalogVersion());
     }
 }

--- a/src/Resources/Role.php
+++ b/src/Resources/Role.php
@@ -43,6 +43,15 @@ class Role extends Resource
         'super_admin' => 'boolean',
     ];
 
+    /**
+     * Monotonic Role Catalog version, bumped whenever any role is written or
+     * deleted (including quiet catalog-role writes). It keys the per-instance
+     * resolved-roles memo (User::cachedRoles) so creating or deleting a Shadow
+     * invalidates every user's cache lazily — instant shadow effect without
+     * paying resolution queries on every permission check.
+     */
+    protected static int $catalogVersion = 0;
+
     protected static $dropdown = 'Users';
 
     protected $fillable = [
@@ -60,53 +69,110 @@ class Role extends Resource
 
     protected $with = [];
 
+    /**
+     * Bump the Role Catalog version, invalidating every user's resolved-roles
+     * memo. Called from Role write/delete hooks and from the quiet catalog-role
+     * writes (which fire no model events) so a Shadow or catalog role created or
+     * deleted mid-request takes effect on the next permission check.
+     */
+    public static function bumpCatalogVersion(): void
+    {
+        static::$catalogVersion++;
+    }
+
+    /**
+     * The default attributes for a base Role Catalog role, keyed by slug.
+     *
+     * Single source of truth for the seeded/self-healed catalog defaults, shared
+     * by RoleCatalogSeeder, firstOrCreateCatalogRole(), the MakeUser command and
+     * the test helpers. (The upgrade migration deliberately keeps its own copy —
+     * a migration must not depend on model code.)
+     *
+     * @return array{name: string, slug: string, description: string, super_admin: bool, permissions: array<string, bool>}
+     */
+    public static function catalogDefaults(string $slug): array
+    {
+        return match ($slug) {
+            'admin' => [
+                'name' => 'Admin',
+                'slug' => 'admin',
+                'description' => 'Admin can perform everything.',
+                'super_admin' => true,
+                'permissions' => [],
+            ],
+            'user' => [
+                'name' => 'User',
+                'slug' => 'user',
+                'description' => 'Default role with minimal permissions.',
+                'super_admin' => false,
+                'permissions' => [],
+            ],
+            default => throw new \InvalidArgumentException("Unknown catalog role slug [{$slug}]."),
+        };
+    }
+
+    /**
+     * The monotonic Role Catalog version. Keys the per-instance resolved-roles
+     * memo (User::cachedRoles) so creating or deleting a catalog role or Shadow
+     * invalidates every user's cache lazily.
+     */
+    public static function catalogVersion(): int
+    {
+        return static::$catalogVersion;
+    }
+
     public function createMissingPermissions()
     {
         GenerateAllResourcePermissions::dispatch();
     }
 
     /**
-     * Ensure the shared global `admin` Global Role exists and return it.
-     *
-     * This backs the "attach-don't-mint" model: team creation and registration
-     * attach the creator to this single Super Admin Global Role (team_id = null)
-     * instead of minting a per-team admin row. It self-heals installs whose
-     * catalog was never seeded (bare `migrate`, or the test harness, which does
-     * not run aura:install), using the same defaults as RoleCatalogSeeder.
+     * Ensure a base Role Catalog role (Global Role, team_id = null) exists and
+     * return it. Self-heals installs whose catalog was never seeded (a bare
+     * `migrate`, or the test harness, which does not run aura:install), using the
+     * shared catalogDefaults().
      *
      * The row is written with saveQuietly() so the InitialPostFields saving hook
-     * — which auto-assigns the current team's id whenever team_id is not set —
-     * does not silently re-team the Global Role. The catalog version is bumped
-     * explicitly since quiet writes fire no model events.
+     * — which auto-assigns the current team's id whenever team_id is unset — does
+     * not silently re-team the Global Role. In Teams-off mode the roles table has
+     * no team_id column, so the flat catalog row is used as-is. The catalog
+     * version is bumped explicitly since quiet writes fire no model events.
      */
-    public static function firstOrCreateGlobalAdmin(): self
+    public static function firstOrCreateCatalogRole(string $slug): self
     {
-        $role = static::withoutGlobalScopes()
-            ->where('slug', 'admin')
-            ->whereNull('team_id')
-            ->first();
+        $query = static::withoutGlobalScopes()->where('slug', $slug);
 
-        if ($role) {
+        if (config('aura.teams')) {
+            $query->whereNull('team_id');
+        }
+
+        if ($role = $query->first()) {
             return $role;
         }
 
-        // team_id is passed explicitly (it is fillable) so the row is written as
-        // a Global Role. saveQuietly() skips the InitialPostFields saving hook,
-        // which would otherwise re-team it to the current team.
-        $role = static::withoutGlobalScopes()->newModelInstance([
-            'name' => 'Admin',
-            'slug' => 'admin',
-            'description' => 'Admin can perform everything.',
-            'super_admin' => true,
-            'permissions' => [],
-            'team_id' => null,
-        ]);
+        $attributes = static::catalogDefaults($slug);
 
+        if (config('aura.teams')) {
+            // team_id is fillable, so passing it explicitly writes a Global Role.
+            $attributes['team_id'] = null;
+        }
+
+        $role = static::withoutGlobalScopes()->newModelInstance($attributes);
         $role->saveQuietly();
 
-        User::bumpRoleCatalogVersion();
+        static::bumpCatalogVersion();
 
         return $role;
+    }
+
+    /**
+     * Ensure the shared global `admin` Global Role (Super Admin) exists. Backs
+     * the "attach-don't-mint" model: team creation and registration attach the
+     * creator to this single role instead of minting a per-team admin row.
+     */
+    public static function firstOrCreateGlobalAdmin(): self
+    {
+        return static::firstOrCreateCatalogRole('admin');
     }
 
     public static function getFields()
@@ -249,6 +315,21 @@ class Role extends Resource
             ->first();
     }
 
+    /**
+     * Constrain a role query to the roles visible within a team context: the
+     * team's own Team Roles plus the shared Global Roles (team_id = null). This
+     * is the single expression of the "team-or-global" shape used by the
+     * assignable-roles guard, invitation acceptance and TeamScope's roles branch.
+     */
+    public function scopeVisibleToTeam($query, ?int $teamId)
+    {
+        $column = $query->getModel()->getTable().'.team_id';
+
+        return $query->where(function ($query) use ($column, $teamId) {
+            $query->where($column, $teamId)->orWhereNull($column);
+        });
+    }
+
     public function teams(): BelongsToMany
     {
         return $this->belongsToMany(Team::class, 'user_role')
@@ -286,7 +367,7 @@ class Role extends Resource
         // Any catalog write (including creating or deleting a Shadow) bumps the
         // Role Catalog version so every user's resolved-roles memo recomputes on
         // its next permission check — instant shadow effect, no per-call queries.
-        static::saved(fn () => User::bumpRoleCatalogVersion());
-        static::deleted(fn () => User::bumpRoleCatalogVersion());
+        static::saved(fn () => static::bumpCatalogVersion());
+        static::deleted(fn () => static::bumpCatalogVersion());
     }
 }

--- a/src/Resources/Team.php
+++ b/src/Resources/Team.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 
 class Team extends Resource
 {
@@ -282,28 +283,16 @@ class Team extends Resource
                 $user->save();
             }
 
-            // Create an Admin role for the team
-            $role = Role::firstOrCreate([
-                'slug' => 'admin',
-                'team_id' => $team->id,
-            ], [
-                'name' => 'Admin',
-                'description' => 'Admin can perform everything.',
-                'super_admin' => true,
-                'permissions' => [],
-            ]);
+            // Attach-don't-mint: creating a team no longer mints a per-team admin
+            // role. The creator is attached to the shared global `admin` Global
+            // Role (team_id = null, super_admin), with the Membership recording
+            // the team. The helper self-heals the Global Role when the catalog
+            // was never seeded (bare `migrate`, or the test harness).
+            $globalAdmin = Role::firstOrCreateGlobalAdmin();
 
-            // Attach the current user to the team
+            // Attach the current user to the team via the global admin role.
             if ($user) {
-                // $role->users()->sync([$user->id]);
-
-                $team->users()->attach($user->id, ['role_id' => $role->id]);
-
-                // $fields = $user->fields;
-                // $fields['roles'] = [$role->id];
-                // $user->update([
-                //     'fields' => $fields->toArray(),
-                // ]);
+                $team->users()->attach($user->id, ['role_id' => $globalAdmin->id]);
 
                 // Clear cache of Cache('user.'.$user->id.'.teams')
                 Cache::forget('user.'.$user->id.'.teams');
@@ -333,8 +322,20 @@ class Team extends Resource
                 User::clearCurrentTeamCache($user->id);
             }
 
-            // Delete all the team's roles
-            // $team->roles()->delete();
+            // A team's Memberships and its own Team Roles (including Shadows) die
+            // with the team; the shared Global Roles (team_id = null) are never
+            // touched. Remove the pivot rows first, then the team-owned roles.
+            DB::table('user_role')->where('team_id', $team->id)->delete();
+
+            // Bypass TeamScope: by this point the affected users' current team has
+            // already been reassigned above, so a scoped query would filter to the
+            // wrong team and delete nothing.
+            Role::withoutGlobalScopes()->where('team_id', $team->id)->delete();
+
+            // The role rows above were removed via a mass delete (no model
+            // events), so bump the catalog version explicitly to invalidate every
+            // user's resolved-roles memo.
+            User::bumpRoleCatalogVersion();
 
             // Delete all the team's metas
             $team->meta()->delete();

--- a/src/Resources/Team.php
+++ b/src/Resources/Team.php
@@ -335,7 +335,7 @@ class Team extends Resource
             // The role rows above were removed via a mass delete (no model
             // events), so bump the catalog version explicitly to invalidate every
             // user's resolved-roles memo.
-            User::bumpRoleCatalogVersion();
+            Role::bumpCatalogVersion();
 
             // Delete all the team's metas
             $team->meta()->delete();

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -663,8 +663,12 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
     public function indexQuery($query)
     {
         if (config('aura.teams')) {
+            // A user belongs to the current team when they hold a Membership for
+            // it — filter on the pivot's team_id, not the role row's team_id. A
+            // Global Role carries team_id = null, so keying off the role row would
+            // wrongly exclude members who hold a Global Role (e.g. global admin).
             return $query->whereHas('roles', function ($query) {
-                $query->where('roles.team_id', Auth::user()->current_team_id);
+                $query->where('user_role.team_id', Auth::user()->current_team_id);
             });
         }
 

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -17,8 +17,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\Access\Authorizable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rules\Password;
 use Lab404\Impersonate\Models\Impersonate;
@@ -43,6 +45,14 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
     public static bool $indexViewEnabled = true;
 
     public $preventPasswordUpdate = false;
+
+    /**
+     * Monotonic Role Catalog version, bumped whenever any Role is written or
+     * deleted. It keys the per-instance resolved-roles memo so that creating or
+     * deleting a Shadow invalidates every user's cache lazily — instant shadow
+     * effect without paying resolution queries on every permission check.
+     */
+    public static int $roleCatalogVersion = 0;
 
     public static ?string $slug = 'user';
 
@@ -89,6 +99,14 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
         'two_factor_secret',
     ];
 
+    /**
+     * Per-instance memo of resolved (shadow-applied) roles, keyed by
+     * "{teamId|global}:{roleCatalogVersion}".
+     *
+     * @var array<string, Collection>
+     */
+    protected array $resolvedRolesCache = [];
+
     protected static array $searchable = ['name', 'email'];
 
     protected $table = 'users';
@@ -130,9 +148,69 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
         });
     }
 
+    /**
+     * Bump the Role Catalog version, invalidating every user's resolved-roles
+     * memo. Called from Role model write/delete hooks so a Shadow created or
+     * deleted mid-request takes effect on the next permission check.
+     */
+    public static function bumpRoleCatalogVersion(): void
+    {
+        static::$roleCatalogVersion++;
+    }
+
+    /**
+     * The user's effective (shadow-resolved) roles in the current team context.
+     *
+     * This is the User-side entry to the Role Catalog resolution seam. Each of
+     * the user's Memberships is resolved by slug through Role::resolveForTeam:
+     * a Team Role (Shadow) wins over the Global Role of the same slug. Pivot
+     * rows are never rewritten.
+     *
+     * The result is memoized per instance and keyed by team context + catalog
+     * version, so repeated permission checks in a request (policies fire this
+     * per row/action) stay query-free, while creating/deleting a Shadow bumps
+     * the version and forces a recompute — instant shadow effect, no per-call
+     * queries.
+     */
     public function cachedRoles(): mixed
     {
-        return $this->roles;
+        if (! $this->id) {
+            return collect();
+        }
+
+        $teamId = config('aura.teams') ? $this->current_team_id : null;
+        $cacheKey = ($teamId ?? 'global').':'.static::$roleCatalogVersion;
+
+        if (array_key_exists($cacheKey, $this->resolvedRolesCache)) {
+            return $this->resolvedRolesCache[$cacheKey];
+        }
+
+        // Read the raw Membership rows for the relevant team context. In
+        // Teams-off mode the pivot has no team_id column.
+        $roleIds = DB::table('user_role')
+            ->where('user_id', $this->id)
+            ->when(
+                config('aura.teams') && $teamId,
+                fn ($query) => $query->where('team_id', $teamId)
+            )
+            ->pluck('role_id');
+
+        if ($roleIds->isEmpty()) {
+            return $this->resolvedRolesCache[$cacheKey] = collect();
+        }
+
+        // The Membership's identity is its role slug; resolve each slug through
+        // the catalog seam. Bypass scopes to read slugs of global rows too.
+        $slugs = Role::withoutGlobalScopes()
+            ->whereIn('id', $roleIds)
+            ->pluck('slug')
+            ->unique();
+
+        return $this->resolvedRolesCache[$cacheKey] = $slugs
+            ->map(fn ($slug) => Role::resolveForTeam($slug, $teamId))
+            ->filter()
+            ->unique('id')
+            ->values();
     }
 
     public function canBeImpersonated()
@@ -515,7 +593,7 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
                 return true;
             }
 
-            $permissions = $role->fields['permissions'];
+            $permissions = $this->normalizePermissions($role);
 
             if (empty($permissions)) {
                 continue;
@@ -544,15 +622,10 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
                 return true;
             }
 
-            $permissions = $role->fields['permissions'];
+            $permissions = $this->normalizePermissions($role);
 
             if (empty($permissions)) {
                 continue;
-            }
-
-            // Temporary Fix. To Do: It should be an array
-            if (is_string($permissions)) {
-                $permissions = json_decode($permissions, true);
             }
 
             foreach ($permissions as $permission => $value) {
@@ -650,6 +723,18 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
         }
 
         return $this->id == $team->{$this->getForeignKey()};
+    }
+
+    /**
+     * Clear the resolved-roles memo when the model is refreshed, so a pivot
+     * attached/detached directly followed by refresh() reflects fresh roles
+     * (the staleness semantics existing tests rely on).
+     */
+    public function refresh()
+    {
+        $this->resolvedRolesCache = [];
+
+        return parent::refresh();
     }
 
     public function resource()
@@ -777,5 +862,23 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
     protected static function newFactory()
     {
         return UserFactory::new();
+    }
+
+    /**
+     * Normalize a role's permission set into an array.
+     *
+     * The single place that reconciles permission sets stored as a cast array
+     * or as a JSON string (meta/field values can deliver either), so permission
+     * checks behave identically regardless of how the set was persisted.
+     */
+    protected function normalizePermissions($role): array
+    {
+        $permissions = $role->permissions;
+
+        if (is_string($permissions)) {
+            $permissions = json_decode($permissions, true);
+        }
+
+        return is_array($permissions) ? $permissions : [];
     }
 }

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -46,14 +46,6 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
 
     public $preventPasswordUpdate = false;
 
-    /**
-     * Monotonic Role Catalog version, bumped whenever any Role is written or
-     * deleted. It keys the per-instance resolved-roles memo so that creating or
-     * deleting a Shadow invalidates every user's cache lazily — instant shadow
-     * effect without paying resolution queries on every permission check.
-     */
-    public static int $roleCatalogVersion = 0;
-
     public static ?string $slug = 'user';
 
     public static ?int $sort = 1;
@@ -101,7 +93,7 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
 
     /**
      * Per-instance memo of resolved (shadow-applied) roles, keyed by
-     * "{teamId|global}:{roleCatalogVersion}".
+     * "{teamId|global}:{Role::catalogVersion()}".
      *
      * @var array<string, Collection>
      */
@@ -149,16 +141,6 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
     }
 
     /**
-     * Bump the Role Catalog version, invalidating every user's resolved-roles
-     * memo. Called from Role model write/delete hooks so a Shadow created or
-     * deleted mid-request takes effect on the next permission check.
-     */
-    public static function bumpRoleCatalogVersion(): void
-    {
-        static::$roleCatalogVersion++;
-    }
-
-    /**
      * The user's effective (shadow-resolved) roles in the current team context.
      *
      * This is the User-side entry to the Role Catalog resolution seam. Each of
@@ -179,19 +161,25 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
         }
 
         $teamId = config('aura.teams') ? $this->current_team_id : null;
-        $cacheKey = ($teamId ?? 'global').':'.static::$roleCatalogVersion;
+        $cacheKey = ($teamId ?? 'global').':'.Role::catalogVersion();
 
         if (array_key_exists($cacheKey, $this->resolvedRolesCache)) {
             return $this->resolvedRolesCache[$cacheKey];
         }
 
-        // Read the raw Membership rows for the relevant team context. In
-        // Teams-off mode the pivot has no team_id column.
+        // Read the raw Membership rows for the relevant team context. The team
+        // filter is strict: in Teams-on mode a non-null current team reads only
+        // that team's Memberships, and a null current team reads only Memberships
+        // with a null pivot team_id — never an unfiltered read across all teams
+        // (which would leak roles from teams the user is not currently in). In
+        // Teams-off mode the pivot has no team_id column, so it is a flat read.
         $roleIds = DB::table('user_role')
             ->where('user_id', $this->id)
             ->when(
-                config('aura.teams') && $teamId,
-                fn ($query) => $query->where('team_id', $teamId)
+                config('aura.teams'),
+                fn ($query) => $teamId
+                    ? $query->where('team_id', $teamId)
+                    : $query->whereNull('team_id')
             )
             ->pluck('role_id');
 

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -229,6 +229,27 @@ describe('Registration Without Teams', function () {
             ->assertSessionDoesntHaveErrors('team');
     });
 
+    test('registration self-heals the user role when the catalog was never seeded', function () {
+        $roleModel = app(config('aura.resources.role'));
+
+        // Precondition: the default `user` Global Role does not exist (bare
+        // migrate, no seeder run).
+        expect($roleModel::where('slug', 'user')->exists())->toBeFalse();
+
+        $this->post(route('aura.register'), [
+            'name' => 'Fresh User',
+            'email' => 'fresh-noseed@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ])->assertRedirect(config('aura.auth.redirect'));
+
+        $this->assertAuthenticated();
+
+        $user = app(config('aura.resources.user'))::where('email', 'fresh-noseed@example.com')->first();
+        expect($user)->not->toBeNull();
+        expect($user->hasRole('user'))->toBeTrue();
+    })->skip(fn () => Schema::hasColumn('user_role', 'team_id'), 'Teams-off registration self-heal (runs on the teams-off schema).');
+
     test('name is required', function () {
         $this->post(route('aura.register'), [
             'email' => 'test@example.com',

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -91,7 +91,7 @@ describe('Registration With Teams', function () {
         expect($user->current_team_id)->toBe($team->id);
     });
 
-    test('team role is created on registration', function () {
+    test('registrant is attached to the global admin role on registration', function () {
         Team::factory()->create();
 
         $this->post(route('aura.register'), [
@@ -103,8 +103,12 @@ describe('Registration With Teams', function () {
         ]);
 
         $team = Team::where('name', 'New Team')->first();
+        $user = User::where('email', 'newuser@example.com')->first();
 
-        $this->assertDatabaseHas('roles', ['team_id' => $team->id]);
+        // Attach-don't-mint: no per-team role row; the registrant holds the
+        // shared global admin role (team_id = null) via a Membership.
+        $this->assertDatabaseMissing('roles', ['team_id' => $team->id]);
+        $this->assertDatabaseHas('user_role', ['team_id' => $team->id, 'user_id' => $user->id]);
     });
 
     test('registered event is dispatched', function () {

--- a/tests/Feature/Resource/UserCreateIntegrationTest.php
+++ b/tests/Feature/Resource/UserCreateIntegrationTest.php
@@ -71,7 +71,7 @@ test('created user can log in with the provided password', function () {
 test('user created in a team context is assigned to the correct team', function () {
     $team = $this->user->currentTeam;
     // Attach-don't-mint: the assignable admin role is the shared Global Role.
-    $role = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+    $role = globalAdminRole();
 
     Livewire::test(Create::class, ['slug' => 'user'])
         ->set('form.fields.name', 'Team User')
@@ -118,7 +118,7 @@ test('client cannot assign a new user to another team', function () {
 test('user created with a role can log in and access the correct team', function () {
     $team = $this->user->currentTeam;
     // Attach-don't-mint: the assignable admin role is the shared Global Role.
-    $role = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+    $role = globalAdminRole();
 
     Livewire::test(Create::class, ['slug' => 'user'])
         ->set('form.fields.name', 'Full Flow User')

--- a/tests/Feature/Resource/UserCreateIntegrationTest.php
+++ b/tests/Feature/Resource/UserCreateIntegrationTest.php
@@ -70,7 +70,8 @@ test('created user can log in with the provided password', function () {
 
 test('user created in a team context is assigned to the correct team', function () {
     $team = $this->user->currentTeam;
-    $role = Role::where('team_id', $team->id)->where('slug', 'admin')->first();
+    // Attach-don't-mint: the assignable admin role is the shared Global Role.
+    $role = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
 
     Livewire::test(Create::class, ['slug' => 'user'])
         ->set('form.fields.name', 'Team User')
@@ -86,10 +87,11 @@ test('user created in a team context is assigned to the correct team', function 
 
     expect($newUser)->not->toBeNull();
 
-    // User should have the role with the correct team
+    // The user holds the role via a Membership scoped to the team (pivot),
+    // even though the shared Global Role row carries team_id = null.
     $userRoles = $newUser->roles;
     expect($userRoles)->not->toBeEmpty();
-    expect($userRoles->first()->team_id)->toBe($team->id);
+    expect($userRoles->first()->pivot->team_id)->toBe($team->id);
     expect($newUser->current_team_id)->toBe($team->id);
 })->skip(fn () => ! config('aura.teams'), 'Team assignment requires teams enabled.');
 
@@ -115,7 +117,8 @@ test('client cannot assign a new user to another team', function () {
 
 test('user created with a role can log in and access the correct team', function () {
     $team = $this->user->currentTeam;
-    $role = Role::where('team_id', $team->id)->where('slug', 'admin')->first();
+    // Attach-don't-mint: the assignable admin role is the shared Global Role.
+    $role = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
 
     Livewire::test(Create::class, ['slug' => 'user'])
         ->set('form.fields.name', 'Full Flow User')

--- a/tests/Feature/Roles/AttachDontMintTest.php
+++ b/tests/Feature/Roles/AttachDontMintTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use Aura\Base\Livewire\Resource\Create;
+use Aura\Base\Livewire\Resource\Edit;
+use Aura\Base\Models\Scopes\TeamScope;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Schema;
+
+use function Pest\Laravel\post;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    if (! Schema::hasTable('teams')) {
+        $this->markTestSkipped('Attach-don\'t-mint behaviour is teams-on only.');
+    }
+
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+describe('Team creation attaches to the global admin role', function () {
+    it('does not mint a per-team admin role and attaches the creator to the global role', function () {
+        $team = Team::create(['name' => 'Fresh Team', 'user_id' => $this->user->id]);
+
+        // No per-team admin row minted.
+        expect(Role::withoutGlobalScopes()->where('team_id', $team->id)->exists())->toBeFalse();
+
+        // The single global admin row backs the Membership.
+        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+        expect($globalAdmin)->not->toBeNull();
+
+        $this->assertDatabaseHas('user_role', [
+            'team_id' => $team->id,
+            'user_id' => $this->user->id,
+            'role_id' => $globalAdmin->id,
+        ]);
+    });
+});
+
+describe('Registrant becomes Super Admin of their new team via the global role', function () {
+    it('resolves to Super Admin with all permissions granted', function () {
+        config(['aura.auth.registration' => true, 'aura.teams' => true, 'aura.auth.redirect' => '/admin']);
+        Auth::logout();
+
+        post(route('aura.register.post'), [
+            'name' => 'Nadia New',
+            'email' => 'nadia@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+            'team' => 'Nadia Team',
+        ])->assertRedirect('/admin');
+
+        $user = User::where('email', 'nadia@example.com')->first();
+        $user->refresh();
+
+        // Resolution seam: the Membership resolves through the global admin role.
+        expect($user->isSuperAdmin())->toBeTrue();
+        expect($user->hasRole('admin'))->toBeTrue();
+
+        // Super Admin grants every permission via super_admin, not an enumerated set.
+        expect($user->hasPermissionTo('viewAny', new User))->toBeTrue();
+        expect($user->hasPermissionTo('delete', new Role))->toBeTrue();
+    });
+});
+
+describe('Roles field team-ownership and escalation guards', function () {
+    it('accepts a global role id assigned within the current team', function () {
+        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+
+        livewire(Create::class, ['slug' => 'user'])
+            ->set('form.fields.name', 'Global Grant')
+            ->set('form.fields.email', 'global-grant@example.com')
+            ->set('form.fields.password', 'Str0ng!Pass#2024')
+            ->set('form.fields.roles', [$globalAdmin->id])
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $target = User::withoutGlobalScope(TeamScope::class)->where('email', 'global-grant@example.com')->first();
+
+        $this->assertDatabaseHas('user_role', [
+            'team_id' => $this->user->current_team_id,
+            'user_id' => $target->id,
+            'role_id' => $globalAdmin->id,
+        ]);
+    });
+
+    it('refuses assigning a role owned by another team', function () {
+        // A Team Role owned by a different team must never be assignable here.
+        $otherTeam = Team::factory()->createQuietly();
+        $otherTeamRole = Role::create([
+            'name' => 'Other Editor',
+            'slug' => 'other-editor',
+            'team_id' => $otherTeam->id,
+            'super_admin' => false,
+            'permissions' => [],
+        ]);
+
+        livewire(Create::class, ['slug' => 'user'])
+            ->set('form.fields.name', 'Cross Team')
+            ->set('form.fields.email', 'cross-team@example.com')
+            ->set('form.fields.password', 'Str0ng!Pass#2024')
+            ->set('form.fields.roles', [$otherTeamRole->id])
+            ->call('save')
+            ->assertStatus(403);
+
+        $this->assertDatabaseMissing('user_role', [
+            'role_id' => $otherTeamRole->id,
+        ]);
+    });
+
+    it('refuses a non-super-admin assigning a super admin global role (escalation)', function () {
+        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+
+        // A delegated, non-super-admin manager acting in the team.
+        $managerRole = Role::create([
+            'name' => 'Manager',
+            'slug' => 'manager',
+            'team_id' => $this->user->current_team_id,
+            'super_admin' => false,
+            'permissions' => ['viewAny-user' => true, 'view-user' => true, 'update-user' => true],
+        ]);
+
+        $manager = User::factory()->create(['current_team_id' => $this->user->current_team_id]);
+        $manager->roles()->attach($managerRole->id, ['team_id' => $this->user->current_team_id]);
+
+        $target = User::factory()->create(['current_team_id' => $this->user->current_team_id]);
+        $target->roles()->attach($managerRole->id, ['team_id' => $this->user->current_team_id]);
+
+        $this->actingAs($manager);
+
+        livewire(Edit::class, ['slug' => 'user', 'id' => $target->id])
+            ->set('form.fields.roles', [$globalAdmin->id])
+            ->call('save')
+            ->assertStatus(403);
+
+        $this->assertDatabaseMissing('user_role', [
+            'user_id' => $target->id,
+            'role_id' => $globalAdmin->id,
+        ]);
+    });
+});

--- a/tests/Feature/Roles/AttachDontMintTest.php
+++ b/tests/Feature/Roles/AttachDontMintTest.php
@@ -28,7 +28,7 @@ describe('Team creation attaches to the global admin role', function () {
         expect(Role::withoutGlobalScopes()->where('team_id', $team->id)->exists())->toBeFalse();
 
         // The single global admin row backs the Membership.
-        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+        $globalAdmin = globalAdminRole();
         expect($globalAdmin)->not->toBeNull();
 
         $this->assertDatabaseHas('user_role', [
@@ -67,7 +67,7 @@ describe('Registrant becomes Super Admin of their new team via the global role',
 
 describe('Roles field team-ownership and escalation guards', function () {
     it('accepts a global role id assigned within the current team', function () {
-        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+        $globalAdmin = globalAdminRole();
 
         livewire(Create::class, ['slug' => 'user'])
             ->set('form.fields.name', 'Global Grant')
@@ -111,7 +111,7 @@ describe('Roles field team-ownership and escalation guards', function () {
     });
 
     it('refuses a non-super-admin assigning a super admin global role (escalation)', function () {
-        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+        $globalAdmin = globalAdminRole();
 
         // A delegated, non-super-admin manager acting in the team.
         $managerRole = Role::create([

--- a/tests/Feature/Roles/RoleResolutionTest.php
+++ b/tests/Feature/Roles/RoleResolutionTest.php
@@ -242,3 +242,37 @@ describe('permission set normalization', function () {
         expect($user->hasPermission('delete-post'))->toBeFalse();
     });
 });
+
+describe('strict team scoping of resolved roles', function () {
+    it('resolves no roles and is not super admin when the current team is null, even holding admin in other teams', function () {
+        // Reuse the seeded global admin (a second team_id=null admin would break
+        // the unique slug constraint).
+        $admin = globalAdminRole();
+
+        $teamA = Team::factory()->createQuietly();
+        $teamB = Team::factory()->createQuietly();
+
+        $user = User::factory()->create(['current_team_id' => null]);
+
+        DB::table('user_role')->insert([
+            ['user_id' => $user->id, 'team_id' => $teamA->id, 'role_id' => $admin->id, 'created_at' => now(), 'updated_at' => now()],
+            ['user_id' => $user->id, 'team_id' => $teamB->id, 'role_id' => $admin->id, 'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        Cache::forget("user_{$user->id}_current_team_id");
+        $user->refresh();
+
+        // Strict null-team rule: with a null current team, only Memberships with a
+        // null pivot team_id are read (there are none). Roles from teams the user
+        // is not currently in must not leak in.
+        expect($user->cachedRoles())->toHaveCount(0);
+        expect($user->isSuperAdmin())->toBeFalse();
+
+        // Switching into one of the teams resolves that team's Membership.
+        $user->forceFill(['current_team_id' => $teamA->id])->save();
+        Cache::forget("user_{$user->id}_current_team_id");
+        $user->refresh();
+
+        expect($user->isSuperAdmin())->toBeTrue();
+    });
+});

--- a/tests/Feature/Roles/RoleResolutionTest.php
+++ b/tests/Feature/Roles/RoleResolutionTest.php
@@ -1,0 +1,244 @@
+<?php
+
+use Aura\Base\Database\Seeders\RoleCatalogSeeder;
+use Aura\Base\Models\Scopes\TeamScope;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Aura\Base\Tests\Resources\Post;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+// The Role Catalog resolution seam (Role::resolveForTeam + User::cachedRoles):
+// Shadowing resolves by slug at check time. A Team Role wins over a Global Role
+// of the same slug; deleting the Team Role falls back to the Global Role. No
+// Membership pivot rows are ever rewritten.
+
+beforeEach(function () {
+    if (! Schema::hasTable('teams')) {
+        $this->markTestSkipped('Role catalog resolution requires the teams schema.');
+    }
+
+    // Seed the base catalog the same way a fresh install does.
+    RoleCatalogSeeder::seed();
+});
+
+/**
+ * Create a Global Role (team_id = null) bypassing TeamScope.
+ */
+function makeGlobalRole(string $slug, array $attributes = []): Role
+{
+    return Role::withoutGlobalScopes()->create(array_merge([
+        'name' => ucfirst($slug),
+        'slug' => $slug,
+        'super_admin' => false,
+        'permissions' => [],
+        'team_id' => null,
+    ], $attributes));
+}
+
+/**
+ * Create a Team Role (a Shadow) for the given team.
+ */
+function makeTeamRole(int $teamId, string $slug, array $attributes = []): Role
+{
+    return Role::withoutGlobalScopes()->create(array_merge([
+        'name' => ucfirst($slug),
+        'slug' => $slug,
+        'super_admin' => false,
+        'permissions' => [],
+        'team_id' => $teamId,
+    ], $attributes));
+}
+
+describe('Role::resolveForTeam', function () {
+    it('seeds admin and user Global Roles', function () {
+        $admin = Role::resolveForTeam('admin', null);
+        $user = Role::resolveForTeam('user', null);
+
+        expect($admin)->not->toBeNull();
+        expect($admin->super_admin)->toBeTrue();
+        expect($admin->team_id)->toBeNull();
+
+        expect($user)->not->toBeNull();
+        expect($user->super_admin)->toBeFalse();
+        expect($user->team_id)->toBeNull();
+    });
+
+    it('resolves the Global Role when the team has no Shadow', function () {
+        $team = Team::factory()->create();
+        makeGlobalRole('editor', ['permissions' => ['view-post' => true]]);
+
+        $resolved = Role::resolveForTeam('editor', $team->id);
+
+        expect($resolved)->not->toBeNull();
+        expect($resolved->team_id)->toBeNull();
+        expect($resolved->permissions)->toBe(['view-post' => true]);
+    });
+
+    it('prefers the Team Role (Shadow) over the Global Role of the same slug', function () {
+        $team = Team::factory()->create();
+        makeGlobalRole('editor', ['permissions' => ['view-post' => true]]);
+        $shadow = makeTeamRole($team->id, 'editor', ['permissions' => ['delete-post' => true]]);
+
+        $resolved = Role::resolveForTeam('editor', $team->id);
+
+        expect($resolved->id)->toBe($shadow->id);
+        expect($resolved->team_id)->toBe($team->id);
+        expect($resolved->permissions)->toBe(['delete-post' => true]);
+    });
+
+    it('does not leak one team\'s Shadow into another team', function () {
+        $teamA = Team::factory()->create();
+        $teamB = Team::factory()->create();
+        makeGlobalRole('editor', ['permissions' => ['view-post' => true]]);
+        makeTeamRole($teamA->id, 'editor', ['permissions' => ['delete-post' => true]]);
+
+        // Team B has no Shadow, so it resolves the Global Role.
+        $resolved = Role::resolveForTeam('editor', $teamB->id);
+
+        expect($resolved->team_id)->toBeNull();
+        expect($resolved->permissions)->toBe(['view-post' => true]);
+    });
+
+    it('returns null for an unknown slug', function () {
+        $team = Team::factory()->create();
+
+        expect(Role::resolveForTeam('does-not-exist', $team->id))->toBeNull();
+    });
+
+    it('makes Global Roles visible to team-scoped Role queries (TeamScope)', function () {
+        $user = createSuperAdmin();
+        $this->actingAs($user);
+        $teamId = $user->current_team_id;
+
+        makeGlobalRole('editor', ['permissions' => ['view-post' => true]]);
+        makeTeamRole($teamId, 'moderator');
+
+        // A plain, team-scoped Role query now sees the team's own roles AND the
+        // Global Roles (team_id = null), without bypassing scopes.
+        $slugs = Role::pluck('slug');
+
+        expect($slugs)->toContain('editor');   // Global Role
+        expect($slugs)->toContain('moderator'); // Team Role
+        expect($slugs)->toContain('admin');     // seeded Global Role
+    });
+});
+
+describe('shadow create/delete takes instant effect through the User seam', function () {
+    it('applies the Shadow the moment it is created and falls back when deleted', function () {
+        // A user whose Membership is the global "editor" role in their team.
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+        $user->forceFill(['current_team_id' => $team->id])->save();
+        Cache::forget("user_{$user->id}_current_team_id");
+
+        $globalEditor = makeGlobalRole('editor', ['permissions' => ['view-post' => true]]);
+        $user->roles()->syncWithPivotValues([$globalEditor->id], ['team_id' => $team->id]);
+        $user->refresh();
+        $this->actingAs($user);
+
+        // Global definition applies.
+        expect($user->hasPermission('view-post'))->toBeTrue();
+        expect($user->hasPermission('delete-post'))->toBeFalse();
+
+        // Creating a Shadow changes the outcome instantly — no pivot rewrite.
+        $shadow = makeTeamRole($team->id, 'editor', ['permissions' => ['delete-post' => true]]);
+
+        expect($user->hasPermission('view-post'))->toBeFalse();
+        expect($user->hasPermission('delete-post'))->toBeTrue();
+
+        // The Membership row still points at the global role id.
+        $pivotRoleId = DB::table('user_role')
+            ->where('user_id', $user->id)
+            ->where('team_id', $team->id)
+            ->value('role_id');
+        expect($pivotRoleId)->toBe($globalEditor->id);
+
+        // Deleting the Shadow falls back to the global definition instantly.
+        $shadow->delete();
+
+        expect($user->hasPermission('view-post'))->toBeTrue();
+        expect($user->hasPermission('delete-post'))->toBeFalse();
+    });
+
+    it('resolves a super_admin Shadow so isSuperAdmin reflects it live', function () {
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+        $user->forceFill(['current_team_id' => $team->id])->save();
+        Cache::forget("user_{$user->id}_current_team_id");
+
+        $globalManager = makeGlobalRole('manager', ['super_admin' => false]);
+        $user->roles()->syncWithPivotValues([$globalManager->id], ['team_id' => $team->id]);
+        $user->refresh();
+        $this->actingAs($user);
+
+        expect($user->isSuperAdmin())->toBeFalse();
+        expect($user->hasRole('manager'))->toBeTrue();
+
+        // Shadow the manager role as a Super Admin inside this team.
+        makeTeamRole($team->id, 'manager', ['super_admin' => true]);
+
+        expect($user->isSuperAdmin())->toBeTrue();
+    });
+});
+
+describe('resolved-roles memoization', function () {
+    it('serves repeated permission checks from cache and recomputes only when the catalog changes', function () {
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+        $user->forceFill(['current_team_id' => $team->id])->save();
+        Cache::forget("user_{$user->id}_current_team_id");
+
+        $editor = makeGlobalRole('editor', ['permissions' => ['view-post' => true]]);
+        $user->roles()->syncWithPivotValues([$editor->id], ['team_id' => $team->id]);
+        $user->refresh();
+        $this->actingAs($user);
+
+        // Warm the memo (this call does the resolution queries).
+        expect($user->hasPermission('view-post'))->toBeTrue();
+
+        // Repeated permission checks in the same request are served from the
+        // memo and must issue ZERO role/user_role queries.
+        DB::enableQueryLog();
+        $user->isSuperAdmin();
+        $user->hasPermission('view-post');
+        $user->hasPermissionTo('view', new Post);
+        $roleQueries = collect(DB::getQueryLog())
+            ->pluck('query')
+            ->filter(fn ($q) => str_contains($q, 'user_role') || str_contains($q, '"roles"'));
+        DB::disableQueryLog();
+
+        expect($roleQueries)->toHaveCount(0);
+
+        // Creating a Shadow bumps the catalog version → the next check recomputes
+        // and reflects the new definition (instant shadow effect preserved).
+        makeTeamRole($team->id, 'editor', ['permissions' => ['delete-post' => true]]);
+
+        expect($user->hasPermission('view-post'))->toBeFalse();
+        expect($user->hasPermission('delete-post'))->toBeTrue();
+    });
+});
+
+describe('permission set normalization', function () {
+    it('behaves identically whether permissions are stored as an array or a JSON string', function () {
+        $user = User::factory()->create();
+        $team = Team::factory()->create();
+        $user->forceFill(['current_team_id' => $team->id])->save();
+        Cache::forget("user_{$user->id}_current_team_id");
+
+        // Persist the permission set as a raw JSON string, bypassing the cast.
+        $role = makeTeamRole($team->id, 'reviewer');
+        DB::table('roles')
+            ->where('id', $role->id)
+            ->update(['permissions' => json_encode(['view-post' => true])]);
+
+        $user->roles()->syncWithPivotValues([$role->id], ['team_id' => $team->id]);
+        $user->refresh();
+        $this->actingAs($user);
+
+        expect($user->hasPermission('view-post'))->toBeTrue();
+        expect($user->hasPermission('delete-post'))->toBeFalse();
+    });
+});

--- a/tests/Feature/Security/RemainingSecurityGapsTest.php
+++ b/tests/Feature/Security/RemainingSecurityGapsTest.php
@@ -88,8 +88,10 @@ it('sanitizes unsafe rich text while preserving safe formatting', function () {
 
 it('prevents a delegated user manager from assigning a super admin role', function () {
     $team = $this->user->currentTeam;
+    // Attach-don't-mint: the Super Admin role is the shared global admin
+    // (team_id = null), assignable within the team as a Global Role.
     $superAdminRole = Role::withoutGlobalScope(TeamScope::class)
-        ->where('team_id', $team->id)
+        ->whereNull('team_id')
         ->where('super_admin', true)
         ->firstOrFail();
 

--- a/tests/Feature/Team/CreateTeamTest.php
+++ b/tests/Feature/Team/CreateTeamTest.php
@@ -54,9 +54,10 @@ describe('Team Creation Authorization', function () {
         expect($team->description)->toBe('Test Description');
     });
 
-    it('creates admin role when team is created via Livewire', function () {
+    it('attaches the creator to the global admin role when team is created via Livewire', function () {
         Gate::define('AuraGlobalAdmin', fn (User $user) => true);
 
+        // Attach-don't-mint: creating a team must not mint any new role row.
         $initialRoleCount = Role::withoutGlobalScopes()->count();
 
         livewire(Create::class, ['slug' => 'team'])
@@ -64,17 +65,20 @@ describe('Team Creation Authorization', function () {
             ->call('save')
             ->assertHasNoErrors();
 
-        // A new admin role should be created for the new team
-        expect(Role::withoutGlobalScopes()->count())->toBe($initialRoleCount + 1);
+        expect(Role::withoutGlobalScopes()->count())->toBe($initialRoleCount);
 
         $newTeam = Team::where('name', 'New Team')->first();
-        $adminRole = Role::withoutGlobalScopes()
-            ->where('team_id', $newTeam->id)
-            ->where('slug', 'admin')
-            ->first();
 
-        expect($adminRole)->not->toBeNull();
-        expect($adminRole->super_admin)->toBeTrue();
+        // No per-team admin row exists; the creator holds the global admin role.
+        expect(Role::withoutGlobalScopes()->where('team_id', $newTeam->id)->exists())->toBeFalse();
+
+        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+
+        $this->assertDatabaseHas('user_role', [
+            'team_id' => $newTeam->id,
+            'user_id' => $this->user->id,
+            'role_id' => $globalAdmin->id,
+        ]);
     });
 });
 

--- a/tests/Feature/Team/CreateTeamTest.php
+++ b/tests/Feature/Team/CreateTeamTest.php
@@ -72,7 +72,7 @@ describe('Team Creation Authorization', function () {
         // No per-team admin row exists; the creator holds the global admin role.
         expect(Role::withoutGlobalScopes()->where('team_id', $newTeam->id)->exists())->toBeFalse();
 
-        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+        $globalAdmin = globalAdminRole();
 
         $this->assertDatabaseHas('user_role', [
             'team_id' => $newTeam->id,

--- a/tests/Feature/Team/CurrentTeamCacheTest.php
+++ b/tests/Feature/Team/CurrentTeamCacheTest.php
@@ -65,17 +65,15 @@ it('clears current team and team list caches for affected users when deleting a 
         'current_team_id' => $secondTeam->id,
     ]);
 
-    $firstTeamRole = Role::withoutGlobalScopes()
-        ->where('team_id', $firstTeam->id)
-        ->where('slug', 'admin')
-        ->first();
-    $secondTeamRole = Role::withoutGlobalScopes()
-        ->where('team_id', $secondTeam->id)
+    // Attach-don't-mint: Memberships in every team point at the shared global
+    // admin role (team_id = null), scoped to the team via the pivot.
+    $globalAdmin = Role::withoutGlobalScopes()
+        ->whereNull('team_id')
         ->where('slug', 'admin')
         ->first();
 
-    $firstTeam->users()->attach($otherUser->id, ['role_id' => $firstTeamRole->id]);
-    $secondTeam->users()->attach($otherUser->id, ['role_id' => $secondTeamRole->id]);
+    $firstTeam->users()->attach($otherUser->id, ['role_id' => $globalAdmin->id]);
+    $secondTeam->users()->attach($otherUser->id, ['role_id' => $globalAdmin->id]);
 
     $firstTeamPost = createPost([
         'title' => 'Remaining Team Post',

--- a/tests/Feature/Team/CurrentTeamCacheTest.php
+++ b/tests/Feature/Team/CurrentTeamCacheTest.php
@@ -67,10 +67,7 @@ it('clears current team and team list caches for affected users when deleting a 
 
     // Attach-don't-mint: Memberships in every team point at the shared global
     // admin role (team_id = null), scoped to the team via the pivot.
-    $globalAdmin = Role::withoutGlobalScopes()
-        ->whereNull('team_id')
-        ->where('slug', 'admin')
-        ->first();
+    $globalAdmin = globalAdminRole();
 
     $firstTeam->users()->attach($otherUser->id, ['role_id' => $globalAdmin->id]);
     $secondTeam->users()->attach($otherUser->id, ['role_id' => $globalAdmin->id]);

--- a/tests/Feature/Team/InvitationGlobalRoleTest.php
+++ b/tests/Feature/Team/InvitationGlobalRoleTest.php
@@ -1,0 +1,127 @@
+<?php
+
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\TeamInvitation;
+use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\URL;
+
+beforeEach(function () {
+    if (! Schema::hasTable('teams')) {
+        $this->markTestSkipped('Invitations are teams-on only.');
+    }
+
+    $this->actingAs($this->user = createSuperAdmin());
+    config(['aura.auth.user_invitations' => true]);
+});
+
+it('lets an existing user accept an invitation carrying a global role id', function () {
+    $team = $this->user->currentTeam;
+    $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+
+    $existingUser = User::factory()->create([
+        'email' => 'existing-global@example.com',
+        'current_team_id' => null,
+    ]);
+
+    $invitation = TeamInvitation::create([
+        'team_id' => $team->id,
+        'email' => $existingUser->email,
+        'role' => $globalAdmin->id,
+    ]);
+
+    $url = URL::temporarySignedRoute(
+        'aura.team-invitations.accept',
+        now()->addDays(config('aura.auth.invitation_expiry')),
+        ['invitation' => $invitation],
+    );
+
+    $this->actingAs($existingUser)
+        ->get($url)
+        ->assertRedirect(route('aura.dashboard'));
+
+    // The Membership records the team and points at the shared global role.
+    $this->assertDatabaseHas('user_role', [
+        'team_id' => $team->id,
+        'user_id' => $existingUser->id,
+        'role_id' => $globalAdmin->id,
+    ]);
+
+    $existingUser->refresh();
+    expect($existingUser->current_team_id)->toBe($team->id);
+    expect($existingUser->isSuperAdmin())->toBeTrue();
+});
+
+it('lets a new user register through an invitation carrying a global role id', function () {
+    $team = Team::first();
+    $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+
+    $invitation = TeamInvitation::create([
+        'team_id' => $team->id,
+        'email' => 'invited-global@example.com',
+        'role' => $globalAdmin->id,
+    ]);
+
+    $url = URL::signedRoute('aura.invitation.register', [$team, $invitation]);
+
+    auth()->logout();
+
+    $this->post($url, [
+        'name' => 'Invited Global',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertRedirect(config('aura.auth.redirect'));
+
+    $user = User::where('email', 'invited-global@example.com')->first();
+    expect($user)->not->toBeNull();
+    expect($user->current_team_id)->toBe($team->id);
+
+    $this->assertDatabaseHas('user_role', [
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+        'role_id' => $globalAdmin->id,
+    ]);
+
+    $user->refresh();
+    expect($user->isSuperAdmin())->toBeTrue();
+    expect(TeamInvitation::withoutGlobalScopes()->whereKey($invitation->id)->exists())->toBeFalse();
+});
+
+it('still refuses an invitation whose role belongs to another team', function () {
+    $team = $this->user->currentTeam;
+    $otherTeam = Team::factory()->createQuietly();
+    $otherTeamRole = Role::create([
+        'name' => 'Other Role',
+        'slug' => 'other-role',
+        'team_id' => $otherTeam->id,
+        'super_admin' => false,
+        'permissions' => [],
+    ]);
+
+    $existingUser = User::factory()->create([
+        'email' => 'existing-cross@example.com',
+        'current_team_id' => null,
+    ]);
+
+    $invitation = TeamInvitation::create([
+        'team_id' => $team->id,
+        'email' => $existingUser->email,
+        'role' => $otherTeamRole->id,
+    ]);
+
+    $url = URL::temporarySignedRoute(
+        'aura.team-invitations.accept',
+        now()->addDays(config('aura.auth.invitation_expiry')),
+        ['invitation' => $invitation],
+    );
+
+    $this->actingAs($existingUser)
+        ->get($url)
+        ->assertNotFound();
+
+    $this->assertDatabaseMissing('user_role', [
+        'user_id' => $existingUser->id,
+        'role_id' => $otherTeamRole->id,
+    ]);
+});

--- a/tests/Feature/Team/InvitationGlobalRoleTest.php
+++ b/tests/Feature/Team/InvitationGlobalRoleTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
 
 it('lets an existing user accept an invitation carrying a global role id', function () {
     $team = $this->user->currentTeam;
-    $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+    $globalAdmin = globalAdminRole();
 
     $existingUser = User::factory()->create([
         'email' => 'existing-global@example.com',
@@ -55,7 +55,7 @@ it('lets an existing user accept an invitation carrying a global role id', funct
 
 it('lets a new user register through an invitation carrying a global role id', function () {
     $team = Team::first();
-    $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+    $globalAdmin = globalAdminRole();
 
     $invitation = TeamInvitation::create([
         'team_id' => $team->id,

--- a/tests/Feature/Team/RegisterTeamTest.php
+++ b/tests/Feature/Team/RegisterTeamTest.php
@@ -112,7 +112,7 @@ describe('Team Registration with User', function () {
         // shared global admin role, scoped to their new team via the Membership.
         expect(Role::withoutGlobalScopes()->where('team_id', $team->id)->exists())->toBeFalse();
 
-        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+        $globalAdmin = globalAdminRole();
         expect($globalAdmin)->not->toBeNull();
         expect($globalAdmin->super_admin)->toBeTrue();
 

--- a/tests/Feature/Team/RegisterTeamTest.php
+++ b/tests/Feature/Team/RegisterTeamTest.php
@@ -87,7 +87,7 @@ describe('Team Registration with User', function () {
         expect($user->ownsTeam($team))->toBeTrue();
     });
 
-    it('creates admin role for new team during registration', function () {
+    it('attaches the registrant to the global admin role for their new team', function () {
         config(['aura.auth.registration' => true]);
         config(['aura.teams' => true]);
         config(['aura.auth.redirect' => '/admin']);
@@ -106,14 +106,21 @@ describe('Team Registration with User', function () {
         post(route('aura.register.post'), $userData);
 
         $team = Team::where('name', 'Bob Team')->first();
+        $user = User::where('email', 'bob@example.com')->first();
 
-        $adminRole = Role::withoutGlobalScopes()
-            ->where('team_id', $team->id)
-            ->where('slug', 'admin')
-            ->first();
+        // Attach-don't-mint: no per-team admin row; the registrant holds the
+        // shared global admin role, scoped to their new team via the Membership.
+        expect(Role::withoutGlobalScopes()->where('team_id', $team->id)->exists())->toBeFalse();
 
-        expect($adminRole)->not->toBeNull();
-        expect($adminRole->super_admin)->toBeTrue();
+        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+        expect($globalAdmin)->not->toBeNull();
+        expect($globalAdmin->super_admin)->toBeTrue();
+
+        $this->assertDatabaseHas('user_role', [
+            'team_id' => $team->id,
+            'user_id' => $user->id,
+            'role_id' => $globalAdmin->id,
+        ]);
     });
 
     it('assigns new user admin role for their team', function () {

--- a/tests/Feature/Team/RolesAndPermissionsTest.php
+++ b/tests/Feature/Team/RolesAndPermissionsTest.php
@@ -187,7 +187,7 @@ describe('Role Team Association', function () {
         expect(Role::withoutGlobalScopes()->where('team_id', $team2->id)->count())->toBe(0);
 
         // Both teams' Memberships resolve to the same shared global admin role.
-        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+        $globalAdmin = globalAdminRole();
 
         $this->assertDatabaseHas('user_role', ['team_id' => $team1->id, 'role_id' => $globalAdmin->id]);
         $this->assertDatabaseHas('user_role', ['team_id' => $team2->id, 'role_id' => $globalAdmin->id]);

--- a/tests/Feature/Team/RolesAndPermissionsTest.php
+++ b/tests/Feature/Team/RolesAndPermissionsTest.php
@@ -46,36 +46,44 @@ describe('Permissions Table Structure', function () {
     });
 });
 
-describe('Team Role Creation', function () {
-    it('creates default admin role when team is created', function () {
+describe('Team Membership Creation', function () {
+    // Attach-don't-mint: creating a team no longer mints a per-team admin role;
+    // the creator is attached to the shared global `admin` role (team_id = null).
+    it('attaches the creator to the global admin role when team is created', function () {
         $team = Team::factory()->create();
 
-        $this->assertDatabaseHas('roles', [
+        $globalAdmin = Role::withoutGlobalScopes()
+            ->whereNull('team_id')
+            ->where('slug', 'admin')
+            ->first();
+
+        expect($globalAdmin)->not->toBeNull();
+        expect($globalAdmin->super_admin)->toBeTrue();
+
+        $this->assertDatabaseHas('user_role', [
             'team_id' => $team->id,
-            'name' => 'Admin',
-            'super_admin' => true,
+            'user_id' => $this->user->id,
+            'role_id' => $globalAdmin->id,
         ]);
     });
 
-    it('admin role has correct slug', function () {
+    it('does not mint a per-team admin role', function () {
         $team = Team::factory()->create();
 
-        $role = Role::withoutGlobalScopes()
+        $perTeamRole = Role::withoutGlobalScopes()
             ->where('team_id', $team->id)
-            ->where('super_admin', true)
-            ->first();
+            ->exists();
 
-        expect($role->slug)->toBe('admin');
+        expect($perTeamRole)->toBeFalse();
     });
 
-    it('admin role has super_admin flag set to true', function () {
+    it('makes the creator a super admin of the new team via the global role', function () {
         $team = Team::factory()->create();
 
-        $role = Role::withoutGlobalScopes()
-            ->where('team_id', $team->id)
-            ->first();
+        $this->user->update(['current_team_id' => $team->id]);
+        $this->user->refresh();
 
-        expect($role->super_admin)->toBeTrue();
+        expect($this->user->isSuperAdmin())->toBeTrue();
     });
 });
 
@@ -155,26 +163,34 @@ describe('Role Permissions Structure', function () {
 });
 
 describe('Role Team Association', function () {
-    it('role belongs to a team', function () {
+    it('a Team Role belongs to a team', function () {
         $team = Team::factory()->create();
 
-        $role = Role::withoutGlobalScopes()
-            ->where('team_id', $team->id)
-            ->first();
+        // A genuine Team Role (as opposed to the shared global admin) still
+        // carries the team_id it was created under.
+        $role = Role::create([
+            'name' => 'Editor',
+            'slug' => 'editor',
+            'team_id' => $team->id,
+            'permissions' => [],
+        ]);
 
         expect($role->team_id)->toBe($team->id);
     });
 
-    it('different teams have separate roles', function () {
+    it('teams share the single global admin role rather than minting separate rows', function () {
         $team1 = Team::factory()->create();
         $team2 = Team::factory()->create();
 
-        $team1Roles = Role::withoutGlobalScopes()->where('team_id', $team1->id)->count();
-        $team2Roles = Role::withoutGlobalScopes()->where('team_id', $team2->id)->count();
+        // No per-team admin rows are minted for either team.
+        expect(Role::withoutGlobalScopes()->where('team_id', $team1->id)->count())->toBe(0);
+        expect(Role::withoutGlobalScopes()->where('team_id', $team2->id)->count())->toBe(0);
 
-        // Each team should have at least one role (admin)
-        expect($team1Roles)->toBeGreaterThanOrEqual(1);
-        expect($team2Roles)->toBeGreaterThanOrEqual(1);
+        // Both teams' Memberships resolve to the same shared global admin role.
+        $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+
+        $this->assertDatabaseHas('user_role', ['team_id' => $team1->id, 'role_id' => $globalAdmin->id]);
+        $this->assertDatabaseHas('user_role', ['team_id' => $team2->id, 'role_id' => $globalAdmin->id]);
     });
 });
 

--- a/tests/Feature/Team/TeamDeletionCleanupTest.php
+++ b/tests/Feature/Team/TeamDeletionCleanupTest.php
@@ -29,7 +29,7 @@ it('removes a deleted team\'s Memberships and Team Roles but never the shared gl
     $member = User::factory()->create(['current_team_id' => $team->id]);
     $member->roles()->attach($shadowRole->id, ['team_id' => $team->id]);
 
-    $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+    $globalAdmin = globalAdminRole();
 
     // Sanity: memberships and the shadow row exist pre-deletion.
     expect(DB::table('user_role')->where('team_id', $team->id)->count())->toBeGreaterThan(0);

--- a/tests/Feature/Team/TeamDeletionCleanupTest.php
+++ b/tests/Feature/Team/TeamDeletionCleanupTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function () {
+    if (! Schema::hasTable('teams')) {
+        $this->markTestSkipped('Team deletion cleanup is teams-on only.');
+    }
+
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+it('removes a deleted team\'s Memberships and Team Roles but never the shared global rows', function () {
+    // A secondary team with its own Team Role (a Shadow) and a member holding it.
+    $team = Team::create(['name' => 'Doomed Team', 'user_id' => $this->user->id]);
+
+    $shadowRole = Role::create([
+        'name' => 'Team Admin',
+        'slug' => 'admin', // Shadows the global admin by slug within this team.
+        'team_id' => $team->id,
+        'super_admin' => true,
+        'permissions' => [],
+    ]);
+
+    $member = User::factory()->create(['current_team_id' => $team->id]);
+    $member->roles()->attach($shadowRole->id, ['team_id' => $team->id]);
+
+    $globalAdmin = Role::withoutGlobalScopes()->whereNull('team_id')->where('slug', 'admin')->first();
+
+    // Sanity: memberships and the shadow row exist pre-deletion.
+    expect(DB::table('user_role')->where('team_id', $team->id)->count())->toBeGreaterThan(0);
+    expect(Role::withoutGlobalScopes()->where('id', $shadowRole->id)->exists())->toBeTrue();
+
+    $team->delete();
+
+    // The team's Memberships are gone.
+    expect(DB::table('user_role')->where('team_id', $team->id)->count())->toBe(0);
+
+    // The team's own Team Role (Shadow) dies with the team.
+    expect(Role::withoutGlobalScopes()->where('id', $shadowRole->id)->exists())->toBeFalse();
+
+    // The shared global admin role is never touched.
+    expect(Role::withoutGlobalScopes()->whereKey($globalAdmin->id)->whereNull('team_id')->exists())->toBeTrue();
+});

--- a/tests/Feature/Team/TeamTest.php
+++ b/tests/Feature/Team/TeamTest.php
@@ -100,10 +100,7 @@ describe('Team Creation Side Effects', function () {
         // No per-team admin row is minted; the shared global admin role is used.
         expect(Role::withoutGlobalScopes()->where('team_id', $team->id)->exists())->toBeFalse();
 
-        $role = Role::withoutGlobalScopes()
-            ->where('slug', 'admin')
-            ->whereNull('team_id')
-            ->first();
+        $role = globalAdminRole();
 
         expect($role)->not->toBeNull();
         expect($role->name)->toEqual('Admin');
@@ -147,10 +144,7 @@ describe('Team Creation Side Effects', function () {
         expect($pivotData)->not->toBeNull();
 
         // The Membership points at the shared global admin role (team_id = null).
-        $role = Role::withoutGlobalScopes()
-            ->whereNull('team_id')
-            ->where('slug', 'admin')
-            ->first();
+        $role = globalAdminRole();
 
         expect($pivotData->role_id)->toBe($role->id);
     });

--- a/tests/Feature/Team/TeamTest.php
+++ b/tests/Feature/Team/TeamTest.php
@@ -91,15 +91,18 @@ describe('Team SoftDeletes', function () {
 });
 
 describe('Team Creation Side Effects', function () {
-    it('creates an admin role when team is created', function () {
+    it('ensures the global admin role when team is created (attach-don\'t-mint)', function () {
         $team = Team::create([
             'name' => 'New Team With Role',
             'user_id' => $this->user->id,
         ]);
 
+        // No per-team admin row is minted; the shared global admin role is used.
+        expect(Role::withoutGlobalScopes()->where('team_id', $team->id)->exists())->toBeFalse();
+
         $role = Role::withoutGlobalScopes()
             ->where('slug', 'admin')
-            ->where('team_id', $team->id)
+            ->whereNull('team_id')
             ->first();
 
         expect($role)->not->toBeNull();
@@ -143,8 +146,9 @@ describe('Team Creation Side Effects', function () {
 
         expect($pivotData)->not->toBeNull();
 
+        // The Membership points at the shared global admin role (team_id = null).
         $role = Role::withoutGlobalScopes()
-            ->where('team_id', $team->id)
+            ->whereNull('team_id')
             ->where('slug', 'admin')
             ->first();
 
@@ -170,8 +174,17 @@ describe('Team Relationships', function () {
     it('has many roles', function () {
         $team = Team::first();
 
+        // Attach-don't-mint means a team owns no roles by default; the relation
+        // still resolves the team's own Team Roles when it has any.
+        Role::create([
+            'name' => 'Editor',
+            'slug' => 'editor',
+            'team_id' => $team->id,
+            'permissions' => [],
+        ]);
+
         expect($team->roles())->toBeInstanceOf(HasMany::class);
-        expect($team->roles->first())->toBeInstanceOf(Role::class);
+        expect($team->roles()->first())->toBeInstanceOf(Role::class);
     });
 
     it('has many team invitations', function () {

--- a/tests/Feature/UserRoleConditionalIndexFieldsTest.php
+++ b/tests/Feature/UserRoleConditionalIndexFieldsTest.php
@@ -89,8 +89,9 @@ test('super admin can view all headers', function () {
         'team_id' => $this->user->current_team_id,
     ]);
 
-    // Attach role to User
-    $this->user->update(['roles' => [$role->id]]);
+    // Attach the Super Admin role directly: granting a Super Admin role through
+    // the guarded form path requires the acting user to already be a Super Admin.
+    $this->user->roles()->syncWithPivotValues([$role->id], ['team_id' => $this->user->current_team_id]);
     $this->user->refresh();
     $model = new UserRoleConditionalIndexFieldsModel;
 
@@ -174,8 +175,9 @@ test('super admin can get all fields', function () {
         'team_id' => $this->user->current_team_id,
     ]);
 
-    // Attach role to User
-    $this->user->update(['roles' => [$role->id]]);
+    // Attach the Super Admin role directly: granting a Super Admin role through
+    // the guarded form path requires the acting user to already be a Super Admin.
+    $this->user->roles()->syncWithPivotValues([$role->id], ['team_id' => $this->user->current_team_id]);
     $this->user->refresh();
 
     // Test getHeaders()

--- a/tests/FeatureWithDatabaseMigrations/ConsolidatePerTeamAdminRolesMigrationTest.php
+++ b/tests/FeatureWithDatabaseMigrations/ConsolidatePerTeamAdminRolesMigrationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+beforeEach(function () {
+    // Rebuild a fresh teams-on schema, matching the DatabaseMigrations pattern
+    // used by MigrationOwnershipTest, so the consolidation migration runs against
+    // a deterministic pre-upgrade shape (roles.team_id + user_role.team_id).
+    foreach (Schema::getTableListing() as $table) {
+        $table = str($table)->afterLast('.')->toString();
+
+        if ($table !== 'migrations') {
+            Schema::drop($table);
+        }
+    }
+
+    config(['aura.teams' => true]);
+
+    $install = require dirname(__DIR__, 2).'/database/migrations/create_aura_tables.php.stub';
+    $install->up();
+});
+
+function runConsolidationMigration(): void
+{
+    $migration = require dirname(__DIR__, 2).'/database/migrations/consolidate_per_team_admin_roles.php.stub';
+    $migration->up();
+}
+
+function insertPerTeamRole(int $teamId, array $overrides = []): int
+{
+    return (int) DB::table('roles')->insertGetId(array_merge([
+        'name' => 'Admin',
+        'slug' => 'admin',
+        'description' => 'Admin can perform everything.',
+        'super_admin' => true,
+        'permissions' => json_encode([]),
+        'team_id' => $teamId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ], $overrides));
+}
+
+it('consolidates an untouched per-team admin row into the global admin role', function () {
+    // Build the pre-upgrade state directly, bypassing the attach-don't-mint
+    // hooks: a team whose creator holds a minted per-team admin row.
+    $team = Team::factory()->createQuietly();
+    $user = User::factory()->create();
+
+    $perTeamRoleId = insertPerTeamRole($team->id);
+
+    DB::table('user_role')->insert([
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+        'role_id' => $perTeamRoleId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    runConsolidationMigration();
+
+    // The per-team admin row is gone; a single global admin row exists.
+    expect(DB::table('roles')->where('id', $perTeamRoleId)->exists())->toBeFalse();
+
+    $globalAdmin = DB::table('roles')->whereNull('team_id')->where('slug', 'admin')->first();
+    expect($globalAdmin)->not->toBeNull();
+    expect((bool) $globalAdmin->super_admin)->toBeTrue();
+
+    // The Membership is remapped to the global role, still scoped to the team.
+    $membership = DB::table('user_role')->where('user_id', $user->id)->where('team_id', $team->id)->first();
+    expect((int) $membership->role_id)->toBe((int) $globalAdmin->id);
+});
+
+it('leaves a customized admin row in place as a Shadow', function () {
+    $team = Team::factory()->createQuietly();
+    $user = User::factory()->create();
+
+    // Customized: a non-empty permission set marks it as intentionally edited.
+    $shadowRoleId = insertPerTeamRole($team->id, [
+        'permissions' => json_encode(['view-user' => true]),
+    ]);
+
+    DB::table('user_role')->insert([
+        'team_id' => $team->id,
+        'user_id' => $user->id,
+        'role_id' => $shadowRoleId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    runConsolidationMigration();
+
+    // The customized row survives as a Team Role (Shadow) and keeps its Membership.
+    expect(DB::table('roles')->where('id', $shadowRoleId)->whereNotNull('team_id')->exists())->toBeTrue();
+
+    $membership = DB::table('user_role')->where('user_id', $user->id)->where('team_id', $team->id)->first();
+    expect((int) $membership->role_id)->toBe($shadowRoleId);
+});
+
+it('consolidates untouched rows while leaving customized rows as Shadows in one pass', function () {
+    $teamA = Team::factory()->createQuietly();
+    $teamB = Team::factory()->createQuietly();
+    $userA = User::factory()->create();
+    $userB = User::factory()->create();
+
+    $untouchedId = insertPerTeamRole($teamA->id);
+    $customizedId = insertPerTeamRole($teamB->id, [
+        'name' => 'Team Admin',
+        'permissions' => json_encode(['view-user' => true]),
+    ]);
+
+    DB::table('user_role')->insert([
+        ['team_id' => $teamA->id, 'user_id' => $userA->id, 'role_id' => $untouchedId, 'created_at' => now(), 'updated_at' => now()],
+        ['team_id' => $teamB->id, 'user_id' => $userB->id, 'role_id' => $customizedId, 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    runConsolidationMigration();
+
+    $globalAdmin = DB::table('roles')->whereNull('team_id')->where('slug', 'admin')->first();
+
+    // Untouched consolidated.
+    expect(DB::table('roles')->where('id', $untouchedId)->exists())->toBeFalse();
+    expect((int) DB::table('user_role')->where('user_id', $userA->id)->value('role_id'))->toBe((int) $globalAdmin->id);
+
+    // Customized preserved.
+    expect(DB::table('roles')->where('id', $customizedId)->exists())->toBeTrue();
+    expect((int) DB::table('user_role')->where('user_id', $userB->id)->value('role_id'))->toBe($customizedId);
+});
+
+it('is a strict no-op on a fresh install with no per-team admin rows', function () {
+    $rolesBefore = DB::table('roles')->count();
+    $membershipsBefore = DB::table('user_role')->count();
+
+    runConsolidationMigration();
+
+    expect(DB::table('roles')->count())->toBe($rolesBefore);
+    expect(DB::table('user_role')->count())->toBe($membershipsBefore);
+});

--- a/tests/FeatureWithDatabaseMigrations/RoleResolutionWithoutTeamsTest.php
+++ b/tests/FeatureWithDatabaseMigrations/RoleResolutionWithoutTeamsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use Aura\Base\Database\Seeders\RoleCatalogSeeder;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\Schema;
+
+// Teams-off behavior of the Role Catalog: there is a single flat catalog, so the
+// Global Roles simply are the roles. A fresh install seeds `admin` and `user`,
+// and Teams-off registration assigns the seeded `user` role with zero manual
+// seeding.
+
+beforeEach(function () {
+    config(['aura.teams' => false]);
+    config(['aura.auth.registration' => true]);
+
+    $this->artisan('migrate:fresh');
+
+    $migration = require __DIR__.'/../../database/migrations/create_aura_tables.php.stub';
+    $migration->up();
+
+    // Seed the base catalog the same way a fresh install does.
+    RoleCatalogSeeder::seed();
+});
+
+afterEach(function () {
+    config(['aura.teams' => true]);
+});
+
+describe('Teams-off role resolution', function () {
+    it('seeds the admin and user Global Roles without a team_id column', function () {
+        expect(Schema::hasColumn('roles', 'team_id'))->toBeFalse();
+
+        expect(Role::where('slug', 'admin')->count())->toBe(1);
+        expect(Role::where('slug', 'user')->count())->toBe(1);
+    });
+
+    it('resolves roles by slug (the Global Roles are the roles)', function () {
+        $admin = Role::resolveForTeam('admin', null);
+        $user = Role::resolveForTeam('user', null);
+
+        expect($admin)->not->toBeNull();
+        expect($admin->super_admin)->toBeTrue();
+
+        expect($user)->not->toBeNull();
+        expect($user->super_admin)->toBeFalse();
+
+        expect(Role::resolveForTeam('missing', null))->toBeNull();
+    });
+
+    it('is idempotent — re-seeding does not duplicate roles', function () {
+        RoleCatalogSeeder::seed();
+        RoleCatalogSeeder::seed();
+
+        expect(Role::where('slug', 'admin')->count())->toBe(1);
+        expect(Role::where('slug', 'user')->count())->toBe(1);
+    });
+});
+
+describe('Teams-off permission checks via the seam', function () {
+    it('grants a super admin every permission and a plain user none', function () {
+        $admin = User::factory()->create();
+        $admin->roles()->sync([Role::resolveForTeam('admin', null)->id]);
+        $admin->refresh();
+
+        expect($admin->isSuperAdmin())->toBeTrue();
+        expect($admin->hasPermission('delete-post'))->toBeTrue();
+
+        $plain = User::factory()->create();
+        $plain->roles()->sync([Role::resolveForTeam('user', null)->id]);
+        $plain->refresh();
+
+        expect($plain->isSuperAdmin())->toBeFalse();
+        expect($plain->hasPermission('delete-post'))->toBeFalse();
+        expect($plain->hasRole('user'))->toBeTrue();
+    });
+});
+
+describe('Teams-off registration', function () {
+    it('succeeds on a fresh install and assigns the seeded user role', function () {
+        $this->post(route('aura.register'), [
+            'name' => 'Fresh Install User',
+            'email' => 'fresh@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ])->assertRedirect(config('aura.auth.redirect'));
+
+        $this->assertAuthenticated();
+
+        $user = User::where('email', 'fresh@example.com')->first();
+
+        expect($user)->not->toBeNull();
+        expect($user->hasRole('user'))->toBeTrue();
+        expect($user->isSuperAdmin())->toBeFalse();
+    });
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -65,6 +65,19 @@ function createPost(array $attributes = []): Post
     return Post::factory()->create($attributes);
 }
 
+/**
+ * The shared global `admin` Global Role (team_id = null) that backs the
+ * attach-don't-mint model. Returned unscoped so it is visible regardless of the
+ * current team context.
+ */
+function globalAdminRole(): ?Role
+{
+    return Role::withoutGlobalScopes()
+        ->whereNull('team_id')
+        ->where('slug', 'admin')
+        ->first();
+}
+
 function createSuperAdmin()
 {
     if (! config('aura.teams')) {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -143,10 +143,11 @@ function createSuperAdminWithoutTeam()
 
     auth()->login($user);
 
-    $role = Role::create([
+    // Reuse the seeded admin Global Role when present (Teams-off has a unique
+    // slug constraint), otherwise create it.
+    $role = Role::firstOrCreate(['slug' => 'admin'], [
         'type' => 'Role',
         'title' => 'Admin',
-        'slug' => 'admin',
         'name' => 'Admin',
         'description' => 'Admin can perform everything.',
         'super_admin' => true,

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,13 +1,11 @@
 <?php
 
-use Aura\Base\Models\Scopes\TeamScope;
 use Aura\Base\Resources\Role;
 use Aura\Base\Resources\Team;
 use Aura\Base\Resources\User;
 use Aura\Base\Tests\BrowserTestCase;
 use Aura\Base\Tests\Resources\Post;
 use Aura\Base\Tests\TestCase;
-use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
@@ -77,7 +75,9 @@ function createSuperAdmin()
 
     auth()->login($user);
 
-    // Create Team
+    // Attach-don't-mint: creating the team attaches the creator to the shared
+    // global `admin` role via Team::booted (self-healing the Global Role when the
+    // catalog was not seeded). No per-team admin row is minted.
     $team = Team::factory()->create();
 
     // Set current_team_id of the user
@@ -85,42 +85,6 @@ function createSuperAdmin()
 
     // Clear the cache for the user's current_team_id to ensure TeamScope uses the updated value
     Cache::forget("user_{$user->id}_current_team_id");
-
-    // Create or find Admin role for the team with race condition handling
-    // Use withoutGlobalScope to bypass TeamScope and avoid cache issues
-    $role = Role::withoutGlobalScope(TeamScope::class)
-        ->where('team_id', $team->id)
-        ->where('slug', 'admin')
-        ->first();
-
-    if (! $role) {
-        try {
-            $role = Role::create([
-                'team_id' => $team->id,
-                'slug' => 'admin',
-                'type' => 'Role',
-                'title' => 'Admin',
-                'name' => 'Admin',
-                'description' => 'Admin can perform everything.',
-                'super_admin' => true,
-                'permissions' => [],
-                'user_id' => $user->id,
-            ]);
-        } catch (UniqueConstraintViolationException $e) {
-            // Handle race condition: another process created the role, just fetch it
-            $role = Role::withoutGlobalScope(TeamScope::class)
-                ->where('team_id', $team->id)
-                ->where('slug', 'admin')
-                ->first();
-        }
-    }
-
-    // Associate the role with the user using the proper relationship
-    if (config('aura.teams')) {
-        $user->roles()->syncWithPivotValues([$role->id], ['team_id' => $team->id]);
-    } else {
-        $user->roles()->sync([$role->id]);
-    }
 
     $user->refresh();
 


### PR DESCRIPTION
## Summary

PR 1 of the access-control stack (parent spec #45). Introduces the **Role Catalog**:

- Roles are **Global Roles** (`team_id = null`, instance-wide) or **Team Roles** (one team). A team **Shadows** a global role by slug; resolution happens **at check time** through the single new seam `Role::resolveForTeam()` — Membership pivots are never rewritten, so shadow create/delete takes effect instantly (ADR 0005).
- `User::cachedRoles()` resolves every Membership through the seam, memoized per team context with a catalog-version invalidation (zero queries on repeat permission checks — locked in by a query-count test). Permission sets normalize in one place; the old string-decode "temporary fix" is gone. Null team context strictly resolves no team roles.
- **Seeded catalog**: `admin` (Super Admin) + `user` ship via `RoleCatalogSeeder` (install command, both modes) and self-heal at runtime (`Role::firstOrCreateCatalogRole()`) — teams-off registration works on a bare-migrate install.
- **Attach-don't-mint** (#50): team creation and registration attach the creator to the shared global `admin` role instead of minting per-team admin rows. Invitations and the Roles field accept current-team or global roles, still refusing other teams'. Team deletion removes the team's Memberships and its own roles, never global rows.
- **Consolidation migration** (best-effort, deliberate ADR 0003 exception): remaps Memberships of untouched per-team admin rows to the global admin; customized rows stay as Shadows. Strict no-op on fresh/teams-off installs.

Known interim state (by design, next PRs): the Roles index shows global roles un-deduplicated and without read-only marking — the merged catalog UI is #52; Global Admin (gate/flag) is #48/#51.

## Testing

- Teams-on: 1651 passed (4917 assertions) · Teams-off: 1400 passed (4170) · Browser: 12 passed · PHPStan: 0 errors · Pint clean
- New: resolution-seam tests (16), attach-don't-mint (5), global-role invitations (3), team-deletion cleanup, consolidation migration (4), memoization query-count regression test
- Two-axis code review (standards + spec vs. #47/#50) ran; all findings fixed in e2ced02b

Closes #47. Closes #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)