### PR TITLE
Teams tab, merged catalog UI, Membership editor (#49, #52, #53)

### DIFF
--- a/resources/views/components/fields/role-name-index.blade.php
+++ b/resources/views/components/fields/role-name-index.blade.php
@@ -1,0 +1,11 @@
+<div class="flex items-center gap-x-2">
+    <span>{{ $value }}</span>
+
+    @if (config('aura.teams') && is_null($row->team_id))
+        <span
+            class="inline-flex items-center whitespace-nowrap rounded-full bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-700 ring-1 ring-inset ring-primary-600/20 dark:bg-primary-500/10 dark:text-primary-300 dark:ring-primary-400/30"
+            title="{{ __('Global Role — part of the shared catalog. Read-only in this team.') }}">
+            {{ __('Global') }}
+        </span>
+    @endif
+</div>

--- a/resources/views/components/fields/user-teams.blade.php
+++ b/resources/views/components/fields/user-teams.blade.php
@@ -1,0 +1,8 @@
+@checkCondition($this->model, $field, $this->form)
+    <div class="w-full px-2 {{ $field['style']['class'] ?? '' }}">
+        <livewire:aura::user-teams
+            :user-id="$this->model->id"
+            :wire:key="'user-teams-'.$this->model->id"
+            />
+    </div>
+@endcheckCondition

--- a/resources/views/livewire/user/user-teams.blade.php
+++ b/resources/views/livewire/user/user-teams.blade.php
@@ -1,0 +1,108 @@
+<div class="w-full" wire:key="user-teams-{{ $userId }}">
+    <div class="p-4 bg-white rounded-lg shadow dark:bg-gray-800">
+        <h3 class="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {{ __('Team Memberships') }}
+        </h3>
+
+        @if (count($this->memberships))
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm text-left" wire:key="memberships-table">
+                    <thead class="text-xs text-gray-500 uppercase border-b dark:text-gray-400">
+                        <tr>
+                            <th class="px-3 py-2">{{ __('Team') }}</th>
+                            <th class="px-3 py-2">{{ __('Role') }}</th>
+                            <th class="px-3 py-2 text-right">{{ __('Actions') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($this->memberships as $membership)
+                            <tr class="border-b dark:border-gray-700" wire:key="membership-{{ $membership['team_id'] }}">
+                                <td class="px-3 py-2 font-medium text-gray-900 dark:text-gray-100">
+                                    {{ $membership['team_name'] }}
+                                </td>
+                                <td class="px-3 py-2">
+                                    @if ($membership['can_manage'])
+                                        <select
+                                            wire:model="roleSelections.{{ $membership['team_id'] }}"
+                                            wire:change="changeRole({{ $membership['team_id'] }})"
+                                            dusk="role-select-{{ $membership['team_id'] }}"
+                                            class="text-sm border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600"
+                                        >
+                                            @foreach ($membership['role_options'] as $roleId => $roleName)
+                                                <option value="{{ $roleId }}">{{ $roleName }}</option>
+                                            @endforeach
+                                        </select>
+                                    @else
+                                        <span class="text-gray-700 dark:text-gray-300" dusk="role-readonly-{{ $membership['team_id'] }}">
+                                            {{ $membership['role_name'] ?? '–' }}
+                                        </span>
+                                    @endif
+                                </td>
+                                <td class="px-3 py-2 text-right">
+                                    @if ($membership['can_manage'])
+                                        <x-aura::button.transparent
+                                            wire:click="detach({{ $membership['team_id'] }})"
+                                            dusk="detach-{{ $membership['team_id'] }}"
+                                            class="text-red-500 hover:text-red-700"
+                                        >
+                                            {{ __('Detach') }}
+                                        </x-aura::button.transparent>
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @else
+            <p class="text-sm text-gray-500 dark:text-gray-400" dusk="no-memberships">
+                {{ __('This user is not a member of any team.') }}
+            </p>
+        @endif
+
+        @if (count($this->teamOptions))
+            <div class="pt-4 mt-6 border-t dark:border-gray-700" wire:key="attach-form">
+                <h4 class="mb-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+                    {{ __('Add to a team') }}
+                </h4>
+                <div class="flex flex-wrap items-start gap-2">
+                    <div>
+                        <select
+                            wire:model.live="attachTeamId"
+                            dusk="attach-team"
+                            class="text-sm border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600"
+                        >
+                            <option value="">{{ __('Select a team') }}</option>
+                            @foreach ($this->teamOptions as $teamId => $teamName)
+                                <option value="{{ $teamId }}">{{ $teamName }}</option>
+                            @endforeach
+                        </select>
+                        @error('attachTeamId')
+                            <p class="mt-1 text-xs text-red-500" dusk="attach-team-error">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <select
+                            wire:model="attachRoleId"
+                            dusk="attach-role"
+                            class="text-sm border-gray-300 rounded-md dark:bg-gray-700 dark:border-gray-600"
+                        >
+                            <option value="">{{ __('Select a role') }}</option>
+                            @foreach ($this->attachRoleOptions as $roleId => $roleName)
+                                <option value="{{ $roleId }}">{{ $roleName }}</option>
+                            @endforeach
+                        </select>
+                        @error('attachRoleId')
+                            <p class="mt-1 text-xs text-red-500" dusk="attach-role-error">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <x-aura::button.primary wire:click="attach" dusk="attach-submit">
+                        {{ __('Add') }}
+                    </x-aura::button.primary>
+                </div>
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/user/user-teams.blade.php
+++ b/resources/views/livewire/user/user-teams.blade.php
@@ -45,7 +45,7 @@
                                             dusk="detach-{{ $membership['team_id'] }}"
                                             class="text-red-500 hover:text-red-700"
                                         >
-                                            {{ __('Detach') }}
+                                            {{ __('Remove') }}
                                         </x-aura::button.transparent>
                                     @endif
                                 </td>

--- a/src/AuraServiceProvider.php
+++ b/src/AuraServiceProvider.php
@@ -47,6 +47,7 @@ use Aura\Base\Livewire\ResourceEditor;
 use Aura\Base\Livewire\Styleguide;
 use Aura\Base\Livewire\Table\Table;
 use Aura\Base\Livewire\TwoFactorAuthenticationForm;
+use Aura\Base\Livewire\UserTeams;
 use Aura\Base\Navigation\Navigation as AuraNavigation;
 use Aura\Base\Policies\ResourcePolicy;
 use Aura\Base\Policies\TeamPolicy;
@@ -153,6 +154,7 @@ class AuraServiceProvider extends PackageServiceProvider
             'aura::create-resource' => CreateResource::class,
             'aura::resource-editor' => ResourceEditor::class,
             'aura::invite-user' => InviteUser::class,
+            'aura::user-teams' => UserTeams::class,
             'aura::modals' => Modals::class,
             'aura::plugins-page' => PluginsPage::class,
             'aura::styleguide' => Styleguide::class,
@@ -172,6 +174,7 @@ class AuraServiceProvider extends PackageServiceProvider
             'aura.base.livewire.create-resource' => CreateResource::class,
             'aura.base.livewire.resource-editor' => ResourceEditor::class,
             'aura.base.livewire.invite-user' => InviteUser::class,
+            'aura.base.livewire.user-teams' => UserTeams::class,
             'aura.base.livewire.modals' => Modals::class,
             'aura.base.livewire.plugins-page' => PluginsPage::class,
             'aura.base.livewire.styleguide' => Styleguide::class,

--- a/src/Fields/AdvancedSelect.php
+++ b/src/Fields/AdvancedSelect.php
@@ -25,7 +25,14 @@ class AdvancedSelect extends Field implements ProvidesTableEagerLoad
 
         $field = $request->fullField;
 
-        $values = $model->searchIn($searchableFields, $request->search, $model)
+        $query = $model->searchIn($searchableFields, $request->search, $model);
+
+        // Subclasses (e.g. the Roles field) may constrain the query in place
+        // before it is fetched and mapped, without re-implementing the shared
+        // search/map plumbing.
+        $this->constrainApiQuery($query, $request);
+
+        return $query
             ->take(5)
             ->get()
             ->map(function ($item) use ($field) {
@@ -37,8 +44,6 @@ class AdvancedSelect extends Field implements ProvidesTableEagerLoad
                 ];
             })
             ->toArray();
-
-        return $values;
     }
 
     public function filter()
@@ -394,5 +399,16 @@ class AdvancedSelect extends Field implements ProvidesTableEagerLoad
 
             ];
         })->toArray();
+    }
+
+    /**
+     * Hook for subclasses to constrain the api() search query in place before it
+     * is fetched. The base field applies no extra constraint; the Roles field
+     * overrides this to add the shadow-resolved catalog constraint, so the shared
+     * search/map plumbing lives in one place.
+     */
+    protected function constrainApiQuery($query, $request): void
+    {
+        // No-op by default.
     }
 }

--- a/src/Fields/BelongsToMany.php
+++ b/src/Fields/BelongsToMany.php
@@ -2,8 +2,7 @@
 
 namespace Aura\Base\Fields;
 
-use Aura\Base\Resources\Team;
-use Aura\Base\Resources\User;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
 
 class BelongsToMany extends Field
 {
@@ -17,19 +16,72 @@ class BelongsToMany extends Field
 
     // public $view = 'components.fields.hasmany';
 
+    /**
+     * Scope the embedded table (the target resource, e.g. Team) to exactly the
+     * records related to the PARENT record through the many-to-many pivot.
+     *
+     * The table renders with the target resource as its model and the record
+     * being viewed as $component->parent (e.g. a User's Teams tab: model = Team,
+     * parent = User). The relationship — and therefore the correct set of rows —
+     * is derived from the PARENT, not from the table model. The previous branches
+     * keyed off the table model ($component->model), which is why the Teams tab
+     * showed the full, unfiltered set instead of the user's Memberships.
+     *
+     * Resolution is generic: whichever many-to-many relation the parent exposes
+     * for this field (by declared relation name, else the field slug) is used as
+     * a pivot-resolved subquery, so search/sort/pagination applied by the Table
+     * afterwards compose cleanly. With no parent (a standalone index) the field
+     * lists the full target set, unchanged.
+     */
     public function queryFor($query, $component)
     {
         $field = $component->field;
-        $model = $component->model;
+        $parent = optional($component)->parent;
 
-        if ($model instanceof User) {
-            return $query->where('user_id', $model->id);
-        }
-
-        if ($model instanceof Team) {
+        // Standalone / parentless context (bare index): no parent record to
+        // scope by, so list the full target set unchanged.
+        if (! $parent) {
             return $query;
         }
 
-        return $query->where('user_id', $model->id);
+        $relation = $this->parentRelation($parent, $field);
+
+        // The parent exposes a genuine many-to-many relation to the target — the
+        // set of rows is the parent's related records, resolved through the pivot.
+        // A whereIn against a pivot-constrained subquery of the target key leaves
+        // the Table's later modifications (search, sort, pagination) intact.
+        if ($relation instanceof EloquentBelongsToMany) {
+            $relatedKey = $relation->getRelated()->getQualifiedKeyName();
+
+            return $query->whereIn(
+                $relatedKey,
+                $relation->getQuery()->select($relatedKey)
+            );
+        }
+
+        // Parent present but no matching relation: show nothing rather than
+        // leaking the full set.
+        return $query->whereRaw('1 = 0');
+    }
+
+    /**
+     * Resolve the parent's many-to-many relation for this field: prefer an
+     * explicitly declared relation-method name, otherwise fall back to the field
+     * slug (the convention the User → Teams tab follows). Returns null when the
+     * parent has no such relation or it is not a BelongsToMany.
+     */
+    protected function parentRelation($parent, $field): ?EloquentBelongsToMany
+    {
+        $method = (isset($field['relation']) && is_string($field['relation']))
+            ? $field['relation']
+            : ($field['slug'] ?? null);
+
+        if (! is_string($method) || ! method_exists($parent, $method)) {
+            return null;
+        }
+
+        $relation = $parent->{$method}();
+
+        return $relation instanceof EloquentBelongsToMany ? $relation : null;
     }
 }

--- a/src/Fields/GlobalAdmin.php
+++ b/src/Fields/GlobalAdmin.php
@@ -10,11 +10,20 @@ use Illuminate\Support\Facades\Gate;
  *
  * `global_admin` is a real users-table column but is deliberately kept out of
  * the mass-assignment surface: the value only ever reaches the column through
- * this guarded write. Mirroring the escalation guard on the Roles field, the
- * flag can only be changed by an acting user who is already a Global Admin.
- * Every other actor — a guest during registration, a team Super Admin, mass
- * assignment, or form tampering — leaves the persisted flag untouched (silent
- * refusal), so the flag can never be self-granted.
+ * this guarded write. The flag can only be changed by an acting user who is
+ * already a Global Admin; every other actor — a guest during registration, a
+ * team Super Admin, mass assignment, or form tampering — leaves the persisted
+ * flag untouched, so the flag can never be self-granted.
+ *
+ * The refusal here is a SILENT no-op, not the 403 abort the Roles field's
+ * escalation guard raises — a deliberate difference, not an inconsistency. This
+ * field rides the ordinary create/update save pipeline (registration, the user
+ * form), where the flag defaults into every submitted payload and a hidden or
+ * tampered value must simply be ignored: aborting would strand a half-created
+ * user or fail a legitimate edit that never intended to touch the flag. The
+ * Roles field, by contrast, guards an explicit, deliberate role assignment, so
+ * a 403 is the correct, visible answer there. Same goal (no privilege
+ * escalation), different failure mode fitted to each write path.
  */
 class GlobalAdmin extends Boolean
 {

--- a/src/Fields/Roles.php
+++ b/src/Fields/Roles.php
@@ -9,6 +9,40 @@ use Illuminate\Database\Eloquent\Collection;
 
 class Roles extends AdvancedSelect implements PreloadsTableDisplay
 {
+    /**
+     * The user-form role picker offers the merged, shadow-resolved catalog: each
+     * slug once, the team's Shadow winning over the Global Role it shadows — the
+     * same resolved set the Roles index and the invitation modal present, so a
+     * shadowed Global Role never shows up twice in the search results. Mirrors
+     * AdvancedSelect::api() with the extra shadowResolved() constraint.
+     */
+    public function api($request)
+    {
+        $model = app($request->model);
+        $searchableFields = $model->getSearchableFields()->pluck('slug')->toArray();
+
+        $field = $request->fullField;
+
+        $query = $model->searchIn($searchableFields, $request->search, $model);
+
+        if (config('aura.teams') && method_exists($model, 'scopeShadowResolved')) {
+            $query->shadowResolved(optional(auth()->user())->current_team_id);
+        }
+
+        return $query
+            ->take(5)
+            ->get()
+            ->map(function ($item) use ($field) {
+                return [
+                    'id' => $item->id,
+                    'title' => $item->title(),
+                    'view' => isset($field['view_select']) ? view($field['view_select'], ['item' => $item, 'field' => $field])->render() : view('aura::components.fields.advanced-select-view-select', ['item' => $item, 'field' => $field])->render(),
+                    'view_selected' => isset($field['view_selected']) ? view($field['view_selected'], ['item' => $item, 'field' => $field])->render() : view('aura::components.fields.advanced-select-view-selected', ['item' => $item, 'field' => $field])->render(),
+                ];
+            })
+            ->toArray();
+    }
+
     public function display($field, $value, $model)
     {
         if (! $model->exists) {

--- a/src/Fields/Roles.php
+++ b/src/Fields/Roles.php
@@ -9,40 +9,6 @@ use Illuminate\Database\Eloquent\Collection;
 
 class Roles extends AdvancedSelect implements PreloadsTableDisplay
 {
-    /**
-     * The user-form role picker offers the merged, shadow-resolved catalog: each
-     * slug once, the team's Shadow winning over the Global Role it shadows — the
-     * same resolved set the Roles index and the invitation modal present, so a
-     * shadowed Global Role never shows up twice in the search results. Mirrors
-     * AdvancedSelect::api() with the extra shadowResolved() constraint.
-     */
-    public function api($request)
-    {
-        $model = app($request->model);
-        $searchableFields = $model->getSearchableFields()->pluck('slug')->toArray();
-
-        $field = $request->fullField;
-
-        $query = $model->searchIn($searchableFields, $request->search, $model);
-
-        if (config('aura.teams') && method_exists($model, 'scopeShadowResolved')) {
-            $query->shadowResolved(optional(auth()->user())->current_team_id);
-        }
-
-        return $query
-            ->take(5)
-            ->get()
-            ->map(function ($item) use ($field) {
-                return [
-                    'id' => $item->id,
-                    'title' => $item->title(),
-                    'view' => isset($field['view_select']) ? view($field['view_select'], ['item' => $item, 'field' => $field])->render() : view('aura::components.fields.advanced-select-view-select', ['item' => $item, 'field' => $field])->render(),
-                    'view_selected' => isset($field['view_selected']) ? view($field['view_selected'], ['item' => $item, 'field' => $field])->render() : view('aura::components.fields.advanced-select-view-selected', ['item' => $item, 'field' => $field])->render(),
-                ];
-            })
-            ->toArray();
-    }
-
     public function display($field, $value, $model)
     {
         if (! $model->exists) {
@@ -220,5 +186,21 @@ class Roles extends AdvancedSelect implements PreloadsTableDisplay
         // Roles use a per-row team constraint that generic eager loading cannot
         // express; they are batched via preloadTableDisplay() instead.
         return null;
+    }
+
+    /**
+     * The user-form role picker offers the merged, shadow-resolved catalog: each
+     * slug once, the team's Shadow winning over the Global Role it shadows — the
+     * same resolved set the Roles index and the invitation modal present, so a
+     * shadowed Global Role never shows up twice in the search results. The search
+     * and result-mapping plumbing lives in AdvancedSelect::api(); this field only
+     * contributes the shadowResolved() constraint through the constrainApiQuery()
+     * hook.
+     */
+    protected function constrainApiQuery($query, $request): void
+    {
+        if (config('aura.teams') && method_exists($query->getModel(), 'scopeShadowResolved')) {
+            $query->shadowResolved(Role::currentTeamIdForResolution());
+        }
     }
 }

--- a/src/Fields/UserTeams.php
+++ b/src/Fields/UserTeams.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Aura\Base\Fields;
+
+/**
+ * The User → Teams tab field. It reuses the parent-aware BelongsToMany query
+ * scoping (#49) for any embedded-table context, but on the user View page it
+ * renders the dedicated Membership editor (the aura::user-teams Livewire
+ * component) instead of the read-only has-many table, so an authorized admin can
+ * attach/detach teams and change the per-team role. Only the view() output
+ * differs from the generic BelongsToMany field; every other resource pair keeps
+ * the generic behavior.
+ */
+class UserTeams extends BelongsToMany
+{
+    public $view = 'aura::fields.user-teams';
+}

--- a/src/Livewire/InviteUser.php
+++ b/src/Livewire/InviteUser.php
@@ -44,7 +44,7 @@ class InviteUser extends Component
                 // the team's Shadow winning over the Global Role it shadows —
                 // the same set the Roles index and the user-form picker show.
                 'options' => config('aura.teams')
-                    ? Role::shadowResolved(optional(auth()->user())->current_team_id)->get()->pluck('name', 'id')->toArray()
+                    ? Role::shadowResolvedForCurrentTeam()->get()->pluck('name', 'id')->toArray()
                     : [],
                 'style' => [
                     'width' => '50',

--- a/src/Livewire/InviteUser.php
+++ b/src/Livewire/InviteUser.php
@@ -40,7 +40,12 @@ class InviteUser extends Component
                 'type' => 'Aura\\Base\\Fields\\Select',
                 'validation' => 'required',
                 'slug' => 'role',
-                'options' => config('aura.teams') ? Role::get()->pluck('name', 'id')->toArray() : [],
+                // Offer the merged, shadow-resolved catalog — each slug once,
+                // the team's Shadow winning over the Global Role it shadows —
+                // the same set the Roles index and the user-form picker show.
+                'options' => config('aura.teams')
+                    ? Role::shadowResolved(optional(auth()->user())->current_team_id)->get()->pluck('name', 'id')->toArray()
+                    : [],
                 'style' => [
                     'width' => '50',
                 ],

--- a/src/Livewire/UserTeams.php
+++ b/src/Livewire/UserTeams.php
@@ -45,7 +45,9 @@ class UserTeams extends Component
 
     /**
      * Per-team role select state, keyed by team id — the id the row's select is
-     * bound to so a change can be submitted with changeRole().
+     * bound to so a change can be submitted with changeRole(). Seeded from the
+     * resolved Memberships in mount() and re-seeded after each mutation, so the
+     * computed render properties stay side-effect free.
      *
      * @var array<int|string, int|string|null>
      */
@@ -56,7 +58,7 @@ class UserTeams extends Component
 
     public function attach(): void
     {
-        abort_unless(config('aura.teams'), 404);
+        $this->guardTeamsEnabled();
 
         $teamId = $this->attachTeamId !== '' ? (int) $this->attachTeamId : null;
         $roleId = $this->attachRoleId !== '' ? (int) $this->attachRoleId : null;
@@ -101,7 +103,7 @@ class UserTeams extends Component
 
         $user->roles()->attach($role->id, ['team_id' => $teamId]);
 
-        $this->afterMembershipChange($user, $teamId);
+        $this->afterMembershipChange($user);
 
         $this->reset('attachTeamId', 'attachRoleId');
 
@@ -110,7 +112,7 @@ class UserTeams extends Component
 
     public function changeRole($teamId, $roleId = null): void
     {
-        abort_unless(config('aura.teams'), 404);
+        $this->guardTeamsEnabled();
 
         $teamId = (int) $teamId;
         $roleId = $roleId ?? ($this->roleSelections[$teamId] ?? null);
@@ -132,21 +134,21 @@ class UserTeams extends Component
         // currently held (in case it was a Super Admin being removed).
         $this->guardSuperAdmin($teamId, $role);
 
-        if ($current = $this->resolvedMembershipRole($teamId)) {
+        if ($current = $this->resolvedRoleForUser($this->userId, $teamId)) {
             $this->guardSuperAdmin($teamId, $current);
         }
 
         $user->roles()->wherePivot('team_id', $teamId)->detach();
         $user->roles()->attach($role->id, ['team_id' => $teamId]);
 
-        $this->afterMembershipChange($user, $teamId);
+        $this->afterMembershipChange($user);
 
         $this->notify(__('Role updated.'));
     }
 
     public function detach($teamId): void
     {
-        abort_unless(config('aura.teams'), 404);
+        $this->guardTeamsEnabled();
 
         $teamId = (int) $teamId;
 
@@ -157,7 +159,7 @@ class UserTeams extends Component
         abort_unless($user->teams()->where('teams.id', $teamId)->exists(), 404);
 
         // Guard removing a Super Admin Membership the same way granting one is.
-        if ($current = $this->resolvedMembershipRole($teamId)) {
+        if ($current = $this->resolvedRoleForUser($this->userId, $teamId)) {
             $this->guardSuperAdmin($teamId, $current);
         }
 
@@ -172,9 +174,7 @@ class UserTeams extends Component
             User::clearCurrentTeamCache($user->getKey());
         }
 
-        $this->afterMembershipChange($user, $teamId);
-
-        unset($this->roleSelections[$teamId]);
+        $this->afterMembershipChange($user);
 
         $this->notify(__('Membership removed.'));
     }
@@ -199,22 +199,17 @@ class UserTeams extends Component
     /**
      * The Memberships rendered on the tab: one row per team the user belongs to,
      * with the role resolved through the catalog seam and a per-row read-only
-     * flag reflecting whether the actor may manage that team.
+     * flag reflecting whether the actor may manage that team. Pure: it reads
+     * state only (roleSelections is seeded in mount()/after mutations).
      *
      * @return array<int, array<string, mixed>>
      */
     public function getMembershipsProperty(): array
     {
-        $user = $this->user();
-
-        return $user->teams()->get()->map(function ($team) {
+        return $this->user()->teams()->get()->map(function ($team) {
             $teamId = (int) $team->getKey();
-            $resolved = $this->resolvedMembershipRole($teamId);
+            $resolved = $this->resolvedRoleForUser($this->userId, $teamId);
             $canManage = $this->canManageTeam($teamId);
-
-            if ($canManage && ! array_key_exists($teamId, $this->roleSelections)) {
-                $this->roleSelections[$teamId] = $resolved?->getKey();
-            }
 
             return [
                 'team_id' => $teamId,
@@ -254,14 +249,16 @@ class UserTeams extends Component
 
     public function mount($userId): void
     {
-        abort_unless(config('aura.teams'), 404);
+        $this->guardTeamsEnabled();
 
         $this->userId = $userId;
+
+        $this->seedRoleSelections();
     }
 
     public function render()
     {
-        abort_unless(config('aura.teams'), 404);
+        $this->guardTeamsEnabled();
 
         return view('aura::livewire.user.user-teams');
     }
@@ -283,39 +280,17 @@ class UserTeams extends Component
     }
 
     /**
-     * The role the actor holds in the given team, resolved through the catalog
-     * seam (pivot role_id → slug → Role::resolveForTeam). Null when the actor has
-     * no Membership in that team.
-     */
-    protected function actorRoleForTeam(User $actor, int $teamId): ?Role
-    {
-        $pivot = DB::table('user_role')
-            ->where('user_id', $actor->getKey())
-            ->where('team_id', $teamId)
-            ->first();
-
-        if (! $pivot) {
-            return null;
-        }
-
-        $role = Role::withoutGlobalScopes()->find($pivot->role_id);
-
-        if (! $role) {
-            return null;
-        }
-
-        return Role::resolveForTeam($role->getAttribute('slug'), $teamId);
-    }
-
-    /**
      * Refresh the viewed user's cached team list after a Membership change so the
-     * tab and the user's permission checks reflect the new state immediately.
+     * tab and the user's permission checks reflect the new state immediately, and
+     * re-seed the per-row role selects from the new Memberships.
      */
-    protected function afterMembershipChange(User $user, int $teamId): void
+    protected function afterMembershipChange(User $user): void
     {
         Cache::forget('user.'.$user->id.'.teams');
         $user->unsetRelation('teams');
         $user->unsetRelation('roles');
+
+        $this->seedRoleSelections();
     }
 
     /**
@@ -351,7 +326,7 @@ class UserTeams extends Component
             return true;
         }
 
-        return (bool) optional($this->actorRoleForTeam($actor, $teamId))->super_admin;
+        return (bool) optional($this->resolvedRoleForUser($actor->getKey(), $teamId))->super_admin;
     }
 
     /**
@@ -368,19 +343,28 @@ class UserTeams extends Component
 
         abort_if(
             ! $actor
-            || (! $actor->isAuraGlobalAdmin() && ! optional($this->actorRoleForTeam($actor, $teamId))->super_admin),
+            || (! $actor->isAuraGlobalAdmin() && ! optional($this->resolvedRoleForUser($actor->getKey(), $teamId))->super_admin),
             403
         );
     }
 
+    /** Every entry point is teams-only; a Teams-off request 404s. */
+    protected function guardTeamsEnabled(): void
+    {
+        abort_unless(config('aura.teams'), 404);
+    }
+
     /**
-     * The viewed user's role in a team, resolved through the catalog seam so a
-     * Shadow displays as the team's version.
+     * The role a user holds in a team, resolved through the catalog seam
+     * (pivot role_id → slug → Role::resolveForTeam, so a Shadow resolves to the
+     * team's version). Null when the user has no Membership in that team. The
+     * single pivot→slug→resolve path for both the viewed user's rows and the
+     * actor's own team authority.
      */
-    protected function resolvedMembershipRole(int $teamId): ?Role
+    protected function resolvedRoleForUser($userId, int $teamId): ?Role
     {
         $pivot = DB::table('user_role')
-            ->where('user_id', $this->userId)
+            ->where('user_id', $userId)
             ->where('team_id', $teamId)
             ->first();
 
@@ -412,6 +396,22 @@ class UserTeams extends Component
             ->pluck('name', 'id')
             ->map(fn ($name) => (string) $name)
             ->all();
+    }
+
+    /**
+     * Seed the per-row role selects from the viewed user's current Memberships,
+     * keeping the computed render properties free of state mutation.
+     */
+    protected function seedRoleSelections(): void
+    {
+        $selections = [];
+
+        foreach ($this->user()->teams()->get() as $team) {
+            $teamId = (int) $team->getKey();
+            $selections[$teamId] = $this->resolvedRoleForUser($this->userId, $teamId)?->getKey();
+        }
+
+        $this->roleSelections = $selections;
     }
 
     /** The viewed user, loaded unscoped so cross-team management works. */

--- a/src/Livewire/UserTeams.php
+++ b/src/Livewire/UserTeams.php
@@ -1,0 +1,422 @@
+<?php
+
+namespace Aura\Base\Livewire;
+
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\User;
+use Aura\Base\Traits\WithLivewireHelpers;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Livewire\Component;
+
+/**
+ * The Membership editor on the user View page's Teams tab.
+ *
+ * Displays every Membership of the viewed user — team + the user's role in that
+ * team, resolved through the catalog seam (pivot role_id → slug →
+ * Role::resolveForTeam, so a Shadow displays as the team's version) — and lets an
+ * authorized admin attach the user to a team with a role from that team's merged
+ * (shadow-resolved) set, change the per-team role, or detach a Membership.
+ *
+ * Authorization is enforced server-side per operation, always scoped to the
+ * TARGET team, never the actor's implicit current team:
+ *   - a Global Admin manages Memberships in any team;
+ *   - a team Super Admin (super_admin via the role resolved for that team) only
+ *     in the teams they administer;
+ *   - everyone else is read-only (refused server-side, not merely hidden).
+ * Assigning a role whose resolved definition is a Super Admin additionally
+ * requires the actor to be a Super Admin of that team (or a Global Admin),
+ * mirroring the Roles field's escalation guard.
+ *
+ * Teams-only: the whole component 404s in Teams-off mode (the Teams tab's
+ * conditional logic already hides it there).
+ */
+class UserTeams extends Component
+{
+    use AuthorizesRequests;
+    use WithLivewireHelpers;
+
+    /** Attach form: the role (from the target team's merged set) to grant. */
+    public $attachRoleId = '';
+
+    /** Attach form: the team to attach the viewed user to. */
+    public $attachTeamId = '';
+
+    /**
+     * Per-team role select state, keyed by team id — the id the row's select is
+     * bound to so a change can be submitted with changeRole().
+     *
+     * @var array<int|string, int|string|null>
+     */
+    public array $roleSelections = [];
+
+    /** The viewed user's primary key. */
+    public $userId;
+
+    public function attach(): void
+    {
+        abort_unless(config('aura.teams'), 404);
+
+        $teamId = $this->attachTeamId !== '' ? (int) $this->attachTeamId : null;
+        $roleId = $this->attachRoleId !== '' ? (int) $this->attachRoleId : null;
+
+        $this->resetErrorBag();
+
+        if (! $teamId) {
+            $this->addError('attachTeamId', __('Please select a team.'));
+
+            return;
+        }
+
+        if (! $roleId) {
+            $this->addError('attachRoleId', __('Please select a role.'));
+
+            return;
+        }
+
+        // Server-side authorization for the TARGET team (never the actor's
+        // implicit current team): a Global Admin anywhere, else a Super Admin of
+        // this team only.
+        abort_unless($this->canManageTeam($teamId), 403);
+
+        $user = $this->user();
+
+        // One role per team: the pivot's unique(team_id, user_id) constraint.
+        // Surface it as a validation error instead of a DB exception.
+        if ($user->teams()->where('teams.id', $teamId)->exists()) {
+            $this->addError('attachTeamId', __('The user is already a member of this team.'));
+
+            return;
+        }
+
+        // The role must belong to the target team's assignable, shadow-resolved
+        // set — its own Team Roles plus unshadowed Global Roles, each slug once.
+        // A Global Role's hidden id for a slug the team shadows is refused here.
+        $role = $this->assignableRole($teamId, $roleId);
+
+        abort_if($role === null, 403);
+
+        $this->guardSuperAdmin($teamId, $role);
+
+        $user->roles()->attach($role->id, ['team_id' => $teamId]);
+
+        $this->afterMembershipChange($user, $teamId);
+
+        $this->reset('attachTeamId', 'attachRoleId');
+
+        $this->notify(__('Membership added.'));
+    }
+
+    public function changeRole($teamId, $roleId = null): void
+    {
+        abort_unless(config('aura.teams'), 404);
+
+        $teamId = (int) $teamId;
+        $roleId = $roleId ?? ($this->roleSelections[$teamId] ?? null);
+        $roleId = $roleId !== null && $roleId !== '' ? (int) $roleId : null;
+
+        abort_unless($this->canManageTeam($teamId), 403);
+
+        $user = $this->user();
+
+        abort_unless($user->teams()->where('teams.id', $teamId)->exists(), 404);
+
+        abort_if($roleId === null, 403);
+
+        $role = $this->assignableRole($teamId, $roleId);
+
+        abort_if($role === null, 403);
+
+        // Guard the escalation both ways: the role being granted and the role
+        // currently held (in case it was a Super Admin being removed).
+        $this->guardSuperAdmin($teamId, $role);
+
+        if ($current = $this->resolvedMembershipRole($teamId)) {
+            $this->guardSuperAdmin($teamId, $current);
+        }
+
+        $user->roles()->wherePivot('team_id', $teamId)->detach();
+        $user->roles()->attach($role->id, ['team_id' => $teamId]);
+
+        $this->afterMembershipChange($user, $teamId);
+
+        $this->notify(__('Role updated.'));
+    }
+
+    public function detach($teamId): void
+    {
+        abort_unless(config('aura.teams'), 404);
+
+        $teamId = (int) $teamId;
+
+        abort_unless($this->canManageTeam($teamId), 403);
+
+        $user = $this->user();
+
+        abort_unless($user->teams()->where('teams.id', $teamId)->exists(), 404);
+
+        // Guard removing a Super Admin Membership the same way granting one is.
+        if ($current = $this->resolvedMembershipRole($teamId)) {
+            $this->guardSuperAdmin($teamId, $current);
+        }
+
+        $user->roles()->wherePivot('team_id', $teamId)->detach();
+
+        // Current-team fallback: if we just detached the user's current team,
+        // fall back to a remaining Membership (or null), mirroring the Team
+        // deletion hook. Query fresh after the detach.
+        if ((int) $user->getAttribute('current_team_id') === $teamId) {
+            $firstTeam = $user->teams()->first();
+            $user->forceFill(['current_team_id' => $firstTeam ? $firstTeam->getKey() : null])->save();
+            User::clearCurrentTeamCache($user->getKey());
+        }
+
+        $this->afterMembershipChange($user, $teamId);
+
+        unset($this->roleSelections[$teamId]);
+
+        $this->notify(__('Membership removed.'));
+    }
+
+    /**
+     * The assignable roles for the attach form of the currently-selected team:
+     * the same merged, shadow-resolved set the pickers offer.
+     *
+     * @return array<int, string>
+     */
+    public function getAttachRoleOptionsProperty(): array
+    {
+        $teamId = $this->attachTeamId !== '' ? (int) $this->attachTeamId : null;
+
+        if (! $teamId) {
+            return [];
+        }
+
+        return $this->rolesForTeam($teamId);
+    }
+
+    /**
+     * The Memberships rendered on the tab: one row per team the user belongs to,
+     * with the role resolved through the catalog seam and a per-row read-only
+     * flag reflecting whether the actor may manage that team.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getMembershipsProperty(): array
+    {
+        $user = $this->user();
+
+        return $user->teams()->get()->map(function ($team) {
+            $teamId = (int) $team->getKey();
+            $resolved = $this->resolvedMembershipRole($teamId);
+            $canManage = $this->canManageTeam($teamId);
+
+            if ($canManage && ! array_key_exists($teamId, $this->roleSelections)) {
+                $this->roleSelections[$teamId] = $resolved?->getKey();
+            }
+
+            return [
+                'team_id' => $teamId,
+                'team_name' => $team->getAttribute('name'),
+                'role_id' => $resolved?->getKey(),
+                'role_name' => $resolved?->getAttribute('name'),
+                'can_manage' => $canManage,
+                'role_options' => $canManage ? $this->rolesForTeam($teamId) : [],
+            ];
+        })->all();
+    }
+
+    /**
+     * The teams the actor may still attach the viewed user to: not yet a member,
+     * and within the actor's authority (all teams for a Global Admin; only the
+     * teams the actor is a Super Admin of otherwise).
+     *
+     * @return array<int, string>
+     */
+    public function getTeamOptionsProperty(): array
+    {
+        if (! config('aura.teams')) {
+            return [];
+        }
+
+        $user = $this->user();
+        $memberTeamIds = $user->teams()->pluck('teams.id')->map(fn ($id) => (int) $id)->all();
+
+        $teams = app(config('aura.resources.team'))::withoutGlobalScopes()->get();
+
+        return $teams
+            ->reject(fn ($team) => in_array((int) $team->getKey(), $memberTeamIds, true))
+            ->filter(fn ($team) => $this->canManageTeam((int) $team->getKey()))
+            ->mapWithKeys(fn ($team) => [(int) $team->getKey() => $team->getAttribute('name')])
+            ->all();
+    }
+
+    public function mount($userId): void
+    {
+        abort_unless(config('aura.teams'), 404);
+
+        $this->userId = $userId;
+    }
+
+    public function render()
+    {
+        abort_unless(config('aura.teams'), 404);
+
+        return view('aura::livewire.user.user-teams');
+    }
+
+    /** The authenticated actor as a first-class User model, or null. */
+    protected function actor(): ?User
+    {
+        $actor = auth()->user();
+
+        if (! $actor) {
+            return null;
+        }
+
+        if ($actor instanceof User) {
+            return $actor;
+        }
+
+        return User::withoutGlobalScopes()->find($actor->getAuthIdentifier());
+    }
+
+    /**
+     * The role the actor holds in the given team, resolved through the catalog
+     * seam (pivot role_id → slug → Role::resolveForTeam). Null when the actor has
+     * no Membership in that team.
+     */
+    protected function actorRoleForTeam(User $actor, int $teamId): ?Role
+    {
+        $pivot = DB::table('user_role')
+            ->where('user_id', $actor->getKey())
+            ->where('team_id', $teamId)
+            ->first();
+
+        if (! $pivot) {
+            return null;
+        }
+
+        $role = Role::withoutGlobalScopes()->find($pivot->role_id);
+
+        if (! $role) {
+            return null;
+        }
+
+        return Role::resolveForTeam($role->getAttribute('slug'), $teamId);
+    }
+
+    /**
+     * Refresh the viewed user's cached team list after a Membership change so the
+     * tab and the user's permission checks reflect the new state immediately.
+     */
+    protected function afterMembershipChange(User $user, int $teamId): void
+    {
+        Cache::forget('user.'.$user->id.'.teams');
+        $user->unsetRelation('teams');
+        $user->unsetRelation('roles');
+    }
+
+    /**
+     * Resolve a submitted role id against the target team's assignable set —
+     * its own Team Roles plus unshadowed Global Roles, each slug once. Returns
+     * null when the id is not assignable in that team (e.g. a role owned by
+     * another team, or a Global Role's hidden id for a slug this team shadows).
+     */
+    protected function assignableRole(int $teamId, int $roleId): ?Role
+    {
+        return Role::withoutGlobalScopes()
+            ->shadowResolved($teamId)
+            ->visibleToTeam($teamId)
+            ->whereKey($roleId)
+            ->first();
+    }
+
+    /**
+     * Whether the actor may manage Memberships for the given team: a Global Admin
+     * anywhere, else a Super Admin of that specific team (resolved through the
+     * catalog seam, so a Shadow's super_admin flag wins). Never keyed off the
+     * actor's implicit current team.
+     */
+    protected function canManageTeam(int $teamId): bool
+    {
+        $actor = $this->actor();
+
+        if (! $actor) {
+            return false;
+        }
+
+        if ($actor->isAuraGlobalAdmin()) {
+            return true;
+        }
+
+        return (bool) optional($this->actorRoleForTeam($actor, $teamId))->super_admin;
+    }
+
+    /**
+     * Refuse assigning/removing a Super Admin role unless the actor is a Super
+     * Admin of that team (or a Global Admin) — mirrors Roles::saved()'s guard.
+     */
+    protected function guardSuperAdmin(int $teamId, Role $role): void
+    {
+        if (! $role->getAttribute('super_admin')) {
+            return;
+        }
+
+        $actor = $this->actor();
+
+        abort_if(
+            ! $actor
+            || (! $actor->isAuraGlobalAdmin() && ! optional($this->actorRoleForTeam($actor, $teamId))->super_admin),
+            403
+        );
+    }
+
+    /**
+     * The viewed user's role in a team, resolved through the catalog seam so a
+     * Shadow displays as the team's version.
+     */
+    protected function resolvedMembershipRole(int $teamId): ?Role
+    {
+        $pivot = DB::table('user_role')
+            ->where('user_id', $this->userId)
+            ->where('team_id', $teamId)
+            ->first();
+
+        if (! $pivot) {
+            return null;
+        }
+
+        $role = Role::withoutGlobalScopes()->find($pivot->role_id);
+
+        if (! $role) {
+            return null;
+        }
+
+        return Role::resolveForTeam($role->getAttribute('slug'), $teamId);
+    }
+
+    /**
+     * The target team's merged, shadow-resolved role set for the pickers: each
+     * slug once, the team's Shadow winning over the Global Role it shadows.
+     *
+     * @return array<int, string>
+     */
+    protected function rolesForTeam(int $teamId): array
+    {
+        return Role::withoutGlobalScopes()
+            ->shadowResolved($teamId)
+            ->visibleToTeam($teamId)
+            ->get()
+            ->pluck('name', 'id')
+            ->map(fn ($name) => (string) $name)
+            ->all();
+    }
+
+    /** The viewed user, loaded unscoped so cross-team management works. */
+    protected function user(): User
+    {
+        return User::withoutGlobalScopes()->findOrFail($this->userId);
+    }
+}

--- a/src/Policies/ResourcePolicy.php
+++ b/src/Policies/ResourcePolicy.php
@@ -98,6 +98,10 @@ class ResourcePolicy
      */
     public function restore(User $user, $resource)
     {
+        if ($this->deniesGlobalRoleWrite($user, $resource)) {
+            return false;
+        }
+
         if ($this->hasBlanketAccess($user)) {
             return true;
         }

--- a/src/Policies/ResourcePolicy.php
+++ b/src/Policies/ResourcePolicy.php
@@ -4,6 +4,7 @@ namespace Aura\Base\Policies;
 
 use App\Models\Post;
 use Aura\Base\Resource;
+use Aura\Base\Resources\Role;
 use Aura\Base\Resources\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -42,6 +43,10 @@ class ResourcePolicy
      */
     public function delete($user, $resource)
     {
+        if ($this->deniesGlobalRoleWrite($user, $resource)) {
+            return false;
+        }
+
         if ($this->hasBlanketAccess($user)) {
             return true;
         }
@@ -70,6 +75,10 @@ class ResourcePolicy
      */
     public function forceDelete($user, $resource)
     {
+        if ($this->deniesGlobalRoleWrite($user, $resource)) {
+            return false;
+        }
+
         if ($this->hasBlanketAccess($user)) {
             return true;
         }
@@ -108,6 +117,10 @@ class ResourcePolicy
     public function update($user, $resource)
     {
         if ($resource::$editEnabled === false) {
+            return false;
+        }
+
+        if ($this->deniesGlobalRoleWrite($user, $resource)) {
             return false;
         }
 
@@ -190,6 +203,30 @@ class ResourcePolicy
         }
 
         return false;
+    }
+
+    /**
+     * Refuse a mutating write to a Global Role from a team context unless the
+     * actor is a Global Admin. A Global Role (team_id = null) belongs to the
+     * shared catalog: a team Super Admin — who otherwise clears every ability
+     * via hasBlanketAccess — must not edit or delete it, or one team could
+     * silently rewrite permissions for every other team. Checked BEFORE
+     * hasBlanketAccess so a team Super Admin's blanket power does not leak here;
+     * a Global Admin passes and is then cleared normally. A team may still
+     * Shadow the global role (create its own Team Role of the same slug) — that
+     * is a separate, allowed create. No-op in Teams-off mode (no catalog).
+     */
+    protected function deniesGlobalRoleWrite($user, $resource): bool
+    {
+        if (! config('aura.teams')) {
+            return false;
+        }
+
+        if (! ($resource instanceof Role) || ! $resource->exists || $resource->getAttribute('team_id') !== null) {
+            return false;
+        }
+
+        return ! $user->isAuraGlobalAdmin();
     }
 
     /**

--- a/src/Resources/Role.php
+++ b/src/Resources/Role.php
@@ -6,6 +6,7 @@ use Aura\Base\Jobs\GenerateAllResourcePermissions;
 use Aura\Base\Models\Meta;
 use Aura\Base\Resource;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Facades\Gate;
 
 class Role extends Resource
 {
@@ -27,6 +28,18 @@ class Role extends Resource
     ];
 
     public static $customTable = true;
+
+    /**
+     * Transient "make this role global" intent captured from the guarded
+     * `is_global` form toggle. It is NOT a database column: the setIsGlobal
+     * mutator (setIsGlobalAttribute) diverts the submitted value here so it
+     * never reaches an INSERT,
+     * and the `saving` hook below translates it into the authoritative team_id
+     * write (team_id = null for a Global Role), gated on the actor being a
+     * Global Admin. `null` means the toggle was never submitted (leave team_id
+     * exactly as the normal pipeline set it).
+     */
+    public ?bool $globalIntent = null;
 
     public static $globalSearch = false;
 
@@ -61,6 +74,7 @@ class Role extends Resource
         'super_admin',
         'permissions',
         'team_id',
+        'is_global',
     ];
 
     protected static ?string $group = 'Aura';
@@ -186,6 +200,11 @@ class Role extends Resource
                 'conditional_logic' => [],
                 'wrapper' => '',
                 'on_index' => true,
+                // Mark Global Roles (team_id = null) in the merged team-context
+                // index so a Team Super Admin sees at a glance which rows are
+                // the shared, read-only catalog roles. Teams-off has no team_id
+                // column, so the badge blade renders nothing there.
+                'display_view' => 'aura::components.fields.role-name-index',
                 'searchable' => true,
                 'on_forms' => true,
                 'on_view' => true,
@@ -232,6 +251,28 @@ class Role extends Resource
                 'default' => false,
             ],
             [
+                'name' => 'Global Role',
+                'slug' => 'is_global',
+                'type' => 'Aura\\Base\\Fields\\Boolean',
+                'instructions' => 'Available in every team as part of the shared Role Catalog. Only a Global Admin can define global roles.',
+                'validation' => '',
+                'default' => false,
+                'on_index' => false,
+                'on_forms' => true,
+                'on_view' => true,
+                // Client-advisory only: the toggle is shown to Global Admins so
+                // they can promote a role to the catalog. The authoritative
+                // guard lives server-side in the `saving` hook, which ignores
+                // the intent for any non-Global-Admin actor. Teams-off has no
+                // global/team distinction, so the toggle is hidden entirely.
+                'conditional_logic' => function ($model, $post) {
+                    return config('aura.teams') && auth()->check() && Gate::allows('AuraGlobalAdmin');
+                },
+                'style' => [
+                    'width' => '50',
+                ],
+            ],
+            [
                 'name' => 'Permissions',
                 'on_index' => false,
                 'type' => 'Aura\\Base\\Fields\\Permissions',
@@ -255,9 +296,44 @@ class Role extends Resource
         return view('aura::components.icon.role')->render();
     }
 
+    /**
+     * Derive the `is_global` toggle value from the authoritative signal: a
+     * Global Role is one with no team (team_id = null). Teams-off has no
+     * team/global distinction, so the toggle is always off there.
+     */
+    public function getIsGlobalAttribute(): bool
+    {
+        // Read team_id straight from the loaded attributes: a fresh (unsaved)
+        // Role has no team, and a Role fetched without its team_id column must
+        // not trip strict-mode missing-attribute access. Only a persisted row
+        // whose team_id is explicitly null is a Global Role.
+        if (! config('aura.teams') || ! $this->exists) {
+            return false;
+        }
+
+        return array_key_exists('team_id', $this->attributes) && $this->attributes['team_id'] === null;
+    }
+
     public static function getWidgets(): array
     {
         return [];
+    }
+
+    /**
+     * Merge/de-duplicate the Roles index in a team context. TeamScope makes both
+     * the team's own Team Roles and every Global Role visible, so a Global Role
+     * that the team Shadows would otherwise appear twice. Resolve to the shown
+     * set — each slug once, the Shadow winning — by dropping the Global rows a
+     * Team Role of the same slug shadows for the current team. Applied as a
+     * plain WHERE so it composes with search, sort and pagination.
+     */
+    public function indexQuery($query, $table = null)
+    {
+        if (config('aura.teams')) {
+            $query->shadowResolved(optional(auth()->user())->current_team_id);
+        }
+
+        return $query;
     }
 
     /**
@@ -316,6 +392,33 @@ class Role extends Resource
     }
 
     /**
+     * Reduce the team-context role set to what the merged Roles index and the
+     * role pickers show: each slug once, with a team's Shadow winning over the
+     * Global Role it shadows. Concretely, exclude Global rows (team_id = null)
+     * whose slug is also defined as a Team Role for the given team. Team Roles
+     * and non-shadowed Global Roles are untouched. A no-op in Teams-off mode,
+     * where the flat catalog already holds one row per slug.
+     */
+    public function scopeShadowResolved($query, ?int $teamId = null)
+    {
+        if (! config('aura.teams')) {
+            return $query;
+        }
+
+        $table = $query->getModel()->getTable();
+
+        return $query->whereNot(function ($inner) use ($table, $teamId) {
+            $inner->whereNull($table.'.team_id')
+                ->whereExists(function ($sub) use ($table, $teamId) {
+                    $sub->selectRaw('1')
+                        ->from($table.' as shadow_roles')
+                        ->whereColumn('shadow_roles.slug', $table.'.slug')
+                        ->where('shadow_roles.team_id', $teamId);
+                });
+        });
+    }
+
+    /**
      * Constrain a role query to the roles visible within a team context: the
      * team's own Team Roles plus the shared Global Roles (team_id = null). This
      * is the single expression of the "team-or-global" shape used by the
@@ -328,6 +431,19 @@ class Role extends Resource
         return $query->where(function ($query) use ($column, $teamId) {
             $query->where($column, $teamId)->orWhereNull($column);
         });
+    }
+
+    /**
+     * Capture the guarded `is_global` toggle without ever letting it reach the
+     * database as a column. The submitted value is diverted into the transient
+     * $globalIntent property; the `saving` hook applies it (team_id = null) only
+     * for a Global Admin actor. Non-global/absent submissions leave team_id as
+     * the normal pipeline set it, so the toggle can never self-grant catalog
+     * scope through mass assignment or form tampering.
+     */
+    public function setIsGlobalAttribute($value): void
+    {
+        $this->globalIntent = filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 
     public function teams(): BelongsToMany
@@ -363,6 +479,40 @@ class Role extends Resource
     protected static function booted()
     {
         parent::booted();
+
+        // Apply the guarded `is_global` toggle. Registered from booted() so it
+        // runs AFTER InitialPostFields' saving hook (which auto-teams a new row
+        // to the current team): only here can team_id be forced back to null for
+        // a Global Admin promoting a role to the catalog. The intent is honored
+        // for a Global Admin only; every other actor's toggle is silently
+        // refused, so a Global Role can never be minted through form tampering.
+        static::saving(function (self $role) {
+            if ($role->globalIntent === null || ! config('aura.teams')) {
+                return;
+            }
+
+            $actor = auth()->user();
+            $isGlobalAdmin = $actor && Gate::forUser($actor)->allows(User::GLOBAL_ADMIN_GATE);
+
+            if (! $isGlobalAdmin) {
+                // Silent refusal: a non-Global-Admin can never produce a Global
+                // Role. If nothing team-scoped it yet, pin it to the actor's
+                // current team so the escalation attempt yields a Team Role.
+                if ($role->getAttribute('team_id') === null) {
+                    $role->setAttribute('team_id', optional($actor)->current_team_id);
+                }
+
+                return;
+            }
+
+            if ($role->globalIntent === true) {
+                $role->setAttribute('team_id', null);
+            } elseif ($role->getAttribute('team_id') === null) {
+                // A Global Admin explicitly turning the toggle off demotes the
+                // role to a Team Role in their current team.
+                $role->setAttribute('team_id', optional($actor)->current_team_id);
+            }
+        });
 
         // Any catalog write (including creating or deleting a Shadow) bumps the
         // Role Catalog version so every user's resolved-roles memo recomputes on

--- a/src/Resources/Role.php
+++ b/src/Resources/Role.php
@@ -141,6 +141,18 @@ class Role extends Resource
     }
 
     /**
+     * The team id to resolve Shadows against for the acting user's current
+     * context — the single source the merged Roles index and the role pickers
+     * (invitation modal, user-form picker) funnel through when calling
+     * shadowResolved(). Null (a guest, or a Global Admin with no current team)
+     * resolves against the global catalog.
+     */
+    public static function currentTeamIdForResolution(): ?int
+    {
+        return optional(auth()->user())->current_team_id;
+    }
+
+    /**
      * Ensure a base Role Catalog role (Global Role, team_id = null) exists and
      * return it. Self-heals installs whose catalog was never seeded (a bare
      * `migrate`, or the test harness, which does not run aura:install), using the
@@ -330,7 +342,7 @@ class Role extends Resource
     public function indexQuery($query, $table = null)
     {
         if (config('aura.teams')) {
-            $query->shadowResolved(optional(auth()->user())->current_team_id);
+            $query->shadowResolved(static::currentTeamIdForResolution());
         }
 
         return $query;
@@ -391,14 +403,6 @@ class Role extends Resource
             ->first();
     }
 
-    /**
-     * Reduce the team-context role set to what the merged Roles index and the
-     * role pickers show: each slug once, with a team's Shadow winning over the
-     * Global Role it shadows. Concretely, exclude Global rows (team_id = null)
-     * whose slug is also defined as a Team Role for the given team. Team Roles
-     * and non-shadowed Global Roles are untouched. A no-op in Teams-off mode,
-     * where the flat catalog already holds one row per slug.
-     */
     public function scopeShadowResolved($query, ?int $teamId = null)
     {
         if (! config('aura.teams')) {
@@ -444,6 +448,24 @@ class Role extends Resource
     public function setIsGlobalAttribute($value): void
     {
         $this->globalIntent = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Reduce the team-context role set to what the merged Roles index and the
+     * role pickers show: each slug once, with a team's Shadow winning over the
+     * Global Role it shadows. Concretely, exclude Global rows (team_id = null)
+     * whose slug is also defined as a Team Role for the given team. Team Roles
+     * and non-shadowed Global Roles are untouched. A no-op in Teams-off mode,
+     * where the flat catalog already holds one row per slug.
+     */
+    /**
+     * A fresh merged, shadow-resolved query for the acting user's current team —
+     * the set the invitation modal's role picker offers. Sugar over
+     * shadowResolved(currentTeamIdForResolution()).
+     */
+    public static function shadowResolvedForCurrentTeam()
+    {
+        return static::shadowResolved(static::currentTeamIdForResolution());
     }
 
     public function teams(): BelongsToMany

--- a/src/Resources/User.php
+++ b/src/Resources/User.php
@@ -409,7 +409,7 @@ class User extends Resource implements AuthenticatableContract, AuthorizableCont
             [
                 'name' => 'Teams',
                 'slug' => 'teams',
-                'type' => 'Aura\\Base\\Fields\\BelongsToMany',
+                'type' => 'Aura\\Base\\Fields\\UserTeams',
                 'resource' => 'Aura\\Base\\Resources\\Team',
                 'validation' => '',
                 'wrapper' => '',

--- a/tests/Feature/Fields/BelongsToManyFieldTest.php
+++ b/tests/Feature/Fields/BelongsToManyFieldTest.php
@@ -3,11 +3,83 @@
 namespace Tests\Feature\Fields;
 
 use Aura\Base\Fields\BelongsToMany;
+use Aura\Base\Livewire\Resource\View;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
 use Aura\Base\Resources\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany as EloquentBelongsToMany;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Features\SupportTesting\Testable;
+use Livewire\Livewire;
 
 beforeEach(function () {
     $this->actingAs($this->user = createSuperAdmin());
 });
+
+/**
+ * A component-like stub exposing the two properties BelongsToMany::queryFor
+ * reads: the field config and the parent record (the record being viewed).
+ */
+function belongsToManyComponent(array $field, $parent = null): object
+{
+    return new class($field, $parent)
+    {
+        public $field;
+
+        public $parent;
+
+        public function __construct($field, $parent)
+        {
+            $this->field = $field;
+            $this->parent = $parent;
+        }
+    };
+}
+
+/**
+ * The Teams-tab field exactly as the User resource declares it, stripped of the
+ * closure keys the has-many view unsets before handing it to the table.
+ */
+function userTeamsField(): array
+{
+    $field = collect(User::getFields())->firstWhere('slug', 'teams');
+    unset($field['conditional_logic'], $field['relation']);
+
+    return $field;
+}
+
+/**
+ * Mount the embedded table exactly as resources/views/components/fields/
+ * has-many.blade.php does for the on_view Teams tab: the target resource as the
+ * model, the viewed record as the parent.
+ */
+function mountTeamsTabTable(User $parent): Testable
+{
+    return Livewire::test('aura::table', [
+        'model' => app(Team::class),
+        'field' => userTeamsField(),
+        'settings' => [
+            'filters' => false,
+            'global_filters' => false,
+            'header_before' => false,
+            'header_after' => false,
+            'settings' => false,
+            'search' => false,
+            'selectable' => false,
+        ],
+        'parent' => $parent,
+        'disabled' => true,
+    ]);
+}
+
+/** Attach a user to a team with a fresh Team Role (records a Membership). */
+function attachMembership(User $user, Team $team): void
+{
+    $role = Role::factory()->create(['team_id' => $team->id]);
+    $user->roles()->attach($role->id, ['team_id' => $team->id]);
+}
 
 describe('BelongsToMany Field Configuration', function () {
     test('has correct properties', function () {
@@ -25,29 +97,163 @@ describe('BelongsToMany Field Configuration', function () {
 });
 
 describe('BelongsToMany Field Query Scoping', function () {
-    test('queryFor scopes to the current user id for a non-User/Team model', function () {
-        $field = new BelongsToMany;
+    // A dedicated, framework-scope-free many-to-many pair proves the fix is
+    // generic (not hardcoded to User/Team) and free of TeamScope side effects.
+    beforeEach(function () {
+        Schema::create('btm_gadgets', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+        Schema::create('btm_widgets', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+        Schema::create('btm_gadget_widget', function (Blueprint $table) {
+            $table->foreignId('btm_gadget_id');
+            $table->foreignId('btm_widget_id');
+        });
+    });
 
-        // Build a lightweight component-like object exposing model + field.
-        $model = createPost(); // a Post resource (not User/Team)
-        $component = new class($model, [])
-        {
-            public $field;
+    afterEach(function () {
+        Schema::dropIfExists('btm_gadget_widget');
+        Schema::dropIfExists('btm_widgets');
+        Schema::dropIfExists('btm_gadgets');
+    });
 
-            public $model;
+    test('parentless context returns the target query unchanged', function () {
+        BtmWidget::create();
+        BtmWidget::create();
+        BtmWidget::create();
 
-            public function __construct($model, $field)
-            {
-                $this->model = $model;
-                $this->field = $field;
-            }
-        };
+        // Old behavior keyed a where('user_id', ...) off the *table* model — the
+        // very bug. With no parent there is nothing to scope by, so the field
+        // lists the full target set.
+        $component = belongsToManyComponent(['slug' => 'widgets']);
 
-        $query = User::query();
-        $scoped = $field->queryFor($query, $component);
+        $scoped = (new BelongsToMany)->queryFor(BtmWidget::query(), $component);
 
-        // Assert the where clause on user_id was applied.
-        $wheres = collect($scoped->getQuery()->wheres);
-        expect($wheres->contains(fn ($w) => ($w['column'] ?? null) === 'user_id'))->toBeTrue();
+        expect($scoped->count())->toBe(3);
+    });
+
+    test('scopes the target to the parent\'s related records for a non-User/Team pair', function () {
+        $gadget = BtmGadget::create();
+
+        $a = BtmWidget::create();
+        $b = BtmWidget::create();
+        BtmWidget::create(); // unrelated
+
+        $gadget->widgets()->attach([$a->id, $b->id]);
+
+        $component = belongsToManyComponent(['slug' => 'widgets'], $gadget);
+
+        $scoped = (new BelongsToMany)->queryFor(BtmWidget::query(), $component);
+
+        expect($scoped->pluck('id')->sort()->values()->all())
+            ->toBe([$a->id, $b->id]);
+    });
+
+    test('parent without a matching relation yields no rows', function () {
+        BtmWidget::create();
+        BtmWidget::create();
+
+        // Parent present, but no `widgets` relation on it — show nothing rather
+        // than leaking the full set.
+        $component = belongsToManyComponent(['slug' => 'widgets'], BtmWidget::create());
+
+        $scoped = (new BelongsToMany)->queryFor(BtmWidget::query(), $component);
+
+        expect($scoped->count())->toBe(0);
     });
 });
+
+describe('BelongsToMany Field Teams Tab (teams on)', function () {
+    beforeEach(function () {
+        if (! config('aura.teams')) {
+            $this->markTestSkipped('The Teams tab is a teams-on feature.');
+        }
+    });
+
+    test('lists exactly the teams the user belongs to', function () {
+        $member = User::factory()->create();
+
+        $t1 = Team::factory()->createQuietly(['user_id' => $this->user->id]);
+        $t2 = Team::factory()->createQuietly(['user_id' => $this->user->id]);
+        Team::factory()->createQuietly(['user_id' => $this->user->id]); // not a member
+
+        attachMembership($member, $t1);
+        attachMembership($member, $t2);
+
+        mountTeamsTabTable($member->refresh())->assertViewHas('rows', function ($rows) use ($t1, $t2) {
+            return collect($rows->items())->pluck('id')->sort()->values()->all()
+                === collect([$t1->id, $t2->id])->sort()->values()->all();
+        });
+    });
+
+    test('a user in no teams shows an empty list', function () {
+        $member = User::factory()->create();
+
+        Team::factory()->createQuietly(['user_id' => $this->user->id]);
+        Team::factory()->createQuietly(['user_id' => $this->user->id]);
+
+        mountTeamsTabTable($member->refresh())->assertViewHas('rows', function ($rows) {
+            return count($rows->items()) === 0;
+        });
+    });
+
+    test('viewing user A then user B never leaks A\'s teams into B\'s tab', function () {
+        $userA = User::factory()->create();
+        $userB = User::factory()->create();
+
+        $teamA = Team::factory()->createQuietly(['user_id' => $this->user->id]);
+        $teamB = Team::factory()->createQuietly(['user_id' => $this->user->id]);
+
+        attachMembership($userA, $teamA);
+        attachMembership($userB, $teamB);
+
+        mountTeamsTabTable($userA->refresh())->assertViewHas('rows', function ($rows) use ($teamA) {
+            return collect($rows->items())->pluck('id')->all() === [$teamA->id];
+        });
+
+        mountTeamsTabTable($userB->refresh())->assertViewHas('rows', function ($rows) use ($teamB) {
+            return collect($rows->items())->pluck('id')->all() === [$teamB->id];
+        });
+    });
+
+    test('the user view page renders the Teams tab for a member', function () {
+        $member = User::factory()->create();
+
+        // The member must share the acting admin's current team, otherwise
+        // TeamScope hides the record from the non-Global-Admin admin and the
+        // view 404/403s before the tab ever renders.
+        $currentTeam = Team::findOrFail($this->user->current_team_id);
+        attachMembership($member, $currentTeam);
+        attachMembership($member, Team::factory()->createQuietly(['user_id' => $this->user->id]));
+
+        Livewire::test(View::class, ['id' => $member->id, 'slug' => 'user'])
+            ->assertOk()
+            ->assertSee($member->name);
+    });
+});
+
+/**
+ * Minimal Eloquent models backing the generic (non-User/Team) many-to-many
+ * scoping tests. Their tables are created/dropped per test above.
+ */
+class BtmWidget extends Model
+{
+    protected $guarded = [];
+
+    protected $table = 'btm_widgets';
+}
+
+class BtmGadget extends Model
+{
+    protected $guarded = [];
+
+    protected $table = 'btm_gadgets';
+
+    public function widgets(): EloquentBelongsToMany
+    {
+        return $this->belongsToMany(BtmWidget::class, 'btm_gadget_widget', 'btm_gadget_id', 'btm_widget_id');
+    }
+}

--- a/tests/Feature/Fields/UserTeamsFieldTest.php
+++ b/tests/Feature/Fields/UserTeamsFieldTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Aura\Base\Fields\BelongsToMany;
+use Aura\Base\Fields\UserTeams;
+use Aura\Base\Resources\User;
+
+it('extends the parent-aware BelongsToMany field', function () {
+    expect(new UserTeams)->toBeInstanceOf(BelongsToMany::class);
+});
+
+it('renders the dedicated Membership editor on the view page instead of the has-many table', function () {
+    $field = new UserTeams;
+
+    // The generic BelongsToMany still edits through the has-many table, but the
+    // user View page (view()) renders the aura::user-teams Membership editor.
+    expect($field->view())->toBe('aura::fields.user-teams')
+        ->and($field->edit())->toBe('aura::fields.has-many');
+});
+
+it('is the type the User resource declares for its Teams tab', function () {
+    $teamsField = collect(User::getFields())->firstWhere('slug', 'teams');
+
+    expect($teamsField['type'])->toBe(UserTeams::class);
+})->skip(fn () => ! config('aura.teams'), 'The Teams tab is a teams-on feature.');

--- a/tests/Feature/Roles/CatalogUiTest.php
+++ b/tests/Feature/Roles/CatalogUiTest.php
@@ -11,6 +11,7 @@ use Aura\Base\Resources\Team;
 use Aura\Base\Resources\User;
 use Aura\Base\Tests\Resources\Post;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Schema;
 
@@ -172,6 +173,29 @@ describe('Global Roles are visibly marked read-only in a team context', function
             ->assertForbidden();
     });
 
+    it('refuses a team Super Admin restoring a Global Role (policy)', function () {
+        $superAdmin = createSuperAdmin();
+        $this->actingAs($superAdmin);
+
+        $globalRole = catalogGlobalRole('auditor');
+        $teamRole = catalogTeamRole($superAdmin->current_team_id, 'reviewer');
+
+        // A soft-deleted Global Role must not be restored back into the shared
+        // catalog by a single team, even though the team Super Admin clears every
+        // ability via hasBlanketAccess. Their own Team Role stays restorable.
+        expect(Gate::forUser($superAdmin)->denies('restore', $globalRole))->toBeTrue()
+            ->and(Gate::forUser($superAdmin)->allows('restore', $teamRole))->toBeTrue();
+    });
+
+    it('lets a Global Admin restore a Global Role (policy)', function () {
+        $ga = promoteToGlobalAdmin(createSuperAdmin());
+        $this->actingAs($ga);
+
+        $globalRole = catalogGlobalRole('auditor');
+
+        expect(Gate::forUser($ga)->allows('restore', $globalRole))->toBeTrue();
+    });
+
     it('lets a Global Admin edit and delete a Global Role', function () {
         $ga = promoteToGlobalAdmin(createSuperAdmin());
         $this->actingAs($ga);
@@ -329,5 +353,94 @@ describe('cross-team assignment stays refused', function () {
         $ids = Role::shadowResolved($superAdmin->current_team_id)->pluck('id');
 
         expect($ids)->not->toContain($foreignRole->id);
+    });
+
+    it('refuses assigning another team\'s role through the user form (403, no pivot written)', function () {
+        $superAdmin = createSuperAdmin();
+        $this->actingAs($superAdmin);
+        $teamId = $superAdmin->current_team_id;
+
+        $foreign = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $foreignRole = catalogTeamRole($foreign->id, 'foreign-role', ['name' => 'Foreign Role']);
+
+        // The target holds a benign Membership in the acting team (so the user is
+        // visible to edit); the attempt swaps in a role owned by another team.
+        $teamRole = catalogTeamRole($teamId, 'member', ['name' => 'Member']);
+        $target = User::factory()->create(['current_team_id' => $teamId]);
+        $target->roles()->attach($teamRole->id, ['team_id' => $teamId]);
+
+        livewire(Edit::class, ['slug' => 'user', 'id' => $target->id])
+            ->set('form.fields.roles', [$foreignRole->id])
+            ->call('save')
+            ->assertStatus(403);
+
+        // The foreign role was never written; the original Membership stands.
+        expect(DB::table('user_role')
+            ->where('user_id', $target->id)
+            ->where('role_id', $foreignRole->id)
+            ->exists())->toBeFalse();
+        $this->assertDatabaseHas('user_role', [
+            'team_id' => $teamId,
+            'user_id' => $target->id,
+            'role_id' => $teamRole->id,
+        ]);
+    });
+});
+
+// Spec: the merged picker must not just OFFER both origins — an assignment
+// driven end-to-end from each origin lands the correct role_id on the pivot.
+describe('assigning through the user-form picker records the right pivot per origin', function () {
+    it('assigns an unshadowed Global Role and records the global role_id', function () {
+        $superAdmin = createSuperAdmin();
+        $this->actingAs($superAdmin);
+        $teamId = $superAdmin->current_team_id;
+
+        $globalEditor = catalogGlobalRole('editor', ['name' => 'Global Editor']);
+
+        livewire(Create::class, ['slug' => 'user'])
+            ->set('form.fields.name', 'Global Assignee')
+            ->set('form.fields.email', 'global-assignee@example.com')
+            ->set('form.fields.password', 'Str0ng!Pass#2024')
+            ->set('form.fields.roles', [$globalEditor->id])
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $target = User::withoutGlobalScopes()->where('email', 'global-assignee@example.com')->first();
+
+        $this->assertDatabaseHas('user_role', [
+            'team_id' => $teamId,
+            'user_id' => $target->id,
+            'role_id' => $globalEditor->id,
+        ]);
+    });
+
+    it('assigns a Shadow (Team Role) and records the shadow role_id, not the global row', function () {
+        $superAdmin = createSuperAdmin();
+        $this->actingAs($superAdmin);
+        $teamId = $superAdmin->current_team_id;
+
+        $globalEditor = catalogGlobalRole('editor', ['name' => 'Global Editor']);
+        $shadow = catalogTeamRole($teamId, 'editor', ['name' => 'Team Editor']);
+
+        livewire(Create::class, ['slug' => 'user'])
+            ->set('form.fields.name', 'Shadow Assignee')
+            ->set('form.fields.email', 'shadow-assignee@example.com')
+            ->set('form.fields.password', 'Str0ng!Pass#2024')
+            ->set('form.fields.roles', [$shadow->id])
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $target = User::withoutGlobalScopes()->where('email', 'shadow-assignee@example.com')->first();
+
+        $this->assertDatabaseHas('user_role', [
+            'team_id' => $teamId,
+            'user_id' => $target->id,
+            'role_id' => $shadow->id,
+        ]);
+        $this->assertDatabaseMissing('user_role', [
+            'team_id' => $teamId,
+            'user_id' => $target->id,
+            'role_id' => $globalEditor->id,
+        ]);
     });
 });

--- a/tests/Feature/Roles/CatalogUiTest.php
+++ b/tests/Feature/Roles/CatalogUiTest.php
@@ -1,0 +1,333 @@
+<?php
+
+use Aura\Base\Database\Seeders\RoleCatalogSeeder;
+use Aura\Base\Fields\Roles as RolesField;
+use Aura\Base\Livewire\InviteUser;
+use Aura\Base\Livewire\Resource\Create;
+use Aura\Base\Livewire\Resource\Edit;
+use Aura\Base\Livewire\Table\Table;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Aura\Base\Tests\Resources\Post;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Schema;
+
+use function Pest\Livewire\livewire;
+
+// Catalog management UI (issue #52): the merged, shadow-resolved Roles index,
+// Global Roles marked read-only in a team context, the Global-Admin-only global
+// toggle, and role pickers offering the same resolved set. Assertions observe
+// behaviour at the seams (index query, policy gate, form save, picker options),
+// never internal call structure.
+
+beforeEach(function () {
+    if (! Schema::hasTable('teams')) {
+        $this->markTestSkipped('Catalog management UI is a teams-on concern.');
+    }
+
+    RoleCatalogSeeder::seed();
+});
+
+/**
+ * A Global Role (team_id = null) written quietly so an authenticated actor's
+ * current team is never auto-applied by InitialPostFields. Bumps the catalog
+ * version the same way the seeder/self-heal path does.
+ */
+function catalogGlobalRole(string $slug, array $attributes = []): Role
+{
+    $role = Role::withoutGlobalScopes()->newModelInstance(array_merge([
+        'name' => ucfirst($slug),
+        'slug' => $slug,
+        'super_admin' => false,
+        'permissions' => [],
+        'team_id' => null,
+    ], $attributes));
+
+    $role->saveQuietly();
+    Role::bumpCatalogVersion();
+
+    return $role->refresh();
+}
+
+/**
+ * A Team Role (a Shadow when its slug matches a Global Role) for the given team.
+ */
+function catalogTeamRole(int $teamId, string $slug, array $attributes = []): Role
+{
+    return Role::withoutGlobalScopes()->create(array_merge([
+        'name' => ucfirst($slug),
+        'slug' => $slug,
+        'super_admin' => false,
+        'permissions' => [],
+        'team_id' => $teamId,
+    ], $attributes));
+}
+
+/** Promote an existing team Super Admin to Global Admin (trusted, quiet write). */
+function promoteToGlobalAdmin(User $user): User
+{
+    $user->forceFill(['global_admin' => true])->saveQuietly();
+
+    return $user->refresh();
+}
+
+describe('merged, shadow-resolved Roles index', function () {
+    it('lists a shadowed Global Role once, as the team version, and hides the global row', function () {
+        $user = createSuperAdmin();
+        $this->actingAs($user);
+        $teamId = $user->current_team_id;
+
+        $globalEditor = catalogGlobalRole('editor', ['name' => 'Global Editor']);
+        $shadow = catalogTeamRole($teamId, 'editor', ['name' => 'Team Editor']);
+
+        // The unpaginated query the Roles table actually runs.
+        $ids = livewire(Table::class, ['query' => null, 'model' => new Role])
+            ->instance()->rowsQuery()->pluck('id');
+
+        // 'editor' appears exactly once — the team's Shadow — and the global row
+        // is hidden in this team context.
+        expect($ids)->toContain($shadow->id)
+            ->and($ids)->not->toContain($globalEditor->id);
+
+        $editorRows = Role::withoutGlobalScopes()
+            ->whereIn('id', $ids)
+            ->where('slug', 'editor')
+            ->count();
+
+        expect($editorRows)->toBe(1);
+    });
+
+    it('still shows the Global Role to a different team that has no Shadow', function () {
+        $owner = createSuperAdmin();
+        $this->actingAs($owner);
+        $ownerTeam = $owner->current_team_id;
+
+        $globalEditor = catalogGlobalRole('editor', ['name' => 'Global Editor']);
+        catalogTeamRole($ownerTeam, 'editor', ['name' => 'Team Editor']);
+
+        // A second, independent team + Super Admin that does NOT shadow editor.
+        $other = createSuperAdmin();
+        $this->actingAs($other);
+
+        $ids = livewire(Table::class, ['query' => null, 'model' => new Role])
+            ->instance()->rowsQuery()->pluck('id');
+
+        expect($ids)->toContain($globalEditor->id);
+    });
+
+    it('leaves the flat index untouched in Teams-off mode', function () {
+        // (Guarded by the teams-on skip in beforeEach; documented for parity —
+        // the Teams-off assertions live in the without-teams describe below.)
+        expect(config('aura.teams'))->toBeTrue();
+    });
+});
+
+describe('Global Roles are visibly marked read-only in a team context', function () {
+    it('renders a Global badge on a Global Role row and none on a Team Role row', function () {
+        $user = createSuperAdmin();
+        $this->actingAs($user);
+        $teamId = $user->current_team_id;
+
+        $globalRole = catalogGlobalRole('auditor', ['name' => 'Auditor']);
+        $teamRole = catalogTeamRole($teamId, 'reviewer', ['name' => 'Reviewer']);
+
+        // The name column's display carries the badge only for global rows.
+        expect($globalRole->display('name'))->toContain('Global')
+            ->and($teamRole->display('name'))->not->toContain('Global');
+    });
+
+    it('shows the Global marker in the rendered Roles index', function () {
+        $user = createSuperAdmin();
+        $this->actingAs($user);
+
+        catalogGlobalRole('auditor', ['name' => 'Auditor']);
+
+        livewire(Table::class, ['query' => null, 'model' => new Role])
+            ->assertSee('Global');
+    });
+
+    it('refuses a team Super Admin editing a Global Role (policy)', function () {
+        $superAdmin = createSuperAdmin();
+        $this->actingAs($superAdmin);
+
+        $globalRole = catalogGlobalRole('auditor');
+        $teamRole = catalogTeamRole($superAdmin->current_team_id, 'reviewer');
+
+        expect(Gate::forUser($superAdmin)->denies('update', $globalRole))->toBeTrue()
+            ->and(Gate::forUser($superAdmin)->denies('delete', $globalRole))->toBeTrue()
+            // Their own Team Role stays fully manageable.
+            ->and(Gate::forUser($superAdmin)->allows('update', $teamRole))->toBeTrue()
+            ->and(Gate::forUser($superAdmin)->allows('delete', $teamRole))->toBeTrue();
+    });
+
+    it('refuses a team Super Admin opening the Global Role edit form (403)', function () {
+        $superAdmin = createSuperAdmin();
+        $this->actingAs($superAdmin);
+
+        $globalRole = catalogGlobalRole('auditor');
+
+        livewire(Edit::class, ['slug' => 'role', 'id' => $globalRole->id])
+            ->assertForbidden();
+    });
+
+    it('lets a Global Admin edit and delete a Global Role', function () {
+        $ga = promoteToGlobalAdmin(createSuperAdmin());
+        $this->actingAs($ga);
+
+        $globalRole = catalogGlobalRole('auditor');
+
+        expect(Gate::forUser($ga)->allows('update', $globalRole))->toBeTrue()
+            ->and(Gate::forUser($ga)->allows('delete', $globalRole))->toBeTrue();
+
+        livewire(Edit::class, ['slug' => 'role', 'id' => $globalRole->id])
+            ->set('form.fields.description', 'Edited by the Global Admin')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        expect($globalRole->fresh()->description)->toBe('Edited by the Global Admin')
+            ->and($globalRole->fresh()->team_id)->toBeNull();
+    });
+});
+
+describe('the Global Admin manages the catalog through the Role form', function () {
+    it('creates a Global Role when a Global Admin checks the global toggle', function () {
+        $ga = promoteToGlobalAdmin(createSuperAdmin());
+        $this->actingAs($ga);
+
+        livewire(Create::class, ['slug' => 'role'])
+            ->set('form.fields.name', 'Continent')
+            ->set('form.fields.slug', 'continent')
+            ->set('form.fields.is_global', true)
+            ->call('save');
+
+        $role = Role::withoutGlobalScopes()->where('slug', 'continent')->first();
+
+        expect($role)->not->toBeNull()
+            ->and($role->team_id)->toBeNull();
+    });
+
+    it('keeps the role team-scoped when a non-Global-Admin sneaks the global toggle into the payload', function () {
+        $superAdmin = createSuperAdmin(); // Team Super Admin, NOT a Global Admin
+        $this->actingAs($superAdmin);
+        $teamId = $superAdmin->current_team_id;
+
+        // Form tampering: the toggle is hidden client-side, but the value is
+        // submitted anyway.
+        livewire(Create::class, ['slug' => 'role'])
+            ->set('form.fields.name', 'Sneaky')
+            ->set('form.fields.slug', 'sneaky')
+            ->set('form.fields.is_global', true)
+            ->call('save');
+
+        $role = Role::withoutGlobalScopes()->where('slug', 'sneaky')->first();
+
+        expect($role)->not->toBeNull()
+            ->and($role->team_id)->toBe($teamId); // team-scoped, no escalation
+    });
+});
+
+describe('a team Super Admin creates Team Roles including Shadows', function () {
+    it('creates a Shadow of a Global Role by slug through the form, flipping permissions live', function () {
+        $superAdmin = createSuperAdmin();
+        $this->actingAs($superAdmin);
+        $teamId = $superAdmin->current_team_id;
+
+        // A member holding the global "editor" role in this team.
+        $globalEditor = catalogGlobalRole('editor', ['permissions' => ['view-post' => true]]);
+
+        $member = User::factory()->create();
+        $member->forceFill(['current_team_id' => $teamId])->save();
+        $member->roles()->syncWithPivotValues([$globalEditor->id], ['team_id' => $teamId]);
+        Cache::forget("user_{$member->id}_current_team_id");
+        $member->refresh();
+
+        // Before the Shadow: the global definition applies.
+        expect($member->hasPermissionTo('view', new Post))->toBeTrue()
+            ->and($member->hasPermissionTo('delete', new Post))->toBeFalse();
+
+        // The team Super Admin creates a Team Role with the SAME slug (a Shadow)
+        // through the ordinary Role create form — no unique-slug rejection.
+        livewire(Create::class, ['slug' => 'role'])
+            ->set('form.fields.name', 'Team Editor')
+            ->set('form.fields.slug', 'editor')
+            ->set('form.fields.permissions', ['delete-post' => true])
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $shadow = Role::withoutGlobalScopes()
+            ->where('slug', 'editor')
+            ->where('team_id', $teamId)
+            ->first();
+
+        expect($shadow)->not->toBeNull()
+            ->and($shadow->team_id)->toBe($teamId);
+
+        // The permission outcome flips instantly through the resolution seam,
+        // with no pivot rewrite.
+        $member->refresh();
+        expect($member->hasPermissionTo('view', new Post))->toBeFalse()
+            ->and($member->hasPermissionTo('delete', new Post))->toBeTrue();
+    });
+});
+
+describe('role pickers offer the merged, shadow-resolved set', function () {
+    it('offers the invitation modal the resolved set — each slug once, Shadow winning', function () {
+        $superAdmin = createSuperAdmin();
+        $this->actingAs($superAdmin);
+        $teamId = $superAdmin->current_team_id;
+
+        $globalEditor = catalogGlobalRole('editor', ['name' => 'Global Editor']);
+        $shadow = catalogTeamRole($teamId, 'editor', ['name' => 'Team Editor']);
+
+        $options = collect(InviteUser::getFields())->firstWhere('slug', 'role')['options'];
+
+        expect($options)->toHaveKey($shadow->id)          // the Shadow is offered
+            ->and($options)->not->toHaveKey($globalEditor->id) // the global row is not
+            ->and(array_keys($options, 'Team Editor', true))->toHaveCount(1);
+    });
+
+    it('offers the user-form Roles picker the same resolved set (each slug once)', function () {
+        $superAdmin = createSuperAdmin();
+        $this->actingAs($superAdmin);
+        $teamId = $superAdmin->current_team_id;
+
+        $globalEditor = catalogGlobalRole('editor', ['name' => 'Global Editor']);
+        $shadow = catalogTeamRole($teamId, 'editor', ['name' => 'Team Editor']);
+
+        $request = (object) [
+            'model' => Role::class,
+            'search' => '',
+            'fullField' => [
+                'name' => 'Role',
+                'slug' => 'roles',
+                'resource' => Role::class,
+                'type' => RolesField::class,
+                'multiple' => false,
+                'polymorphic_relation' => true,
+            ],
+        ];
+
+        $ids = collect((new RolesField)->api($request))->pluck('id');
+
+        expect($ids)->toContain($shadow->id)
+            ->and($ids)->not->toContain($globalEditor->id)
+            ->and($ids->filter(fn ($id) => $id === $shadow->id))->toHaveCount(1);
+    });
+});
+
+describe('cross-team assignment stays refused', function () {
+    it('does not offer or accept another team\'s role in the picker', function () {
+        $superAdmin = createSuperAdmin();
+        $this->actingAs($superAdmin);
+
+        // A role owned by an unrelated team.
+        $foreign = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $foreignRole = catalogTeamRole($foreign->id, 'foreign-role', ['name' => 'Foreign Role']);
+
+        $ids = Role::shadowResolved($superAdmin->current_team_id)->pluck('id');
+
+        expect($ids)->not->toContain($foreignRole->id);
+    });
+});

--- a/tests/Feature/Team/InvitationGlobalRoleTest.php
+++ b/tests/Feature/Team/InvitationGlobalRoleTest.php
@@ -88,6 +88,65 @@ it('lets a new user register through an invitation carrying a global role id', f
     expect(TeamInvitation::withoutGlobalScopes()->whereKey($invitation->id)->exists())->toBeFalse();
 });
 
+it('lets an existing user accept an invitation carrying a team Shadow role id', function () {
+    $team = $this->user->currentTeam;
+
+    // A Global Role and the current team's Shadow of it (same slug, team-owned).
+    // saveQuietly keeps the global row's team_id null (no auto-team from the
+    // acting user's context).
+    $global = Role::withoutGlobalScopes()->newModelInstance([
+        'name' => 'Global Editor',
+        'slug' => 'editor',
+        'super_admin' => false,
+        'permissions' => [],
+        'team_id' => null,
+    ]);
+    $global->saveQuietly();
+
+    $shadow = Role::withoutGlobalScopes()->create([
+        'name' => 'Team Editor',
+        'slug' => 'editor',
+        'super_admin' => false,
+        'permissions' => [],
+        'team_id' => $team->id,
+    ]);
+
+    $existingUser = User::factory()->create([
+        'email' => 'existing-shadow@example.com',
+        'current_team_id' => null,
+    ]);
+
+    $invitation = TeamInvitation::create([
+        'team_id' => $team->id,
+        'email' => $existingUser->email,
+        'role' => $shadow->id,
+    ]);
+
+    $url = URL::temporarySignedRoute(
+        'aura.team-invitations.accept',
+        now()->addDays(config('aura.auth.invitation_expiry')),
+        ['invitation' => $invitation],
+    );
+
+    $this->actingAs($existingUser)
+        ->get($url)
+        ->assertRedirect(route('aura.dashboard'));
+
+    // The Membership carries the Shadow (team) role id, not the global row.
+    $this->assertDatabaseHas('user_role', [
+        'team_id' => $team->id,
+        'user_id' => $existingUser->id,
+        'role_id' => $shadow->id,
+    ]);
+    $this->assertDatabaseMissing('user_role', [
+        'team_id' => $team->id,
+        'user_id' => $existingUser->id,
+        'role_id' => $global->id,
+    ]);
+
+    expect($existingUser->fresh()->current_team_id)->toBe($team->id);
+});
+
 it('still refuses an invitation whose role belongs to another team', function () {
     $team = $this->user->currentTeam;
     $otherTeam = Team::factory()->createQuietly();

--- a/tests/Feature/Users/MembershipEditorTest.php
+++ b/tests/Feature/Users/MembershipEditorTest.php
@@ -4,6 +4,7 @@ use Aura\Base\Livewire\UserTeams;
 use Aura\Base\Resources\Role;
 use Aura\Base\Resources\Team;
 use Aura\Base\Resources\User;
+use Aura\Base\Tests\Resources\Post;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
@@ -394,6 +395,60 @@ describe('Constraints and guards', function () {
             ->assertHasNoErrors();
 
         expect(Cache::has('user.'.$viewed->id.'.teams'))->toBeFalse();
+    });
+});
+
+describe('Membership changes take effect in permission checks', function () {
+    it('flips the user permission outcome when the role is changed (fresh instance)', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $team = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $adminRole = membershipRole($team->id, ['name' => 'Team Admin', 'super_admin' => true]);
+        $userRole = membershipRole($team->id, [
+            'name' => 'Plain User',
+            'super_admin' => false,
+            'permissions' => ['view-post' => true],
+        ]);
+
+        $viewed = User::factory()->create(['current_team_id' => $team->id]);
+        attachMember($viewed, $team->id, $adminRole->id);
+
+        // Baseline: the Super Admin role clears every check.
+        expect(User::find($viewed->id)->isSuperAdmin())->toBeTrue();
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->call('changeRole', $team->id, $userRole->id)
+            ->assertHasNoErrors();
+
+        // A FRESH instance resolves the downgraded role: no longer Super Admin,
+        // and now bound to exactly the plain role's granted permission.
+        $fresh = User::find($viewed->id);
+        expect($fresh->isSuperAdmin())->toBeFalse()
+            ->and($fresh->hasPermissionTo('view', new Post))->toBeTrue()
+            ->and($fresh->hasPermissionTo('delete', new Post))->toBeFalse();
+    });
+
+    it('removes the user permission in a team when detached (fresh instance)', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $team = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $adminRole = membershipRole($team->id, ['name' => 'Team Admin', 'super_admin' => true]);
+
+        $viewed = User::factory()->create(['current_team_id' => $team->id]);
+        attachMember($viewed, $team->id, $adminRole->id);
+
+        expect(User::find($viewed->id)->isSuperAdmin())->toBeTrue();
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->call('detach', $team->id)
+            ->assertHasNoErrors();
+
+        // The Membership is gone; the resolved role set is empty.
+        $fresh = User::find($viewed->id);
+        expect($fresh->isSuperAdmin())->toBeFalse()
+            ->and($fresh->hasPermissionTo('view', new Post))->toBeFalse();
     });
 });
 

--- a/tests/Feature/Users/MembershipEditorTest.php
+++ b/tests/Feature/Users/MembershipEditorTest.php
@@ -1,0 +1,414 @@
+<?php
+
+use Aura\Base\Livewire\UserTeams;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+use function Pest\Livewire\livewire;
+
+/**
+ * A Team Role owned by the given team, unscoped so it can be created regardless
+ * of the acting user's current team.
+ */
+function membershipRole(int $teamId, array $attributes = []): Role
+{
+    return Role::withoutGlobalScopes()->create(array_merge([
+        'type' => 'Role',
+        'name' => 'Member',
+        'slug' => 'member-'.$teamId.'-'.uniqid(),
+        'super_admin' => false,
+        'permissions' => [],
+        'team_id' => $teamId,
+    ], $attributes));
+}
+
+/**
+ * A Global Role (team_id = null) in the shared catalog. Written with
+ * saveQuietly() so the InitialPostFields saving hook does not re-team the null
+ * team_id to the current team — the same posture Role::firstOrCreateCatalogRole
+ * uses.
+ */
+function catalogRole(string $slug, string $name, bool $superAdmin = false): Role
+{
+    $role = Role::withoutGlobalScopes()->newModelInstance([
+        'type' => 'Role',
+        'name' => $name,
+        'slug' => $slug,
+        'super_admin' => $superAdmin,
+        'permissions' => [],
+        'team_id' => null,
+    ]);
+
+    $role->saveQuietly();
+
+    return $role;
+}
+
+/** Record a Membership: user in $team with role $roleId (pivot team_id). */
+function attachMember(User $user, int $teamId, int $roleId): void
+{
+    $user->roles()->attach($roleId, ['team_id' => $teamId]);
+}
+
+/** The pivot row for a (user, team) Membership, unscoped. */
+function membershipPivot(int $userId, int $teamId): ?object
+{
+    return DB::table('user_role')
+        ->where('user_id', $userId)
+        ->where('team_id', $teamId)
+        ->first();
+}
+
+beforeEach(function () {
+    if (! config('aura.teams')) {
+        $this->markTestSkipped('The Membership editor is a teams-on feature.');
+    }
+});
+
+describe('Membership editor display', function () {
+    it('shows each team with the role resolved through the catalog seam (shadow wins)', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $team1 = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $team2 = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+
+        // A Global Role 'editor' and a team1 Shadow of it with a different name.
+        $globalEditor = catalogRole('editor', 'Global Editor');
+        $team1Shadow = membershipRole($team1->id, ['slug' => 'editor', 'name' => 'Team1 Editor']);
+
+        // Plain role in team2.
+        $team2Role = membershipRole($team2->id, ['name' => 'Team2 Member']);
+
+        $viewed = User::factory()->create();
+        // The pivot stores the GLOBAL editor id; team1 shadows 'editor', so it
+        // must display as the Shadow's name — proving resolution by slug.
+        attachMember($viewed, $team1->id, $globalEditor->id);
+        attachMember($viewed, $team2->id, $team2Role->id);
+
+        $rows = collect(livewire(UserTeams::class, ['userId' => $viewed->id])->instance()->memberships);
+
+        expect($rows)->toHaveCount(2);
+
+        $row1 = $rows->firstWhere('team_id', $team1->id);
+        $row2 = $rows->firstWhere('team_id', $team2->id);
+
+        expect($row1['role_name'])->toBe('Team1 Editor')
+            ->and($row1['role_id'])->toBe($team1Shadow->id)
+            ->and($row2['role_name'])->toBe('Team2 Member');
+    });
+});
+
+describe('Global Admin management', function () {
+    it('attaches the viewed user to any team with a chosen role', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $team = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $role = membershipRole($team->id);
+        $viewed = User::factory()->create();
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->set('attachTeamId', $team->id)
+            ->set('attachRoleId', $role->id)
+            ->call('attach')
+            ->assertHasNoErrors();
+
+        $pivot = membershipPivot($viewed->id, $team->id);
+        expect($pivot)->not->toBeNull()
+            ->and((int) $pivot->role_id)->toBe($role->id)
+            ->and((int) $pivot->team_id)->toBe($team->id);
+    });
+
+    it('changes the per-team role', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $team = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $roleA = membershipRole($team->id, ['name' => 'Role A']);
+        $roleB = membershipRole($team->id, ['name' => 'Role B']);
+        $viewed = User::factory()->create();
+        attachMember($viewed, $team->id, $roleA->id);
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->call('changeRole', $team->id, $roleB->id)
+            ->assertHasNoErrors();
+
+        expect((int) membershipPivot($viewed->id, $team->id)->role_id)->toBe($roleB->id);
+        // Still exactly one Membership row for that team.
+        expect(DB::table('user_role')->where('user_id', $viewed->id)->where('team_id', $team->id)->count())->toBe(1);
+    });
+
+    it('detaches a Membership', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $team = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $role = membershipRole($team->id);
+        $viewed = User::factory()->create();
+        attachMember($viewed, $team->id, $role->id);
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->call('detach', $team->id)
+            ->assertHasNoErrors();
+
+        expect(membershipPivot($viewed->id, $team->id))->toBeNull();
+    });
+
+    it('falls the current team back when detaching it', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $teamA = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $teamB = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $roleA = membershipRole($teamA->id);
+        $roleB = membershipRole($teamB->id);
+
+        $viewed = User::factory()->create();
+        attachMember($viewed, $teamA->id, $roleA->id);
+        attachMember($viewed, $teamB->id, $roleB->id);
+        $viewed->forceFill(['current_team_id' => $teamA->id])->save();
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->call('detach', $teamA->id)
+            ->assertHasNoErrors();
+
+        // Fell back to the remaining Membership (teamB).
+        expect((int) $viewed->fresh()->current_team_id)->toBe($teamB->id);
+    });
+
+    it('falls the current team back to null when no Membership remains', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $teamA = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $roleA = membershipRole($teamA->id);
+
+        $viewed = User::factory()->create();
+        attachMember($viewed, $teamA->id, $roleA->id);
+        $viewed->forceFill(['current_team_id' => $teamA->id])->save();
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->call('detach', $teamA->id)
+            ->assertHasNoErrors();
+
+        expect($viewed->fresh()->current_team_id)->toBeNull();
+    });
+});
+
+describe('Team Super Admin management (team-scoped)', function () {
+    it('lets a team Super Admin manage Memberships for their own team', function () {
+        $actor = createSuperAdmin();
+        $teamX = $actor->currentTeam;
+        $this->actingAs($actor);
+
+        $role = membershipRole($teamX->id);
+        $viewed = User::factory()->create();
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->set('attachTeamId', $teamX->id)
+            ->set('attachRoleId', $role->id)
+            ->call('attach')
+            ->assertHasNoErrors();
+
+        expect(membershipPivot($viewed->id, $teamX->id))->not->toBeNull();
+
+        $role2 = membershipRole($teamX->id, ['name' => 'Second']);
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->call('changeRole', $teamX->id, $role2->id)
+            ->assertHasNoErrors();
+
+        expect((int) membershipPivot($viewed->id, $teamX->id)->role_id)->toBe($role2->id);
+    });
+
+    it('refuses (403) an operation submitted for a team the actor does not administer, with no pivot change', function () {
+        $actor = createSuperAdmin();
+        $this->actingAs($actor);
+
+        $teamY = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $roleY = membershipRole($teamY->id);
+        $viewed = User::factory()->create();
+        attachMember($viewed, $teamY->id, $roleY->id);
+
+        // Detach for a foreign team → 403 and Membership intact.
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->call('detach', $teamY->id)
+            ->assertStatus(403);
+
+        expect((int) membershipPivot($viewed->id, $teamY->id)->role_id)->toBe($roleY->id);
+
+        // Change role for a foreign team → 403 and role unchanged.
+        $otherRole = membershipRole($teamY->id, ['name' => 'Other']);
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->call('changeRole', $teamY->id, $otherRole->id)
+            ->assertStatus(403);
+
+        expect((int) membershipPivot($viewed->id, $teamY->id)->role_id)->toBe($roleY->id);
+    });
+
+    it('marks rows for teams the actor cannot manage as read-only', function () {
+        $actor = createSuperAdmin();
+        $teamX = $actor->currentTeam;
+        $this->actingAs($actor);
+
+        $teamY = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $roleX = membershipRole($teamX->id);
+        $roleY = membershipRole($teamY->id);
+
+        $viewed = User::factory()->create();
+        attachMember($viewed, $teamX->id, $roleX->id);
+        attachMember($viewed, $teamY->id, $roleY->id);
+
+        $rows = collect(livewire(UserTeams::class, ['userId' => $viewed->id])->instance()->memberships);
+
+        expect($rows->firstWhere('team_id', $teamX->id)['can_manage'])->toBeTrue()
+            ->and($rows->firstWhere('team_id', $teamY->id)['can_manage'])->toBeFalse();
+    });
+});
+
+describe('Constraints and guards', function () {
+    it('refuses attaching to a team the user already belongs to (validation, single row kept)', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $team = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $role = membershipRole($team->id);
+        $viewed = User::factory()->create();
+        attachMember($viewed, $team->id, $role->id);
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->set('attachTeamId', $team->id)
+            ->set('attachRoleId', $role->id)
+            ->call('attach')
+            ->assertHasErrors('attachTeamId');
+
+        expect(DB::table('user_role')->where('user_id', $viewed->id)->where('team_id', $team->id)->count())->toBe(1);
+    });
+
+    it('refuses a role owned by another team', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $team = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $otherTeam = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $foreignRole = membershipRole($otherTeam->id);
+        $viewed = User::factory()->create();
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->set('attachTeamId', $team->id)
+            ->set('attachRoleId', $foreignRole->id)
+            ->call('attach')
+            ->assertStatus(403);
+
+        expect(membershipPivot($viewed->id, $team->id))->toBeNull();
+    });
+
+    it('refuses a Global Role submitted by its hidden id when the team shadows that slug', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $team = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $globalEditor = catalogRole('editor', 'Global Editor');
+        membershipRole($team->id, ['slug' => 'editor', 'name' => 'Team Editor']); // Shadow
+
+        $viewed = User::factory()->create();
+
+        // The shadowed Global Role's id is not in the team's assignable set.
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->set('attachTeamId', $team->id)
+            ->set('attachRoleId', $globalEditor->id)
+            ->call('attach')
+            ->assertStatus(403);
+
+        expect(membershipPivot($viewed->id, $team->id))->toBeNull();
+    });
+
+    it('refuses a non-super-admin actor granting a Super Admin role (escalation guard)', function () {
+        // A delegated user-manager (not a Super Admin) in the team.
+        $owner = User::factory()->create();
+        $team = Team::factory()->createQuietly(['user_id' => $owner->id]);
+
+        $managerRole = membershipRole($team->id, [
+            'name' => 'User Manager',
+            'permissions' => ['viewAny-user' => true, 'view-user' => true, 'update-user' => true],
+        ]);
+        $manager = User::factory()->create(['current_team_id' => $team->id]);
+        attachMember($manager, $team->id, $managerRole->id);
+
+        $superAdminRole = catalogRole('admin-escalation', 'Escalation Admin', true);
+
+        $viewed = User::factory()->create();
+        $this->actingAs($manager);
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->set('attachTeamId', $team->id)
+            ->set('attachRoleId', $superAdminRole->id)
+            ->call('attach')
+            ->assertStatus(403);
+
+        expect(membershipPivot($viewed->id, $team->id))->toBeNull();
+    });
+
+    it('renders read-only and refuses operations for a regular member', function () {
+        $owner = User::factory()->create();
+        $team = Team::factory()->createQuietly(['user_id' => $owner->id]);
+        $memberRole = membershipRole($team->id, ['name' => 'Plain Member']);
+
+        $actor = User::factory()->create(['current_team_id' => $team->id]);
+        attachMember($actor, $team->id, $memberRole->id);
+
+        $viewed = User::factory()->create();
+        attachMember($viewed, $team->id, $memberRole->id);
+
+        $this->actingAs($actor);
+
+        // Read-only in the rendered data.
+        $rows = collect(livewire(UserTeams::class, ['userId' => $viewed->id])->instance()->memberships);
+        expect($rows->firstWhere('team_id', $team->id)['can_manage'])->toBeFalse();
+
+        // And server-side refusal.
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->call('detach', $team->id)
+            ->assertStatus(403);
+
+        expect(membershipPivot($viewed->id, $team->id))->not->toBeNull();
+    });
+
+    it('clears the viewed user team cache after a Membership change', function () {
+        $ga = createGlobalAdmin();
+        $this->actingAs($ga);
+
+        $team = Team::factory()->createQuietly(['user_id' => User::factory()->create()->id]);
+        $role = membershipRole($team->id);
+        $viewed = User::factory()->create();
+
+        Cache::put('user.'.$viewed->id.'.teams', collect(['stale']), now()->addHour());
+
+        livewire(UserTeams::class, ['userId' => $viewed->id])
+            ->set('attachTeamId', $team->id)
+            ->set('attachRoleId', $role->id)
+            ->call('attach')
+            ->assertHasNoErrors();
+
+        expect(Cache::has('user.'.$viewed->id.'.teams'))->toBeFalse();
+    });
+});
+
+describe('Teams-off guard', function () {
+    it('404s the component when teams are disabled', function () {
+        $teamsEnabled = config('aura.teams');
+        config(['aura.teams' => false]);
+
+        $viewed = User::factory()->create();
+
+        try {
+            livewire(UserTeams::class, ['userId' => $viewed->id])
+                ->assertStatus(404);
+        } finally {
+            config(['aura.teams' => $teamsEnabled]);
+        }
+    });
+});

--- a/tests/FeatureWithDatabaseMigrations/RoleResolutionWithoutTeamsTest.php
+++ b/tests/FeatureWithDatabaseMigrations/RoleResolutionWithoutTeamsTest.php
@@ -1,9 +1,13 @@
 <?php
 
 use Aura\Base\Database\Seeders\RoleCatalogSeeder;
+use Aura\Base\Livewire\Resource\Create;
+use Aura\Base\Livewire\Table\Table;
 use Aura\Base\Resources\Role;
 use Aura\Base\Resources\User;
 use Illuminate\Support\Facades\Schema;
+
+use function Pest\Livewire\livewire;
 
 // Teams-off behavior of the Role Catalog: there is a single flat catalog, so the
 // Global Roles simply are the roles. A fresh install seeds `admin` and `user`,
@@ -73,6 +77,51 @@ describe('Teams-off permission checks via the seam', function () {
         expect($plain->isSuperAdmin())->toBeFalse();
         expect($plain->hasPermission('delete-post'))->toBeFalse();
         expect($plain->hasRole('user'))->toBeTrue();
+    });
+});
+
+describe('Teams-off catalog UI (issue #52)', function () {
+    it('leaves the Roles index a flat set with no Global marker', function () {
+        $admin = User::factory()->create();
+        $admin->roles()->sync([Role::resolveForTeam('admin', null)->id]);
+        $this->actingAs($admin->refresh());
+
+        // The seeded catalog roles simply ARE the roles — no dedup, no badge.
+        $ids = livewire(Table::class, ['query' => null, 'model' => new Role])
+            ->instance()->rowsQuery()->pluck('id');
+
+        expect($ids)->toContain(Role::where('slug', 'admin')->value('id'))
+            ->toContain(Role::where('slug', 'user')->value('id'));
+
+        // No team_id column means no Global Role concept and no badge.
+        expect(Role::where('slug', 'admin')->first()->display('name'))->not->toContain('Global');
+    });
+
+    it('hides the global toggle from the Role form in Teams-off mode', function () {
+        $admin = User::factory()->create();
+        $admin->roles()->sync([Role::resolveForTeam('admin', null)->id]);
+        $this->actingAs($admin->refresh());
+
+        $isGlobalField = collect((new Role)->getFields())->firstWhere('slug', 'is_global');
+
+        // The field is declared but its conditional_logic hides it entirely when
+        // teams are off (no global/team distinction exists).
+        expect(($isGlobalField['conditional_logic'])(new Role, null))->toBeFalse();
+    });
+
+    it('creates a role through the form without any global escalation surface', function () {
+        $admin = User::factory()->create();
+        $admin->roles()->sync([Role::resolveForTeam('admin', null)->id]);
+        $this->actingAs($admin->refresh());
+
+        livewire(Create::class, ['slug' => 'role'])
+            ->set('form.fields.name', 'Editor')
+            ->set('form.fields.slug', 'editor')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        expect(Role::where('slug', 'editor')->count())->toBe(1);
+        expect(Schema::hasColumn('roles', 'team_id'))->toBeFalse();
     });
 });
 


### PR DESCRIPTION
## Summary

PR 3 of the access-control stack (parent spec #45), stacked on #58. Fixes the bug that started this effort and completes the management UI.

- **Teams tab display fix** (#49): `BelongsToMany::queryFor` keyed off the embedded table's model instead of the parent — the user's Teams tab listed an unfiltered team set. Now parent-aware via a genuine relation subquery (composes with search/sort/pagination); parentless contexts unchanged; a parent without a matching relation shows nothing rather than leaking.
- **Merged catalog UI** (#52): the Roles index shows the shadow-resolved set (each slug once, Shadow wins); Global Roles carry a 'Global' badge and are server-side write-protected (update/delete/forceDelete/restore) against everyone but Global Admins — checked before blanket access so team Super Admin power can't rewrite the shared catalog. GAs promote roles via a guarded `is_global` toggle (transient intent → `team_id = null`, tampering yields a Team Role). Invite modal + user-form pickers offer the same merged set, with end-to-end assignment tests from both origins.
- **Membership editor** (#53): dedicated `aura::user-teams` component on the user's Teams tab — every Membership with its catalog-resolved role, per-row role change/remove, attach form per team's assignable set. Authorization is server-side and target-team-scoped: GA anywhere, team Super Admin only their teams, everyone else read-only; escalation guards on granting *and* removing super-admin roles; one role per team; current-team fallback on remove. Stable `dusk` selectors ship for the browser suite.

## Testing

- Teams-on: 1744 passed (5161 assertions) · Teams-off: 1425 passed · Browser: 12 passed · PHPStan: 0 · Pint clean
- New: BelongsToManyFieldTest team-branch coverage (previously untested — the bug lived there), CatalogUiTest (20+), MembershipEditorTest (19+), UserTeamsFieldTest
- Two-axis code review ran; all findings fixed in the follow-up commit (headline: permission-outcome assertions replacing cache-key assertions, and the `restore` gap in the global-role guard)

Closes #49. Closes #52. Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)