### PR TITLE
Freeze time in ValueWidgetTest to fix twice-daily CI flake

### DIFF
--- a/tests/Feature/Widgets/ValueWidgetTest.php
+++ b/tests/Feature/Widgets/ValueWidgetTest.php
@@ -7,6 +7,12 @@ use Livewire\Livewire;
 
 // Before each test, create a Superadmin and login
 beforeEach(function () {
+    // Freeze time: the posts are seeded relative to now() and the widget
+    // ranges are built from a later now() — crossing a second boundary in
+    // between (routine on loaded CI runners) drops the -15d post out of the
+    // window and flakes the calculation assertions.
+    Carbon::setTestNow(Carbon::now());
+
     $this->actingAs($this->user = createSuperAdmin());
 
     // Create 3 posts before each test


### PR DESCRIPTION
The posts are seeded relative to `now()` in `beforeEach` and the widget window is built from a later `now()` in the test body. Crossing a second boundary between the two — routine on loaded CI runners — pushes the `-15d` post out of the current window and flakes the calculation assertions (`current` becomes `'0'`).

Hit twice today: release/v1's Laravel 12 job and main's Laravel 13 job. One line: `Carbon::setTestNow(Carbon::now())` in `beforeEach` (Laravel resets test-now in tearDown). The same commit goes to release/v1 directly to keep the release merge conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SfSSvBDCogBXr2PfhC6MM