### PR TITLE
Global Admin: gate, flag, CLI bootstrap, sees-all + visitation (#48, #51)

### DIFF
--- a/database/migrations/add_global_admin_to_users.php.stub
+++ b/database/migrations/add_global_admin_to_users.php.stub
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add the Global Admin flag to the users table (best-effort, pre-release
+ * posture per ADR 0003).
+ *
+ * Fresh installs already get `users.global_admin` from create_aura_tables. This
+ * migration covers pre-release installs whose users table predates the column:
+ * it adds the boolean (default false) only when it is missing, so existing
+ * users are non-Global-Admins until an operator grants the flag via the CLI or
+ * a Global Admin toggles it.
+ *
+ * No down(): the flag never carries destructive intent, and dropping a column
+ * that may hold granted operators would be the destructive move.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('users')) {
+            return;
+        }
+
+        if (Schema::hasColumn('users', 'global_admin')) {
+            return;
+        }
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('global_admin')->default(false);
+        });
+    }
+};

--- a/database/migrations/add_global_admin_to_users.php.stub
+++ b/database/migrations/add_global_admin_to_users.php.stub
@@ -14,8 +14,8 @@ use Illuminate\Support\Facades\Schema;
  * users are non-Global-Admins until an operator grants the flag via the CLI or
  * a Global Admin toggles it.
  *
- * No down(): the flag never carries destructive intent, and dropping a column
- * that may hold granted operators would be the destructive move.
+ * Rollback removes only the column this migration added (ADR 0002: an
+ * added-column migration rolls back by dropping only those columns).
  */
 return new class extends Migration
 {
@@ -31,6 +31,21 @@ return new class extends Migration
 
         Schema::table('users', function (Blueprint $table) {
             $table->boolean('global_admin')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('users')) {
+            return;
+        }
+
+        if (! Schema::hasColumn('users', 'global_admin')) {
+            return;
+        }
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('global_admin');
         });
     }
 };

--- a/database/migrations/create_aura_tables.php.stub
+++ b/database/migrations/create_aura_tables.php.stub
@@ -113,6 +113,7 @@ return new class extends Migration
             'two_factor_recovery_codes',
             'two_factor_confirmed_at',
             'current_team_id',
+            'global_admin',
             'deleted_at',
         ];
         $existingUserColumns = Schema::hasTable('users')
@@ -149,6 +150,9 @@ return new class extends Migration
                 if (config('aura.teams')) {
                     $table->foreignId('current_team_id')->nullable();
                 }
+                // Instance-level operator flag (Global Admin). Never mass-assignable;
+                // set only via the CLI bootstrap or a Global Admin-guarded write.
+                $table->boolean('global_admin')->default(false);
                 $table->timestamps();
                 $table->softDeletes();
             });
@@ -165,6 +169,9 @@ return new class extends Migration
                 }
                 if (config('aura.teams') && ! Schema::hasColumn('users', 'current_team_id')) {
                     $table->foreignId('current_team_id')->nullable();
+                }
+                if (! Schema::hasColumn('users', 'global_admin')) {
+                    $table->boolean('global_admin')->default(false);
                 }
                 if (! Schema::hasColumn('users', 'deleted_at')) {
                     $table->softDeletes();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1162,12 +1162,6 @@ parameters:
 			path: src/Resources/User.php
 
 		-
-			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model&object\{pivot\: Illuminate\\Database\\Eloquent\\Relations\\Pivot\}\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/Resources/User.php
-
-		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 2

--- a/src/AuraServiceProvider.php
+++ b/src/AuraServiceProvider.php
@@ -95,6 +95,16 @@ class AuraServiceProvider extends PackageServiceProvider
         Gate::policy(Resource::class, ResourcePolicy::class);
         Gate::policy(User::class, UserPolicy::class);
 
+        // Global Admin: an instance-level operator that transcends the tenant
+        // boundary. The package resolves it from the users.global_admin flag so
+        // the policy bypasses keyed on isAuraGlobalAdmin() become live out of the
+        // box. Host apps may redefine this gate in their own service provider —
+        // app providers boot after package providers, so a later Gate::define
+        // wins. A required $user param means guests are denied automatically.
+        Gate::define('AuraGlobalAdmin', function ($user) {
+            return (bool) ($user->global_admin ?? false);
+        });
+
         return $this;
     }
 
@@ -215,7 +225,7 @@ class AuraServiceProvider extends PackageServiceProvider
             ->hasViews('aura')
             ->hasAssets()
             ->hasRoutes('web')
-            ->hasMigrations(['create_aura_tables', 'consolidate_per_team_admin_roles'])
+            ->hasMigrations(['create_aura_tables', 'consolidate_per_team_admin_roles', 'add_global_admin_to_users'])
             ->runsMigrations()
             ->hasCommands([
                 InstallConfigCommand::class,

--- a/src/AuraServiceProvider.php
+++ b/src/AuraServiceProvider.php
@@ -101,7 +101,7 @@ class AuraServiceProvider extends PackageServiceProvider
         // box. Host apps may redefine this gate in their own service provider —
         // app providers boot after package providers, so a later Gate::define
         // wins. A required $user param means guests are denied automatically.
-        Gate::define('AuraGlobalAdmin', function ($user) {
+        Gate::define(User::GLOBAL_ADMIN_GATE, function ($user) {
             return (bool) ($user->global_admin ?? false);
         });
 

--- a/src/Commands/MakeUser.php
+++ b/src/Commands/MakeUser.php
@@ -8,6 +8,7 @@ use Aura\Base\Resources\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Auth;
 
+use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\text;
 
@@ -18,13 +19,26 @@ class MakeUser extends Command
     protected $signature = 'aura:user
                             {--name= : The name of the user}
                             {--email= : A valid email address}
-                            {--password= : The password for the user}';
+                            {--password= : The password for the user}
+                            {--global-admin : Grant the user instance-level Global Admin status}';
 
     public function handle(): int
     {
         $name = $this->option('name') ?? text('What is your name?');
         $email = $this->option('email') ?? text('What is your email?');
         $password = $this->option('password') ?? password('What is your password?');
+
+        $globalAdmin = (bool) $this->option('global-admin');
+
+        // When running interactively (no CLI options supplied) offer the choice.
+        // Passing any option keeps the command non-interactive and additive, so
+        // existing scripted invocations are unaffected.
+        if (! $globalAdmin
+            && $this->option('name') === null
+            && $this->option('email') === null
+            && $this->option('password') === null) {
+            $globalAdmin = confirm(label: 'Should this user be a Global Admin?', default: false);
+        }
 
         /** @var User $user */
         $user = User::create([
@@ -53,6 +67,13 @@ class MakeUser extends Command
             // This bootstrap command creates the first administrator, so attach
             // the role directly instead of going through delegated role editing.
             $user->roles()->sync([$role->id]);
+        }
+
+        // The CLI is a trusted bootstrap path, so it writes the flag directly.
+        // saveQuietly bypasses the field pipeline's Global Admin escalation guard
+        // (which would otherwise refuse, as the actor is not yet a Global Admin).
+        if ($globalAdmin) {
+            $user->forceFill(['global_admin' => true])->saveQuietly();
         }
 
         $this->info('User created successfully.');

--- a/src/Commands/MakeUser.php
+++ b/src/Commands/MakeUser.php
@@ -30,13 +30,12 @@ class MakeUser extends Command
 
         $globalAdmin = (bool) $this->option('global-admin');
 
-        // When running interactively (no CLI options supplied) offer the choice.
-        // Passing any option keeps the command non-interactive and additive, so
-        // existing scripted invocations are unaffected.
-        if (! $globalAdmin
-            && $this->option('name') === null
-            && $this->option('email') === null
-            && $this->option('password') === null) {
+        // Offer the Global Admin choice on any interactive run that did not
+        // already pass --global-admin — including partial-option runs like
+        // `aura:user --name=X`. Non-interactive runs (scripts, CI, --no-interaction)
+        // keep the flag off unless --global-admin was passed, so automation is
+        // never blocked on a prompt.
+        if (! $globalAdmin && $this->input->isInteractive()) {
             $globalAdmin = confirm(label: 'Should this user be a Global Admin?', default: false);
         }
 

--- a/src/Fields/GlobalAdmin.php
+++ b/src/Fields/GlobalAdmin.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Aura\Base\Fields;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * The Global Admin flag field.
+ *
+ * `global_admin` is a real users-table column but is deliberately kept out of
+ * the mass-assignment surface: the value only ever reaches the column through
+ * this guarded write. Mirroring the escalation guard on the Roles field, the
+ * flag can only be changed by an acting user who is already a Global Admin.
+ * Every other actor — a guest during registration, a team Super Admin, mass
+ * assignment, or form tampering — leaves the persisted flag untouched (silent
+ * refusal), so the flag can never be self-granted.
+ */
+class GlobalAdmin extends Boolean
+{
+    public function saved($post, $field, $value)
+    {
+        $new = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        $current = (bool) $post->getOriginal('global_admin');
+
+        // No change requested (e.g. a non-GA re-submitting a hidden field at its
+        // current value): nothing to guard, nothing to write.
+        if ($new === $current) {
+            return;
+        }
+
+        // Only a Global Admin may change the flag. Anyone else is silently
+        // refused: the persisted value stays as it was, so the escalation
+        // attempt changes nothing.
+        if (! (Auth::check() && Gate::allows('AuraGlobalAdmin'))) {
+            return;
+        }
+
+        // Trusted write. saveQuietly bypasses the field pipeline (no recursion,
+        // no re-guarding) and persists the column directly.
+        $post->forceFill(['global_admin' => $new])->saveQuietly();
+    }
+}

--- a/src/Models/Scopes/TeamScope.php
+++ b/src/Models/Scopes/TeamScope.php
@@ -59,7 +59,7 @@ class TeamScope implements Scope
                     // for any authenticatable, not only the Aura User model.
                     $authUser = Auth::user();
 
-                    if (! ($authUser && Gate::forUser($authUser)->allows('AuraGlobalAdmin'))) {
+                    if (! ($authUser && Gate::forUser($authUser)->allows(User::GLOBAL_ADMIN_GATE))) {
                         $builder->whereHas('teams', function ($query) use ($currentTeamId) {
                             $query->where('teams.id', $currentTeamId);
                         });

--- a/src/Models/Scopes/TeamScope.php
+++ b/src/Models/Scopes/TeamScope.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Scope;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 
 class TeamScope implements Scope
 {
@@ -48,9 +49,21 @@ class TeamScope implements Scope
 
                 // Only apply team scoping if teams are enabled
                 if (config('aura.teams') && $currentTeamId) {
-                    $builder->whereHas('teams', function ($query) use ($currentTeamId) {
-                        $query->where('teams.id', $currentTeamId);
-                    });
+                    // A Global Admin transcends the tenant boundary: their user
+                    // queries are never restricted to current-team members. The
+                    // bypass is gated strictly on the authenticated user being a
+                    // Global Admin, so it never leaks into ordinary requests.
+                    // (Auth::user() is already resolved here; the $applying guard
+                    // above prevents any re-entry while it is read.) The gate is
+                    // consulted directly so the check is host-overridable and safe
+                    // for any authenticatable, not only the Aura User model.
+                    $authUser = Auth::user();
+
+                    if (! ($authUser && Gate::forUser($authUser)->allows('AuraGlobalAdmin'))) {
+                        $builder->whereHas('teams', function ($query) use ($currentTeamId) {
+                            $query->where('teams.id', $currentTeamId);
+                        });
+                    }
                 }
 
                 self::$applying = false;

--- a/src/Policies/ResourcePolicy.php
+++ b/src/Policies/ResourcePolicy.php
@@ -23,7 +23,7 @@ class ResourcePolicy
             return false;
         }
 
-        if ($user->isSuperAdmin()) {
+        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
             return true;
         }
 
@@ -42,7 +42,7 @@ class ResourcePolicy
      */
     public function delete($user, $resource)
     {
-        if ($user->isSuperAdmin()) {
+        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
             return true;
         }
 
@@ -70,7 +70,7 @@ class ResourcePolicy
      */
     public function forceDelete($user, $resource)
     {
-        if ($user->isSuperAdmin()) {
+        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
             return true;
         }
 
@@ -89,7 +89,7 @@ class ResourcePolicy
      */
     public function restore(User $user, $resource)
     {
-        if ($user->isSuperAdmin()) {
+        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
             return true;
         }
         if ($user->hasPermissionTo('restore', $resource)) {
@@ -111,7 +111,7 @@ class ResourcePolicy
             return false;
         }
 
-        if ($user->isSuperAdmin()) {
+        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
             return true;
         }
 
@@ -150,7 +150,7 @@ class ResourcePolicy
         }
 
         // Check if the user is a superadmin
-        if ($user->isSuperAdmin()) {
+        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
             return true;
         }
 
@@ -181,7 +181,7 @@ class ResourcePolicy
             return false;
         }
 
-        if ($user->isSuperAdmin()) {
+        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
             return true;
         }
 

--- a/src/Policies/ResourcePolicy.php
+++ b/src/Policies/ResourcePolicy.php
@@ -23,7 +23,7 @@ class ResourcePolicy
             return false;
         }
 
-        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
+        if ($this->hasBlanketAccess($user)) {
             return true;
         }
 
@@ -42,7 +42,7 @@ class ResourcePolicy
      */
     public function delete($user, $resource)
     {
-        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
+        if ($this->hasBlanketAccess($user)) {
             return true;
         }
 
@@ -70,7 +70,7 @@ class ResourcePolicy
      */
     public function forceDelete($user, $resource)
     {
-        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
+        if ($this->hasBlanketAccess($user)) {
             return true;
         }
 
@@ -89,7 +89,7 @@ class ResourcePolicy
      */
     public function restore(User $user, $resource)
     {
-        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
+        if ($this->hasBlanketAccess($user)) {
             return true;
         }
         if ($user->hasPermissionTo('restore', $resource)) {
@@ -111,7 +111,7 @@ class ResourcePolicy
             return false;
         }
 
-        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
+        if ($this->hasBlanketAccess($user)) {
             return true;
         }
 
@@ -150,7 +150,7 @@ class ResourcePolicy
         }
 
         // Check if the user is a superadmin
-        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
+        if ($this->hasBlanketAccess($user)) {
             return true;
         }
 
@@ -181,7 +181,7 @@ class ResourcePolicy
             return false;
         }
 
-        if ($user->isSuperAdmin() || $user->isAuraGlobalAdmin()) {
+        if ($this->hasBlanketAccess($user)) {
             return true;
         }
 
@@ -190,5 +190,15 @@ class ResourcePolicy
         }
 
         return false;
+    }
+
+    /**
+     * Blanket access: a Super Admin (per-team) or a Global Admin (instance-wide,
+     * including a Global Admin visiting a team where they hold no role) clears
+     * every resource ability. The single gate every method funnels through.
+     */
+    protected function hasBlanketAccess($user): bool
+    {
+        return $user->isSuperAdmin() || $user->isAuraGlobalAdmin();
     }
 }

--- a/src/Resources/Team.php
+++ b/src/Resources/Team.php
@@ -298,6 +298,10 @@ class Team extends Resource
                 Cache::forget('user.'.$user->id.'.teams');
             }
 
+            // A Global Admin's switcher lists every team from one shared cache
+            // key — invalidate it so a newly created team appears immediately.
+            Cache::forget('aura.global_admin.teams');
+
             // Create all permissions for the team
             GenerateAllResourcePermissions::dispatch($team->id);
         });
@@ -356,6 +360,10 @@ class Team extends Resource
                 ->each(function ($userId) {
                     Cache::forget('user.'.$userId.'.teams');
                 });
+
+            // Drop the shared Global Admin switcher cache so the deleted team
+            // no longer shows up for Global Admins.
+            Cache::forget('aura.global_admin.teams');
         });
 
     }

--- a/src/Resources/Team.php
+++ b/src/Resources/Team.php
@@ -259,6 +259,14 @@ class Team extends Resource
     protected static function booted()
     {
         parent::booted();
+
+        // Any team write (create, rename, restore) can change what a Global
+        // Admin's switcher should show — drop the shared cache. created/deleted
+        // also forget it explicitly, but a plain rename only fires saved.
+        static::saved(function ($team) {
+            Cache::forget(User::GLOBAL_ADMIN_TEAMS_CACHE_KEY);
+        });
+
         static::saving(function ($team) {
             // unset title attribute
             unset($team->title);
@@ -300,7 +308,7 @@ class Team extends Resource
 
             // A Global Admin's switcher lists every team from one shared cache
             // key — invalidate it so a newly created team appears immediately.
-            Cache::forget('aura.global_admin.teams');
+            Cache::forget(User::GLOBAL_ADMIN_TEAMS_CACHE_KEY);
 
             // Create all permissions for the team
             GenerateAllResourcePermissions::dispatch($team->id);
@@ -363,7 +371,7 @@ class Team extends Resource
 
             // Drop the shared Global Admin switcher cache so the deleted team
             // no longer shows up for Global Admins.
-            Cache::forget('aura.global_admin.teams');
+            Cache::forget(User::GLOBAL_ADMIN_TEAMS_CACHE_KEY);
         });
 
     }

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -63,6 +63,7 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'global_admin' => 'boolean',
         // 'password' => 'hashed',
     ];
 
@@ -357,6 +358,26 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
                 'on_create' => true,
                 'on_index' => false,
                 'on_view' => false,
+                'style' => [
+                    'width' => '50',
+                ],
+            ],
+            [
+                'name' => 'Global Admin',
+                'slug' => 'global_admin',
+                'type' => 'Aura\\Base\\Fields\\GlobalAdmin',
+                'instructions' => 'Instance-level operator with access across all teams. Only a Global Admin can grant or revoke this.',
+                'validation' => '',
+                'default' => false,
+                'on_index' => false,
+                'on_forms' => true,
+                'on_view' => true,
+                // Client-advisory only: the field is shown to Global Admins so
+                // they can toggle it. The authoritative guard lives server-side
+                // in the GlobalAdmin field's saved() escalation check.
+                'conditional_logic' => function ($model, $post) {
+                    return auth()->check() && Gate::allows('AuraGlobalAdmin');
+                },
                 'style' => [
                     'width' => '50',
                 ],

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -240,10 +240,13 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
         }
 
         if (is_null($this->current_team_id) && $this->id) {
-            $team_id = $this->teams()->first()->id ?? null;
+            // Fall back to the user's first Membership. A Global Admin with no
+            // Membership has no team here — current team stays null and they
+            // operate by visiting a team explicitly via switchTeam().
+            $team = $this->teams()->first();
 
-            if ($team_id) {
-                $this->switchTeam($team_id);
+            if ($team) {
+                $this->switchTeam($team);
             }
         }
 
@@ -561,6 +564,16 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
             return;
         }
 
+        // A Global Admin sees every team in the switcher, not only the teams they
+        // are a member of — visitation lets them enter any of them. The list is
+        // identical for every Global Admin, so it is cached under one shared key
+        // that Team create/delete invalidates (see Team::booted).
+        if ($this->isAuraGlobalAdmin()) {
+            return Cache::remember('aura.global_admin.teams', now()->addHour(), function () {
+                return app(config('aura.resources.team'))::withoutGlobalScopes()->with('meta')->get();
+            });
+        }
+
         // Return cached teams with meta
         return Cache::remember('user.'.$this->id.'.teams', now()->addHour(), function () {
             return $this->teams()->with('meta')->get();
@@ -672,6 +685,17 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
     public function indexQuery($query)
     {
         if (config('aura.teams')) {
+            // A Global Admin transcends the tenant boundary: the Users index
+            // lists every user — including users with no Membership at all
+            // (e.g. orphaned by a team deletion), who must stay reachable for
+            // an instance operator. (TeamScope's users branch grants the
+            // matching cross-team bypass; both seams must relax together or
+            // the index would re-restrict.) The gate is consulted directly so
+            // it stays host-overridable and safe for any authenticatable.
+            if (Auth::user() && Gate::allows('AuraGlobalAdmin')) {
+                return $query;
+            }
+
             // A user belongs to the current team when they hold a Membership for
             // it — filter on the pivot's team_id, not the role row's team_id. A
             // Global Role carries team_id = null, so keying off the role row would
@@ -700,7 +724,10 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
      */
     public function isCurrentTeam($team)
     {
-        return $team->id === $this->currentTeam->id;
+        // A Global Admin may have no current team (no Membership, not yet
+        // visiting) while the switcher still lists teams to enter — guard the
+        // null so the switcher renders instead of dereferencing a null team.
+        return $this->currentTeam && $team->id === $this->currentTeam->id;
     }
 
     /**
@@ -790,7 +817,17 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
      */
     public function switchTeam($team)
     {
-        if (! $this->belongsToTeam($team)) {
+        // Switching the current team is a teams-only operation — a no-op in
+        // Teams-off mode (there is no teams table to switch between).
+        if (! config('aura.teams')) {
+            return false;
+        }
+
+        // Visitation: a Global Admin may enter any team without holding a
+        // Membership (no user_role row is created — switchTeam only moves the
+        // current-team pointer). Their in-team power comes from the policy gate
+        // bypasses, not from resolved roles. Everyone else must be a member.
+        if (! $this->belongsToTeam($team) && ! $this->isAuraGlobalAdmin()) {
             return false;
         }
 

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rules\Password;
 use Lab404\Impersonate\Models\Impersonate;
+use Lab404\Impersonate\Services\ImpersonateManager;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Sanctum\HasApiTokens;
 
@@ -39,6 +40,17 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
     use Notifiable;
     use ProfileFields;
     use TwoFactorAuthenticatable;
+
+    /**
+     * The gate that decides Global Admin status. Host apps may redefine it.
+     */
+    public const GLOBAL_ADMIN_GATE = 'AuraGlobalAdmin';
+
+    /**
+     * Shared cache key for the Global Admin team switcher list (identical for
+     * every Global Admin; invalidated on team create/rename/delete).
+     */
+    public const GLOBAL_ADMIN_TEAMS_CACHE_KEY = 'aura.global_admin.teams';
 
     public static $customTable = true;
 
@@ -118,7 +130,7 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
                 'label' => 'Impersonate',
                 'icon-view' => 'aura::components.actions.impersonate',
                 'conditional_logic' => function () {
-                    return auth()->user()->isAuraGlobalAdmin();
+                    return auth()->user()?->isAuraGlobalAdmin();
                 },
             ],
         ];
@@ -569,7 +581,7 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
         // identical for every Global Admin, so it is cached under one shared key
         // that Team create/delete invalidates (see Team::booted).
         if ($this->isAuraGlobalAdmin()) {
-            return Cache::remember('aura.global_admin.teams', now()->addHour(), function () {
+            return Cache::remember(self::GLOBAL_ADMIN_TEAMS_CACHE_KEY, now()->addHour(), function () {
                 return app(config('aura.resources.team'))::withoutGlobalScopes()->with('meta')->get();
             });
         }
@@ -679,7 +691,21 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
 
     public function impersonateAction()
     {
-        $this->impersonate($this);
+        // The row action is invoked on the TARGET user ($this); the acting user
+        // is the impersonator. Authorize the pair explicitly — Lab404's take()
+        // does not — so only a Global Admin may impersonate (canImpersonate), and
+        // a Global Admin can never be impersonated (canBeImpersonated). The actor
+        // side goes through the gate because auth()->user() is loosely typed.
+        $impersonator = auth()->user();
+
+        abort_unless(
+            $impersonator
+                && Gate::forUser($impersonator)->allows(self::GLOBAL_ADMIN_GATE)
+                && $this->canBeImpersonated(),
+            403
+        );
+
+        app(ImpersonateManager::class)->take($impersonator, $this);
     }
 
     public function indexQuery($query)
@@ -690,9 +716,9 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
             // (e.g. orphaned by a team deletion), who must stay reachable for
             // an instance operator. (TeamScope's users branch grants the
             // matching cross-team bypass; both seams must relax together or
-            // the index would re-restrict.) The gate is consulted directly so
-            // it stays host-overridable and safe for any authenticatable.
-            if (Auth::user() && Gate::allows('AuraGlobalAdmin')) {
+            // the index would re-restrict.) The gate is consulted directly since
+            // the authenticated user is loosely typed here.
+            if (Auth::check() && Gate::allows(self::GLOBAL_ADMIN_GATE)) {
                 return $query;
             }
 
@@ -713,7 +739,10 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
      */
     public function isAuraGlobalAdmin(): bool
     {
-        return Gate::allows('AuraGlobalAdmin');
+        // Evaluate the gate for THIS user instance, not the authenticated user —
+        // policies, switchTeam, and impersonation call this on a specific model
+        // that is not always the current actor.
+        return Gate::forUser($this)->allows(self::GLOBAL_ADMIN_GATE);
     }
 
     /**

--- a/tests/Feature/Aura/MakeUserCommandTest.php
+++ b/tests/Feature/Aura/MakeUserCommandTest.php
@@ -78,6 +78,8 @@ describe('with teams enabled', function () {
             '--email' => 'cli@example.com',
             '--password' => 'clipassword',
         ])
+            // Partial-option interactive runs still prompt for Global Admin.
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
             ->expectsOutput('User created successfully.')
             ->assertExitCode(0);
 
@@ -132,7 +134,10 @@ describe('with teams enabled', function () {
             '--name' => 'Plain User',
             '--email' => 'plain@example.com',
             '--password' => 'plainpassword',
-        ])->assertExitCode(0);
+        ])
+            // Declining the prompt leaves the flag off.
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
+            ->assertExitCode(0);
 
         $user = User::where('email', 'plain@example.com')->first();
 

--- a/tests/Feature/Aura/MakeUserCommandTest.php
+++ b/tests/Feature/Aura/MakeUserCommandTest.php
@@ -27,12 +27,14 @@ describe('with teams enabled', function () {
             ->expectsQuestion('What is your name?', 'John Doe')
             ->expectsQuestion('What is your email?', 'johndoe@example.com')
             ->expectsQuestion('What is your password?', 'password')
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
             ->expectsOutput('User created successfully.')
             ->assertExitCode(0);
 
         $this->assertDatabaseHas('users', [
             'name' => 'John Doe',
             'email' => 'johndoe@example.com',
+            'global_admin' => false,
         ]);
     });
 
@@ -41,6 +43,7 @@ describe('with teams enabled', function () {
             ->expectsQuestion('What is your name?', 'Jane Smith')
             ->expectsQuestion('What is your email?', 'jane@example.com')
             ->expectsQuestion('What is your password?', 'password')
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
             ->assertExitCode(0);
 
         $this->assertDatabaseHas('teams', [
@@ -58,6 +61,7 @@ describe('with teams enabled', function () {
             ->expectsQuestion('What is your name?', 'Admin User')
             ->expectsQuestion('What is your email?', 'admin@example.com')
             ->expectsQuestion('What is your password?', 'password')
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
             ->assertExitCode(0);
 
         $user = User::where('email', 'admin@example.com')->first();
@@ -80,6 +84,7 @@ describe('with teams enabled', function () {
         $this->assertDatabaseHas('users', [
             'name' => 'CLI User',
             'email' => 'cli@example.com',
+            'global_admin' => false,
         ]);
     });
 
@@ -88,11 +93,50 @@ describe('with teams enabled', function () {
             ->expectsQuestion('What is your name?', 'Secure User')
             ->expectsQuestion('What is your email?', 'secure@example.com')
             ->expectsQuestion('What is your password?', 'mysecretpassword')
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
             ->assertExitCode(0);
 
         $user = User::where('email', 'secure@example.com')->first();
 
         expect(Hash::check('mysecretpassword', $user->password))->toBeTrue();
+    });
+
+    it('creates a Global Admin via the --global-admin option', function () {
+        $this->artisan('aura:user', [
+            '--name' => 'Ops Operator',
+            '--email' => 'ops@example.com',
+            '--password' => 'opspassword',
+            '--global-admin' => true,
+        ])->assertExitCode(0);
+
+        $user = User::where('email', 'ops@example.com')->first();
+
+        expect($user->global_admin)->toBeTrue();
+    });
+
+    it('creates a Global Admin via the interactive confirmation', function () {
+        $this->artisan('aura:user')
+            ->expectsQuestion('What is your name?', 'Interactive GA')
+            ->expectsQuestion('What is your email?', 'interactive-ga@example.com')
+            ->expectsQuestion('What is your password?', 'password')
+            ->expectsConfirmation('Should this user be a Global Admin?', 'yes')
+            ->assertExitCode(0);
+
+        $user = User::where('email', 'interactive-ga@example.com')->first();
+
+        expect($user->global_admin)->toBeTrue();
+    });
+
+    it('does not grant Global Admin without the option', function () {
+        $this->artisan('aura:user', [
+            '--name' => 'Plain User',
+            '--email' => 'plain@example.com',
+            '--password' => 'plainpassword',
+        ])->assertExitCode(0);
+
+        $user = User::where('email', 'plain@example.com')->first();
+
+        expect($user->global_admin)->toBeFalse();
     });
 });
 

--- a/tests/Feature/GlobalAdmin/GlobalAdminGateTest.php
+++ b/tests/Feature/GlobalAdmin/GlobalAdminGateTest.php
@@ -9,22 +9,11 @@ use Aura\Base\Resources\TeamInvitation;
 use Aura\Base\Resources\User;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\URL;
+use Lab404\Impersonate\Services\ImpersonateManager;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 use function Pest\Laravel\post;
 use function Pest\Livewire\livewire;
-
-/**
- * Promote a freshly minted user to Global Admin the trusted way (direct,
- * pipeline-bypassing write), the same posture the CLI bootstrap uses. Kept in
- * the test so the flag is never granted through a user-facing write path.
- */
-function makeGlobalAdmin(array $attributes = []): User
-{
-    $user = User::factory()->create($attributes);
-    $user->forceFill(['global_admin' => true])->saveQuietly();
-
-    return $user->refresh();
-}
 
 /**
  * A user who is a member of the given team (Membership pivot + current team), so
@@ -55,7 +44,7 @@ describe('the global_admin field on the user form', function () {
 
 describe('the package AuraGlobalAdmin gate', function () {
     it('allows a user whose global_admin flag is true', function () {
-        $ga = makeGlobalAdmin();
+        $ga = createGlobalAdmin();
 
         expect(Gate::forUser($ga)->allows('AuraGlobalAdmin'))->toBeTrue();
     });
@@ -67,7 +56,7 @@ describe('the package AuraGlobalAdmin gate', function () {
     });
 
     it('reflects the flag through the acting-user entry point', function () {
-        $ga = makeGlobalAdmin();
+        $ga = createGlobalAdmin();
         $plain = User::factory()->create();
 
         $this->actingAs($ga);
@@ -86,7 +75,7 @@ describe('the package AuraGlobalAdmin gate', function () {
 
 describe('host override of the gate', function () {
     it('lets a host redefinition win over the package default (deny a flagged user)', function () {
-        $ga = makeGlobalAdmin();
+        $ga = createGlobalAdmin();
 
         // The package default would allow this flagged user; a later host
         // Gate::define replaces it (app providers boot after package providers).
@@ -119,7 +108,7 @@ describe('TeamPolicy bypasses become live for Global Admins', function () {
     });
 
     it('allows a Global Admin across the key team behaviors', function () {
-        $ga = makeGlobalAdmin();
+        $ga = createGlobalAdmin();
         $this->actingAs($ga);
 
         expect($this->policy->viewAny($ga, $this->team))->toBeTrue();
@@ -143,25 +132,47 @@ describe('TeamPolicy bypasses become live for Global Admins', function () {
 });
 
 describe('impersonation authorization keys off the flag', function () {
-    it('lets a Global Admin impersonate', function () {
-        $ga = makeGlobalAdmin();
-        $this->actingAs($ga);
-
-        expect($ga->canImpersonate())->toBeTrue();
-    });
-
-    it('does not let a non-Global-Admin impersonate', function () {
+    it('evaluates canImpersonate/canBeImpersonated on the right user, not the actor', function () {
+        $ga = createGlobalAdmin();
         $plain = User::factory()->create();
-        $this->actingAs($plain);
 
-        expect($plain->canImpersonate())->toBeFalse();
+        // No actingAs() here on purpose: the checks are instance-correct, so the
+        // authenticated user must not leak into the answer (the auth-coupling bug).
+        expect($ga->canImpersonate())->toBeTrue()
+            ->and($plain->canImpersonate())->toBeFalse()
+            ->and($ga->canBeImpersonated())->toBeFalse()
+            ->and($plain->canBeImpersonated())->toBeTrue();
     });
 
-    it('protects a Global Admin from being impersonated', function () {
-        $ga = makeGlobalAdmin();
+    it('lets a Global Admin impersonate a plain member end-to-end through the row action', function () {
+        $ga = createGlobalAdmin();
+        $member = User::factory()->create();
         $this->actingAs($ga);
 
-        expect($ga->canBeImpersonated())->toBeFalse();
+        // The row action is dispatched on the target user; the acting GA becomes
+        // the impersonator.
+        $member->impersonateAction();
+
+        expect(app(ImpersonateManager::class)->isImpersonating())->toBeTrue()
+            ->and(auth()->id())->toBe($member->id);
+    });
+
+    it('refuses a non-Global-Admin actor', function () {
+        $actor = User::factory()->create(); // flag off
+        $target = User::factory()->create();
+        $this->actingAs($actor);
+
+        expect(fn () => $target->impersonateAction())->toThrow(HttpException::class);
+        expect(app(ImpersonateManager::class)->isImpersonating())->toBeFalse();
+    });
+
+    it('protects a Global Admin from being impersonated, even by another Global Admin', function () {
+        $ga = createGlobalAdmin();
+        $otherGa = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        expect(fn () => $otherGa->impersonateAction())->toThrow(HttpException::class);
+        expect(app(ImpersonateManager::class)->isImpersonating())->toBeFalse();
     });
 });
 
@@ -272,6 +283,39 @@ describe('the flag cannot be self-granted (escalation guards)', function () {
 
         expect($user)->not->toBeNull()
             ->and($user->global_admin)->toBeFalse();
+    })->skip(fn () => ! config('aura.teams'), 'Invitations are teams-on only.');
+
+    it('never grants Global Admin when an existing user accepts an invitation with the flag injected', function () {
+        config(['aura.auth.user_invitations' => true]);
+
+        $team = Team::first() ?? Team::factory()->create();
+        $role = globalAdminRole();
+
+        // An existing account whose email matches the invitation.
+        $existing = User::factory()->create(['email' => 'existing@example.com']);
+
+        $invitation = TeamInvitation::create([
+            'team_id' => $team->id,
+            'email' => 'existing@example.com',
+            'role' => $role->id,
+        ]);
+
+        // Sign the accept URL WITH the injected flag so the signature stays valid
+        // and the tampered value actually reaches the controller.
+        $url = URL::signedRoute('aura.team-invitations.accept', [
+            'invitation' => $invitation->id,
+            'global_admin' => 1,
+        ]);
+
+        $this->actingAs($existing)
+            ->get($url)
+            ->assertRedirect(route('aura.dashboard'));
+
+        $existing->refresh();
+
+        // The accept path ran (membership attached) but the flag was ignored.
+        expect($existing->teams()->whereKey($team->id)->exists())->toBeTrue()
+            ->and($existing->global_admin)->toBeFalse();
     })->skip(fn () => ! config('aura.teams'), 'Invitations are teams-on only.');
 });
 

--- a/tests/Feature/GlobalAdmin/GlobalAdminGateTest.php
+++ b/tests/Feature/GlobalAdmin/GlobalAdminGateTest.php
@@ -1,0 +1,302 @@
+<?php
+
+use Aura\Base\Fields\GlobalAdmin;
+use Aura\Base\Livewire\Resource\Edit;
+use Aura\Base\Policies\TeamPolicy;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\TeamInvitation;
+use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\URL;
+
+use function Pest\Laravel\post;
+use function Pest\Livewire\livewire;
+
+/**
+ * Promote a freshly minted user to Global Admin the trusted way (direct,
+ * pipeline-bypassing write), the same posture the CLI bootstrap uses. Kept in
+ * the test so the flag is never granted through a user-facing write path.
+ */
+function makeGlobalAdmin(array $attributes = []): User
+{
+    $user = User::factory()->create($attributes);
+    $user->forceFill(['global_admin' => true])->saveQuietly();
+
+    return $user->refresh();
+}
+
+/**
+ * A user who is a member of the given team (Membership pivot + current team), so
+ * the team-scoped user form can find and edit them.
+ */
+function teamMember(Team $team): User
+{
+    $role = Role::where('team_id', $team->id)->first()
+        ?? Role::factory()->create(['team_id' => $team->id]);
+
+    $target = User::factory()->create();
+    $target->roles()->attach($role->id, ['team_id' => $team->id]);
+    $target->update(['current_team_id' => $team->id]);
+
+    return $target->refresh();
+}
+
+describe('the global_admin field on the user form', function () {
+    it('exposes the GlobalAdmin field type, on forms and out of the index', function () {
+        $field = collect((new User)->getFields())->firstWhere('slug', 'global_admin');
+
+        expect($field)->not->toBeNull()
+            ->and($field['type'])->toBe(GlobalAdmin::class)
+            ->and($field['on_forms'])->toBeTrue()
+            ->and($field['on_index'])->toBeFalse();
+    });
+});
+
+describe('the package AuraGlobalAdmin gate', function () {
+    it('allows a user whose global_admin flag is true', function () {
+        $ga = makeGlobalAdmin();
+
+        expect(Gate::forUser($ga)->allows('AuraGlobalAdmin'))->toBeTrue();
+    });
+
+    it('denies a user whose global_admin flag is false', function () {
+        $plain = User::factory()->create();
+
+        expect(Gate::forUser($plain)->allows('AuraGlobalAdmin'))->toBeFalse();
+    });
+
+    it('reflects the flag through the acting-user entry point', function () {
+        $ga = makeGlobalAdmin();
+        $plain = User::factory()->create();
+
+        $this->actingAs($ga);
+        expect($ga->isAuraGlobalAdmin())->toBeTrue();
+
+        $this->actingAs($plain);
+        expect($plain->isAuraGlobalAdmin())->toBeFalse();
+    });
+
+    it('denies a guest', function () {
+        auth()->logout();
+
+        expect(Gate::allows('AuraGlobalAdmin'))->toBeFalse();
+    });
+});
+
+describe('host override of the gate', function () {
+    it('lets a host redefinition win over the package default (deny a flagged user)', function () {
+        $ga = makeGlobalAdmin();
+
+        // The package default would allow this flagged user; a later host
+        // Gate::define replaces it (app providers boot after package providers).
+        Gate::define('AuraGlobalAdmin', fn ($user) => false);
+
+        expect(Gate::forUser($ga)->allows('AuraGlobalAdmin'))->toBeFalse();
+    });
+
+    it('lets a host redefinition win over the package default (allow an unflagged user)', function () {
+        $plain = User::factory()->create();
+
+        Gate::define('AuraGlobalAdmin', fn ($user) => true);
+
+        expect(Gate::forUser($plain)->allows('AuraGlobalAdmin'))->toBeTrue();
+    });
+});
+
+describe('TeamPolicy bypasses become live for Global Admins', function () {
+    beforeEach(function () {
+        if (! config('aura.teams')) {
+            $this->markTestSkipped('TeamPolicy exists only with teams enabled.');
+        }
+
+        $this->policy = new TeamPolicy;
+        // A team owned by a distinct user, so the acting users neither own nor
+        // belong to it — any allow comes purely from the Global Admin bypass.
+        $this->team = Team::factory()->createQuietly([
+            'user_id' => User::factory()->create()->id,
+        ]);
+    });
+
+    it('allows a Global Admin across the key team behaviors', function () {
+        $ga = makeGlobalAdmin();
+        $this->actingAs($ga);
+
+        expect($this->policy->viewAny($ga, $this->team))->toBeTrue();
+        expect($this->policy->create($ga, $this->team))->toBeTrue();
+        expect($this->policy->update($ga, $this->team))->toBeTrue();
+        expect($this->policy->delete($ga, $this->team))->toBeTrue();
+        expect($this->policy->inviteUsers($ga, $this->team))->toBeTrue();
+        expect($this->policy->addTeamMember($ga, $this->team))->toBeTrue();
+    });
+
+    it('refuses a non-member non-super-admin with the flag off', function () {
+        $plain = User::factory()->create();
+        $this->actingAs($plain);
+
+        expect($this->policy->viewAny($plain, $this->team))->toBeFalse();
+        expect($this->policy->create($plain, $this->team))->toBeFalse();
+        expect($this->policy->update($plain, $this->team))->toBeFalse();
+        expect($this->policy->delete($plain, $this->team))->toBeFalse();
+        expect($this->policy->inviteUsers($plain, $this->team))->toBeFalse();
+    });
+});
+
+describe('impersonation authorization keys off the flag', function () {
+    it('lets a Global Admin impersonate', function () {
+        $ga = makeGlobalAdmin();
+        $this->actingAs($ga);
+
+        expect($ga->canImpersonate())->toBeTrue();
+    });
+
+    it('does not let a non-Global-Admin impersonate', function () {
+        $plain = User::factory()->create();
+        $this->actingAs($plain);
+
+        expect($plain->canImpersonate())->toBeFalse();
+    });
+
+    it('protects a Global Admin from being impersonated', function () {
+        $ga = makeGlobalAdmin();
+        $this->actingAs($ga);
+
+        expect($ga->canBeImpersonated())->toBeFalse();
+    });
+});
+
+describe('the flag cannot be self-granted (escalation guards)', function () {
+    it('ignores global_admin passed to mass assignment', function () {
+        $this->actingAs(createSuperAdmin()); // a Super Admin, but NOT a Global Admin
+
+        $user = User::create([
+            'name' => 'Escalation Attempt',
+            'email' => 'escalation@example.com',
+            'global_admin' => 1,
+            'fields' => [
+                'password' => 'Password123!XX',
+            ],
+        ]);
+
+        expect($user->fresh()->global_admin)->toBeFalse();
+    });
+
+    it('ignores global_admin injected through the fields payload', function () {
+        $this->actingAs(createSuperAdmin());
+
+        $user = User::create([
+            'name' => 'Fields Escalation',
+            'email' => 'fields-escalation@example.com',
+            'fields' => [
+                'password' => 'Password123!XX',
+                'global_admin' => 1,
+            ],
+        ]);
+
+        expect($user->fresh()->global_admin)->toBeFalse();
+    });
+
+    it('ignores a guest attempting mass assignment', function () {
+        auth()->logout();
+
+        $user = User::create([
+            'name' => 'Guest Escalation',
+            'email' => 'guest-escalation@example.com',
+            'global_admin' => 1,
+            'fields' => [
+                'password' => 'Password123!XX',
+            ],
+        ]);
+
+        expect($user->fresh()->global_admin)->toBeFalse();
+    });
+
+    it('refuses a non-Global-Admin toggling the flag through the user form', function () {
+        $actor = createSuperAdmin(); // Super Admin of the team, not a Global Admin
+        $this->actingAs($actor);
+
+        $target = teamMember($actor->currentTeam);
+
+        livewire(Edit::class, ['slug' => 'user', 'id' => $target->id])
+            ->set('form.fields.global_admin', true)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        expect($target->fresh()->global_admin)->toBeFalse();
+    })->skip(fn () => ! config('aura.teams'), 'Uses the team-scoped user form.');
+
+    it('never produces a Global Admin through registration, even with an injected payload', function () {
+        config(['aura.auth.registration' => true]);
+        config(['aura.auth.redirect' => '/admin']);
+        auth()->logout();
+
+        post(route('aura.register.post'), [
+            'name' => 'Registrant',
+            'team' => 'Registrant Team',
+            'email' => 'registrant@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+            'global_admin' => 1,
+        ])->assertRedirect('/admin');
+
+        $user = User::where('email', 'registrant@example.com')->first();
+
+        expect($user)->not->toBeNull()
+            ->and($user->global_admin)->toBeFalse();
+    })->skip(fn () => ! config('aura.teams'), 'Team registration flow requires teams enabled.');
+
+    it('never produces a Global Admin through invitation registration', function () {
+        config(['aura.auth.user_invitations' => true]);
+        config(['aura.auth.redirect' => '/admin']);
+
+        $team = Team::first() ?? Team::factory()->create();
+        $role = globalAdminRole();
+
+        $invitation = TeamInvitation::create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'role' => $role->id,
+        ]);
+
+        $url = URL::signedRoute('aura.invitation.register', [$team, $invitation]);
+        auth()->logout();
+
+        $this->post($url, [
+            'name' => 'Invited User',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+            'global_admin' => 1,
+        ])->assertRedirect(config('aura.auth.redirect'));
+
+        $user = User::where('email', 'invited@example.com')->first();
+
+        expect($user)->not->toBeNull()
+            ->and($user->global_admin)->toBeFalse();
+    })->skip(fn () => ! config('aura.teams'), 'Invitations are teams-on only.');
+});
+
+describe('a Global Admin can grant and revoke the flag', function () {
+    it('lets a Global Admin toggle another user\'s flag through the form', function () {
+        $ga = createSuperAdmin();
+        $ga->forceFill(['global_admin' => true])->saveQuietly();
+        $this->actingAs($ga->refresh());
+
+        $target = teamMember($ga->currentTeam);
+
+        // Grant.
+        livewire(Edit::class, ['slug' => 'user', 'id' => $target->id])
+            ->set('form.fields.global_admin', true)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        expect($target->fresh()->global_admin)->toBeTrue();
+
+        // Revoke.
+        livewire(Edit::class, ['slug' => 'user', 'id' => $target->id])
+            ->set('form.fields.global_admin', false)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        expect($target->fresh()->global_admin)->toBeFalse();
+    })->skip(fn () => ! config('aura.teams'), 'Uses the team-scoped user form.');
+});

--- a/tests/Feature/GlobalAdmin/GlobalAdminVisibilityTest.php
+++ b/tests/Feature/GlobalAdmin/GlobalAdminVisibilityTest.php
@@ -1,0 +1,186 @@
+<?php
+
+use Aura\Base\Livewire\Table\Table;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\Cache;
+
+use function Pest\Livewire\livewire;
+
+/**
+ * Promote a fresh user to Global Admin the trusted way (direct, pipeline-bypassing
+ * write) — the flag is never granted through a user-facing write path.
+ */
+function gaUser(array $attributes = []): User
+{
+    $user = User::factory()->create($attributes);
+    $user->forceFill(['global_admin' => true])->saveQuietly();
+
+    return $user->refresh();
+}
+
+/**
+ * A user whose only Membership is in the given team.
+ */
+function soleMemberOf(Team $team): User
+{
+    $role = Role::where('team_id', $team->id)->first()
+        ?? Role::factory()->create(['team_id' => $team->id]);
+
+    $member = User::factory()->create();
+    $member->roles()->attach($role->id, ['team_id' => $team->id]);
+    $member->forceFill(['current_team_id' => $team->id])->save();
+
+    return $member->refresh();
+}
+
+/**
+ * Point the acting user's current team at $team without granting a Membership,
+ * and make TeamScope observe it (its team id is cached).
+ */
+function actAsWithCurrentTeam(User $user, Team $team): void
+{
+    $user->forceFill(['current_team_id' => $team->id])->save();
+    $user->refresh();
+    test()->actingAs($user);
+    Cache::forget("user_{$user->id}_current_team_id");
+}
+
+describe('Global Admin Users index sees every team', function () {
+    beforeEach(function () {
+        if (! config('aura.teams')) {
+            $this->markTestSkipped('Cross-team visibility is a teams-on concern.');
+        }
+
+        // A member whose only Membership lives in a separate team.
+        auth()->logout();
+        $this->otherTeam = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $this->otherUser = soleMemberOf($this->otherTeam);
+
+        // The current team the acting user is pointed at (a different tenant).
+        $this->currentTeam = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+    });
+
+    it('lists a user from another team for a Global Admin (indexQuery seam)', function () {
+        $ga = gaUser();
+        actAsWithCurrentTeam($ga, $this->currentTeam);
+
+        $ids = (new User)->indexQuery(User::query())->pluck('id');
+
+        expect($ids)->toContain($this->otherUser->id);
+    });
+
+    it('lists a user from another team for a Global Admin (table component)', function () {
+        $ga = gaUser();
+        actAsWithCurrentTeam($ga, $this->currentTeam);
+
+        // The unpaginated query the table runs — robust to page size/ordering.
+        $ids = livewire(Table::class, ['query' => null, 'model' => new User])
+            ->instance()->rowsQuery()->pluck('id');
+
+        expect($ids)->toContain($this->otherUser->id);
+    });
+
+    it('serves the Users index to a Global Admin over HTTP', function () {
+        $ga = gaUser();
+        actAsWithCurrentTeam($ga, $this->currentTeam);
+
+        $this->get(route('aura.user.index'))
+            ->assertOk()
+            ->assertSeeLivewire(Table::class);
+    });
+
+    it('hides other teams\' users from a non-Global-Admin (indexQuery seam)', function () {
+        $admin = createSuperAdmin(); // super admin scoped to their own team
+
+        $ids = (new User)->indexQuery(User::query())->pluck('id');
+
+        expect($ids)->not->toContain($this->otherUser->id)
+            ->and($ids)->toContain($admin->id);
+    });
+
+    it('hides other teams\' users from a non-Global-Admin (table component)', function () {
+        createSuperAdmin();
+
+        $ids = livewire(Table::class, ['query' => null, 'model' => new User])
+            ->instance()->rowsQuery()->pluck('id');
+
+        expect($ids)->not->toContain($this->otherUser->id);
+    });
+});
+
+describe('Global Admin sees and can manage all teams', function () {
+    beforeEach(function () {
+        if (! config('aura.teams')) {
+            $this->markTestSkipped('Team listing is a teams-on concern.');
+        }
+
+        auth()->logout();
+        $this->teamB = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $this->teamC = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+    });
+
+    it('offers every team to a Global Admin through getTeams (switcher source)', function () {
+        $ga = gaUser();
+        $this->actingAs($ga);
+        Cache::forget('aura.global_admin.teams');
+
+        $ids = $ga->getTeams()->pluck('id');
+
+        expect($ids)->toContain($this->teamB->id)->toContain($this->teamC->id);
+    });
+
+    it('offers a non-Global-Admin only their own teams through getTeams', function () {
+        $admin = createSuperAdmin();
+        $this->actingAs($admin);
+
+        $ids = $admin->getTeams()->pluck('id');
+
+        expect($ids)->toContain($admin->current_team_id)
+            ->and($ids)->not->toContain($this->teamB->id)
+            ->and($ids)->not->toContain($this->teamC->id);
+    });
+
+    it('lists every team for a Global Admin in the Team index table', function () {
+        $ga = gaUser();
+        $this->actingAs($ga);
+
+        $ids = livewire(Table::class, ['query' => null, 'model' => new Team])
+            ->instance()->rowsQuery()->pluck('id');
+
+        expect($ids)->toContain($this->teamB->id)->toContain($this->teamC->id);
+    });
+
+    it('reflects a newly created team in the Global Admin switcher cache immediately', function () {
+        $ga = gaUser();
+        $this->actingAs($ga);
+
+        // Prime the shared cache.
+        $ga->getTeams();
+        expect(Cache::has('aura.global_admin.teams'))->toBeTrue();
+
+        // A real create fires Team::created, which invalidates the shared cache.
+        $newTeam = Team::create(['name' => 'Fresh Tenant']);
+        expect(Cache::has('aura.global_admin.teams'))->toBeFalse();
+
+        expect($ga->getTeams()->pluck('id'))->toContain($newTeam->id);
+    });
+});
+
+describe('Teams-off mode', function () {
+    beforeEach(function () {
+        if (config('aura.teams')) {
+            $this->markTestSkipped('Teams-off no-op assertions only.');
+        }
+    });
+
+    it('keeps the flag readable while team surfaces no-op', function () {
+        $ga = gaUser();
+        $this->actingAs($ga);
+
+        expect($ga->isAuraGlobalAdmin())->toBeTrue()
+            ->and($ga->getTeams())->toBeNull()
+            ->and($ga->currentTeam())->toBeNull();
+    });
+});

--- a/tests/Feature/GlobalAdmin/GlobalAdminVisibilityTest.php
+++ b/tests/Feature/GlobalAdmin/GlobalAdminVisibilityTest.php
@@ -1,39 +1,11 @@
 <?php
 
 use Aura\Base\Livewire\Table\Table;
-use Aura\Base\Resources\Role;
 use Aura\Base\Resources\Team;
 use Aura\Base\Resources\User;
 use Illuminate\Support\Facades\Cache;
 
 use function Pest\Livewire\livewire;
-
-/**
- * Promote a fresh user to Global Admin the trusted way (direct, pipeline-bypassing
- * write) — the flag is never granted through a user-facing write path.
- */
-function gaUser(array $attributes = []): User
-{
-    $user = User::factory()->create($attributes);
-    $user->forceFill(['global_admin' => true])->saveQuietly();
-
-    return $user->refresh();
-}
-
-/**
- * A user whose only Membership is in the given team.
- */
-function soleMemberOf(Team $team): User
-{
-    $role = Role::where('team_id', $team->id)->first()
-        ?? Role::factory()->create(['team_id' => $team->id]);
-
-    $member = User::factory()->create();
-    $member->roles()->attach($role->id, ['team_id' => $team->id]);
-    $member->forceFill(['current_team_id' => $team->id])->save();
-
-    return $member->refresh();
-}
 
 /**
  * Point the acting user's current team at $team without granting a Membership,
@@ -63,7 +35,7 @@ describe('Global Admin Users index sees every team', function () {
     });
 
     it('lists a user from another team for a Global Admin (indexQuery seam)', function () {
-        $ga = gaUser();
+        $ga = createGlobalAdmin();
         actAsWithCurrentTeam($ga, $this->currentTeam);
 
         $ids = (new User)->indexQuery(User::query())->pluck('id');
@@ -72,7 +44,7 @@ describe('Global Admin Users index sees every team', function () {
     });
 
     it('lists a user from another team for a Global Admin (table component)', function () {
-        $ga = gaUser();
+        $ga = createGlobalAdmin();
         actAsWithCurrentTeam($ga, $this->currentTeam);
 
         // The unpaginated query the table runs — robust to page size/ordering.
@@ -83,7 +55,7 @@ describe('Global Admin Users index sees every team', function () {
     });
 
     it('serves the Users index to a Global Admin over HTTP', function () {
-        $ga = gaUser();
+        $ga = createGlobalAdmin();
         actAsWithCurrentTeam($ga, $this->currentTeam);
 
         $this->get(route('aura.user.index'))
@@ -122,9 +94,9 @@ describe('Global Admin sees and can manage all teams', function () {
     });
 
     it('offers every team to a Global Admin through getTeams (switcher source)', function () {
-        $ga = gaUser();
+        $ga = createGlobalAdmin();
         $this->actingAs($ga);
-        Cache::forget('aura.global_admin.teams');
+        Cache::forget(User::GLOBAL_ADMIN_TEAMS_CACHE_KEY);
 
         $ids = $ga->getTeams()->pluck('id');
 
@@ -143,7 +115,7 @@ describe('Global Admin sees and can manage all teams', function () {
     });
 
     it('lists every team for a Global Admin in the Team index table', function () {
-        $ga = gaUser();
+        $ga = createGlobalAdmin();
         $this->actingAs($ga);
 
         $ids = livewire(Table::class, ['query' => null, 'model' => new Team])
@@ -153,16 +125,16 @@ describe('Global Admin sees and can manage all teams', function () {
     });
 
     it('reflects a newly created team in the Global Admin switcher cache immediately', function () {
-        $ga = gaUser();
+        $ga = createGlobalAdmin();
         $this->actingAs($ga);
 
         // Prime the shared cache.
         $ga->getTeams();
-        expect(Cache::has('aura.global_admin.teams'))->toBeTrue();
+        expect(Cache::has(User::GLOBAL_ADMIN_TEAMS_CACHE_KEY))->toBeTrue();
 
         // A real create fires Team::created, which invalidates the shared cache.
         $newTeam = Team::create(['name' => 'Fresh Tenant']);
-        expect(Cache::has('aura.global_admin.teams'))->toBeFalse();
+        expect(Cache::has(User::GLOBAL_ADMIN_TEAMS_CACHE_KEY))->toBeFalse();
 
         expect($ga->getTeams()->pluck('id'))->toContain($newTeam->id);
     });
@@ -176,7 +148,7 @@ describe('Teams-off mode', function () {
     });
 
     it('keeps the flag readable while team surfaces no-op', function () {
-        $ga = gaUser();
+        $ga = createGlobalAdmin();
         $this->actingAs($ga);
 
         expect($ga->isAuraGlobalAdmin())->toBeTrue()

--- a/tests/Feature/GlobalAdmin/GlobalAdminVisitationTest.php
+++ b/tests/Feature/GlobalAdmin/GlobalAdminVisitationTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use Aura\Base\Policies\ResourcePolicy;
+use Aura\Base\Policies\TeamPolicy;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Aura\Base\Tests\Resources\Post;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Promote a fresh user to Global Admin the trusted way (direct, pipeline-bypassing
+ * write). Mirrors the CLI bootstrap posture.
+ */
+function visitingGa(array $attributes = []): User
+{
+    $user = User::factory()->create($attributes);
+    $user->forceFill(['global_admin' => true])->saveQuietly();
+
+    return $user->refresh();
+}
+
+/**
+ * A team the acting user neither owns nor belongs to.
+ */
+function foreignTeam(): Team
+{
+    return Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+}
+
+describe('Global Admin visitation via switchTeam', function () {
+    beforeEach(function () {
+        if (! config('aura.teams')) {
+            $this->markTestSkipped('Visitation is a teams-on power.');
+        }
+    });
+
+    it('lets a Global Admin enter a team they do not belong to, creating no Membership', function () {
+        $ga = visitingGa();
+        $this->actingAs($ga);
+        $team = foreignTeam();
+
+        expect($ga->switchTeam($team))->toBeTrue()
+            ->and($ga->fresh()->current_team_id)->toBe($team->id);
+
+        // Visitation must never mint a user_role row.
+        expect(
+            DB::table('user_role')->where('user_id', $ga->id)->where('team_id', $team->id)->exists()
+        )->toBeFalse();
+    });
+
+    it('refuses a regular user switching into a non-member team (unit)', function () {
+        $user = createSuperAdmin(); // super admin of their own team, not a Global Admin
+        $team = foreignTeam();
+
+        expect($user->switchTeam($team))->toBeFalse();
+    });
+
+    it('lets a Global Admin visit any team over HTTP', function () {
+        $ga = visitingGa();
+        $team = foreignTeam();
+
+        $this->actingAs($ga)
+            ->put(route('aura.current-team.update', ['team_id' => $team->id]))
+            ->assertRedirect(route('aura.dashboard'));
+
+        expect($ga->fresh()->current_team_id)->toBe($team->id);
+    });
+
+    it('refuses a regular user visiting a non-member team over HTTP (403)', function () {
+        $user = createSuperAdmin();
+        $team = foreignTeam();
+
+        $this->actingAs($user)
+            ->put(route('aura.current-team.update', ['team_id' => $team->id]))
+            ->assertForbidden();
+
+        expect($user->fresh()->current_team_id)->not->toBe($team->id);
+    });
+});
+
+describe('a visiting Global Admin acts with Super Admin power', function () {
+    beforeEach(function () {
+        if (! config('aura.teams')) {
+            $this->markTestSkipped('Visitation is a teams-on power.');
+        }
+
+        $this->ga = visitingGa();
+        $this->team = foreignTeam();
+        $this->actingAs($this->ga);
+        $this->ga->switchTeam($this->team);
+        $this->actingAs($this->ga->refresh());
+    });
+
+    it('holds no resolved roles inside the visited team (power is not role-derived)', function () {
+        // The resolution seam is untouched: a visitor has no Membership, so no
+        // roles resolve and isSuperAdmin() is false — the power comes purely from
+        // the gate bypasses.
+        expect($this->ga->isSuperAdmin())->toBeFalse()
+            ->and($this->ga->isAuraGlobalAdmin())->toBeTrue()
+            ->and($this->ga->cachedRoles())->toBeEmpty();
+    });
+
+    it('passes ResourcePolicy checks inside the visited team', function () {
+        $policy = new ResourcePolicy;
+
+        expect($policy->viewAny($this->ga, new Post))->toBeTrue()
+            ->and($policy->create($this->ga, new Post))->toBeTrue()
+            ->and($policy->update($this->ga, new Post))->toBeTrue();
+    });
+
+    it('passes TeamPolicy::update on the visited team', function () {
+        expect((new TeamPolicy)->update($this->ga, $this->team))->toBeTrue();
+    });
+});
+
+describe('a Global Admin with zero Memberships', function () {
+    beforeEach(function () {
+        if (! config('aura.teams')) {
+            $this->markTestSkipped('Visitation is a teams-on power.');
+        }
+    });
+
+    it('is not a Super Admin, is a Global Admin, and can still visit and administer', function () {
+        $ga = visitingGa(['current_team_id' => null]); // no team, no current_team_id, no roles
+        $this->actingAs($ga);
+
+        expect($ga->isSuperAdmin())->toBeFalse()
+            ->and($ga->isAuraGlobalAdmin())->toBeTrue()
+            ->and($ga->current_team_id)->toBeNull();
+
+        $team = foreignTeam();
+
+        expect($ga->switchTeam($team))->toBeTrue()
+            ->and($ga->fresh()->current_team_id)->toBe($team->id);
+    });
+});
+
+describe('Teams-off mode', function () {
+    beforeEach(function () {
+        if (config('aura.teams')) {
+            $this->markTestSkipped('Teams-off no-op assertions only.');
+        }
+    });
+
+    it('grants no visitation through the flag', function () {
+        $ga = visitingGa();
+        $this->actingAs($ga);
+
+        // The flag is live, but visitation is gated on teams being enabled, so a
+        // stray team object never switches the pointer via the Global Admin path.
+        expect($ga->isAuraGlobalAdmin())->toBeTrue()
+            ->and($ga->switchTeam(new Team(['id' => 999])))->toBeFalse();
+    });
+});

--- a/tests/Feature/GlobalAdmin/GlobalAdminVisitationTest.php
+++ b/tests/Feature/GlobalAdmin/GlobalAdminVisitationTest.php
@@ -3,29 +3,8 @@
 use Aura\Base\Policies\ResourcePolicy;
 use Aura\Base\Policies\TeamPolicy;
 use Aura\Base\Resources\Team;
-use Aura\Base\Resources\User;
 use Aura\Base\Tests\Resources\Post;
 use Illuminate\Support\Facades\DB;
-
-/**
- * Promote a fresh user to Global Admin the trusted way (direct, pipeline-bypassing
- * write). Mirrors the CLI bootstrap posture.
- */
-function visitingGa(array $attributes = []): User
-{
-    $user = User::factory()->create($attributes);
-    $user->forceFill(['global_admin' => true])->saveQuietly();
-
-    return $user->refresh();
-}
-
-/**
- * A team the acting user neither owns nor belongs to.
- */
-function foreignTeam(): Team
-{
-    return Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
-}
 
 describe('Global Admin visitation via switchTeam', function () {
     beforeEach(function () {
@@ -35,7 +14,7 @@ describe('Global Admin visitation via switchTeam', function () {
     });
 
     it('lets a Global Admin enter a team they do not belong to, creating no Membership', function () {
-        $ga = visitingGa();
+        $ga = createGlobalAdmin();
         $this->actingAs($ga);
         $team = foreignTeam();
 
@@ -56,7 +35,7 @@ describe('Global Admin visitation via switchTeam', function () {
     });
 
     it('lets a Global Admin visit any team over HTTP', function () {
-        $ga = visitingGa();
+        $ga = createGlobalAdmin();
         $team = foreignTeam();
 
         $this->actingAs($ga)
@@ -84,7 +63,7 @@ describe('a visiting Global Admin acts with Super Admin power', function () {
             $this->markTestSkipped('Visitation is a teams-on power.');
         }
 
-        $this->ga = visitingGa();
+        $this->ga = createGlobalAdmin();
         $this->team = foreignTeam();
         $this->actingAs($this->ga);
         $this->ga->switchTeam($this->team);
@@ -121,7 +100,7 @@ describe('a Global Admin with zero Memberships', function () {
     });
 
     it('is not a Super Admin, is a Global Admin, and can still visit and administer', function () {
-        $ga = visitingGa(['current_team_id' => null]); // no team, no current_team_id, no roles
+        $ga = createGlobalAdmin(['current_team_id' => null]); // no team, no current_team_id, no roles
         $this->actingAs($ga);
 
         expect($ga->isSuperAdmin())->toBeFalse()
@@ -143,7 +122,7 @@ describe('Teams-off mode', function () {
     });
 
     it('grants no visitation through the flag', function () {
-        $ga = visitingGa();
+        $ga = createGlobalAdmin();
         $this->actingAs($ga);
 
         // The flag is live, but visitation is gated on teams being enabled, so a

--- a/tests/FeatureWithDatabaseMigrations/MakeUserWithoutTeamsCommandTest.php
+++ b/tests/FeatureWithDatabaseMigrations/MakeUserWithoutTeamsCommandTest.php
@@ -52,7 +52,9 @@ describe('aura:user command without teams', function () {
             '--name' => 'Jane Smith',
             '--email' => 'jane@example.com',
             '--password' => 'securepass',
-        ])->assertExitCode(0);
+        ])
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
+            ->assertExitCode(0);
 
         $this->assertDatabaseHas('users', [
             'name' => 'Jane Smith',
@@ -69,7 +71,9 @@ describe('aura:user command without teams', function () {
             '--name' => 'Admin',
             '--email' => 'admin@example.com',
             '--password' => 'password',
-        ])->assertExitCode(0);
+        ])
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
+            ->assertExitCode(0);
 
         $role = Role::where('slug', 'admin')->first();
 
@@ -94,7 +98,9 @@ describe('aura:user command without teams', function () {
             '--name' => 'Test User',
             '--email' => 'test@example.com',
             '--password' => 'password',
-        ])->assertExitCode(0);
+        ])
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
+            ->assertExitCode(0);
 
         expect(auth()->check())->toBeTrue()
             ->and(auth()->user()->email)->toBe('test@example.com');
@@ -106,6 +112,7 @@ describe('aura:user command without teams', function () {
             '--email' => 'success@example.com',
             '--password' => 'password',
         ])
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
             ->expectsOutput('User created successfully.')
             ->assertExitCode(0);
     });
@@ -135,7 +142,9 @@ describe('aura:user command without teams', function () {
             '--name' => 'Plain',
             '--email' => 'plain@example.com',
             '--password' => 'password',
-        ])->assertExitCode(0);
+        ])
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
+            ->assertExitCode(0);
 
         $user = User::where('email', 'plain@example.com')->first();
 
@@ -148,7 +157,9 @@ describe('aura:user command without teams', function () {
             '--name' => 'First User',
             '--email' => 'first@example.com',
             '--password' => 'password',
-        ])->assertExitCode(0);
+        ])
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
+            ->assertExitCode(0);
 
         expect(Role::where('slug', 'admin')->count())->toBe(1);
 

--- a/tests/FeatureWithDatabaseMigrations/MakeUserWithoutTeamsCommandTest.php
+++ b/tests/FeatureWithDatabaseMigrations/MakeUserWithoutTeamsCommandTest.php
@@ -2,6 +2,7 @@
 
 use Aura\Base\Resources\Role;
 use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Schema;
 
@@ -26,6 +27,7 @@ describe('aura:user command without teams', function () {
             ->expectsQuestion('What is your name?', 'John Doe')
             ->expectsQuestion('What is your email?', 'johndoe@example.com')
             ->expectsQuestion('What is your password?', 'password123')
+            ->expectsConfirmation('Should this user be a Global Admin?', 'no')
             ->assertExitCode(0);
 
         $this->assertDatabaseHas('users', [
@@ -106,6 +108,38 @@ describe('aura:user command without teams', function () {
         ])
             ->expectsOutput('User created successfully.')
             ->assertExitCode(0);
+    });
+
+    it('creates a Global Admin via the --global-admin option without teams', function () {
+        $this->artisan('aura:user', [
+            '--name' => 'Ops',
+            '--email' => 'ops@example.com',
+            '--password' => 'password',
+            '--global-admin' => true,
+        ])->assertExitCode(0);
+
+        $user = User::where('email', 'ops@example.com')->first();
+
+        expect($user)->not->toBeNull()
+            ->and($user->global_admin)->toBeTrue()
+            // The package gate resolves the flag even in Teams-off mode.
+            ->and(Gate::forUser($user)->allows('AuraGlobalAdmin'))->toBeTrue();
+
+        // And it holds through the acting-user entry point too.
+        $this->actingAs($user);
+        expect($user->isAuraGlobalAdmin())->toBeTrue();
+    });
+
+    it('does not grant Global Admin without the option (teams off)', function () {
+        $this->artisan('aura:user', [
+            '--name' => 'Plain',
+            '--email' => 'plain@example.com',
+            '--password' => 'password',
+        ])->assertExitCode(0);
+
+        $user = User::where('email', 'plain@example.com')->first();
+
+        expect($user->global_admin)->toBeFalse();
     });
 
     it('enforces unique role slug constraint without teams', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -78,6 +78,44 @@ function globalAdminRole(): ?Role
         ->first();
 }
 
+/**
+ * Promote a fresh user to Global Admin the trusted way: a direct,
+ * pipeline-bypassing write (`saveQuietly`), the same posture the CLI bootstrap
+ * uses. The flag is never granted through a user-facing write path in tests.
+ */
+function createGlobalAdmin(array $attributes = []): User
+{
+    $user = User::factory()->create($attributes);
+    $user->forceFill(['global_admin' => true])->saveQuietly();
+
+    return $user->refresh();
+}
+
+/**
+ * A team owned by someone else, with the current user holding no Membership —
+ * for asserting cross-team visibility and Global Admin visitation. Created
+ * quietly so the team-creation hook does not attach the acting user.
+ */
+function foreignTeam(): Team
+{
+    return Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+}
+
+/**
+ * A user whose only Membership is in the given team (pivot role + current team).
+ */
+function soleMemberOf(Team $team): User
+{
+    $role = Role::where('team_id', $team->id)->first()
+        ?? Role::factory()->create(['team_id' => $team->id]);
+
+    $member = User::factory()->create();
+    $member->roles()->attach($role->id, ['team_id' => $team->id]);
+    $member->forceFill(['current_team_id' => $team->id])->save();
+
+    return $member->refresh();
+}
+
 function createSuperAdmin()
 {
     if (! config('aura.teams')) {


### PR DESCRIPTION
## Summary

PR 2 of the access-control stack (parent spec #45), stacked on #57. Brings the **Global Admin** concept to life — the `AuraGlobalAdmin` gate existed only as an undefined hook until now.

- **Flag + gate** (#48): `users.global_admin` boolean (schema stub + reversible upgrade migration) backs a package-defined `AuraGlobalAdmin` gate; host apps override by redefining the gate (test-proven). `isAuraGlobalAdmin()` is instance-correct via `Gate::forUser($this)`.
- **Never self-grantable**: the flag reaches the column only through the guarded `GlobalAdmin` field hook (acting user must already be a GA). Escalation attempts via mass assignment, fields payload, guest create, Livewire form, registration inject, invitation-register inject, and existing-user invitation accept are all refused — each locked by a test.
- **Bootstrap**: `aura:user --global-admin` + interactive confirm on any interactive run.
- **Sees all + visitation** (#51): a GA's Users index lists every user (including Membership-less orphans); TeamScope's users branch grants the matching bypass, strictly gated per authenticated GA. The team switcher lists all teams (shared cache, invalidated on team create/rename/delete). `switchTeam()` lets a GA visit any team **without creating a Membership** — power inside comes from GA bypasses added beside every `isSuperAdmin()` short-circuit in `ResourcePolicy` (deliberate extension: a visiting GA resolves zero roles, keeping PR1's strict resolution seam intact).
- **Impersonation live + safe**: the action authorizes the actor/target pair (GA actor required, GA targets shielded) — previously dead code and, before review, silently broken by the gate's auth-coupling.

## Testing

- Teams-on: 1694 passed (5038 assertions) · Teams-off: 1418 passed · PHPStan: 0 errors · Pint clean
- New: GlobalAdminGateTest (gate contract, host override, escalation matrix, impersonation pairing), GlobalAdminVisibilityTest, GlobalAdminVisitationTest — the first tests exercising TeamPolicy/ResourcePolicy bypasses without defining the gate themselves
- Two-axis code review ran; all findings fixed in 6d4a7056 (headline: the gate's auth-coupling defect the original tests couldn't see)

Closes #48. Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)