### PR TITLE
fix: honor aura.media.disk and aura.media.path across the media pipeline

### DIFF
--- a/config/aura.php
+++ b/config/aura.php
@@ -200,6 +200,10 @@ return [
     */
 
     'media' => [
+        // Filesystem disk (config/filesystems.php) that uploads, thumbnails and
+        // served images live on, plus the base folder within that disk. The
+        // defaults keep media on the public disk under `media/`; point them at
+        // e.g. an S3 disk to store uploads off the local filesystem.
         'disk' => 'public',
         'path' => 'media',
         'quality' => 80,

--- a/resources/views/components/fields/embed.blade.php
+++ b/resources/views/components/fields/embed.blade.php
@@ -1,3 +1,3 @@
 <x-aura::fields.wrapper :field="$field">
-    <embed type="{{ $this->model->mime_type }}" src="/storage/{{ $this->model->url }}" class="w-full">
+    <embed type="{{ $this->model->mime_type }}" src="{{ method_exists($this->model, 'path') ? $this->model->path() : '/storage/'.$this->model->url }}" class="w-full">
 </x-aura::fields.wrapper>

--- a/src/Http/Controllers/ImageController.php
+++ b/src/Http/Controllers/ImageController.php
@@ -40,13 +40,15 @@ class ImageController extends Controller
         // Generate the thumbnail
         $thumbnailPath = $this->thumbnailGenerator->generate($path, $width, $height);
 
+        $disk = config('aura.media.disk', 'public');
+
         // Get the file contents from storage
-        if (! Storage::disk('public')->exists($thumbnailPath)) {
+        if (! Storage::disk($disk)->exists($thumbnailPath)) {
             abort(404);
         }
 
         // Get the file contents and mime type
-        $contents = Storage::disk('public')->get($thumbnailPath);
+        $contents = Storage::disk($disk)->get($thumbnailPath);
 
         // Return the image with image/jpeg mime type since we're always saving as JPG
         return response($contents)

--- a/src/Livewire/MediaUploader.php
+++ b/src/Livewire/MediaUploader.php
@@ -111,7 +111,10 @@ class MediaUploader extends Component
                 continue;
             }
 
-            $url = $media->store('media', 'public');
+            $url = $media->store(
+                config('aura.media.path', 'media'),
+                config('aura.media.disk', 'public'),
+            );
 
             $payload = [
                 'url' => $url,

--- a/src/Resources/Attachment.php
+++ b/src/Resources/Attachment.php
@@ -87,7 +87,7 @@ class Attachment extends Resource
         $basePath = storage_path('app/public');
 
         if ($size) {
-            $relativePath = Str::after($this->url, 'media/');
+            $relativePath = Str::after($this->url, config('aura.media.path', 'media').'/');
 
             return $basePath.'/'.$size.'/'.$relativePath;
         }
@@ -334,12 +334,13 @@ class Attachment extends Resource
         $fileName = uniqid().'.jpg';
 
         // Save the image to the desired storage
+        $disk = config('aura.media.disk', 'public');
         $storagePath = "{$folder}/{$fileName}";
-        Storage::disk('public')->put($storagePath, $imageContent);
+        Storage::disk($disk)->put($storagePath, $imageContent);
 
         // Get the image size and mime type
-        $imageSize = Storage::disk('public')->size($storagePath);
-        $imageMimeType = Storage::disk('public')->mimeType($storagePath);
+        $imageSize = Storage::disk($disk)->size($storagePath);
+        $imageMimeType = Storage::disk($disk)->mimeType($storagePath);
 
         // Create a new Attachment instance
         $attachment = self::create([
@@ -410,8 +411,11 @@ class Attachment extends Resource
 
     public function path($size = null)
     {
+        $disk = config('aura.media.disk', 'public');
+        $mediaPath = config('aura.media.path', 'media');
+
         if ($size) {
-            $url = Str::after($this->url, 'media/');
+            $url = Str::after($this->url, $mediaPath.'/');
 
             $assetPath = 'storage/'.$size.'/'.$url;
 
@@ -420,7 +424,16 @@ class Attachment extends Resource
             }
         }
 
-        return asset('storage/'.$this->url);
+        // The default public disk is served through the `public/storage`
+        // symlink, so preserve the existing asset() URLs. Any other configured
+        // disk resolves its own public URL.
+        $url = $this->url;
+
+        if ($disk === 'public') {
+            return asset('storage/'.$url);
+        }
+
+        return Storage::disk($disk)->url($url);
     }
 
     public function tableComponentView()
@@ -477,7 +490,14 @@ class Attachment extends Resource
 
     public function thumbnail_path()
     {
-        return asset('storage/'.$this->thumbnail_url);
+        $disk = config('aura.media.disk', 'public');
+        $thumbnailUrl = $this->thumbnail_url;
+
+        if ($disk === 'public') {
+            return asset('storage/'.$thumbnailUrl);
+        }
+
+        return Storage::disk($disk)->url($thumbnailUrl);
     }
 
     /**

--- a/src/Services/ThumbnailGenerator.php
+++ b/src/Services/ThumbnailGenerator.php
@@ -19,6 +19,7 @@ class ThumbnailGenerator
         // Get config values
         $quality = (int) Config::get('aura.media.quality', 80);
         $restrictDimensions = Config::get('aura.media.restrict_to_dimensions', true);
+        $disk = Config::get('aura.media.disk', 'public');
 
         // If dimensions are restricted, validate the requested dimensions
         if ($restrictDimensions) {
@@ -63,17 +64,17 @@ class ThumbnailGenerator
         }
 
         // Skip if thumbnail already exists
-        if (Storage::disk('public')->exists($thumbnailPath)) {
+        if (Storage::disk($disk)->exists($thumbnailPath)) {
             return $thumbnailPath;
         }
 
         // Check if the original image exists
-        if (! Storage::disk('public')->exists($folderPath.$basename)) {
+        if (! Storage::disk($disk)->exists($folderPath.$basename)) {
             throw new \Exception('Original image not found: '.$path);
         }
 
         // Create thumbnail via Intervention ImageManager (no Laravel facade package required)
-        $imageContents = Storage::disk('public')->get($path);
+        $imageContents = Storage::disk($disk)->get($path);
         $manager = new ImageManager(new Driver);
         $image = $manager->read($imageContents);
 
@@ -106,13 +107,13 @@ class ThumbnailGenerator
         }
 
         // Ensure the thumbnail directory exists
-        if (! Storage::disk('public')->exists($thumbnailFolder)) {
-            Storage::disk('public')->makeDirectory($thumbnailFolder, 0755, true);
+        if (! Storage::disk($disk)->exists($thumbnailFolder)) {
+            Storage::disk($disk)->makeDirectory($thumbnailFolder, 0755, true);
         }
 
         // Save the thumbnail image with quality from config
         $encodedImage = $image->encodeByExtension('jpg', quality: $quality);
-        Storage::disk('public')->put($thumbnailPath, (string) $encodedImage);
+        Storage::disk($disk)->put($thumbnailPath, (string) $encodedImage);
 
         return $thumbnailPath;
     }

--- a/tests/Feature/Media/MediaDiskConfigTest.php
+++ b/tests/Feature/Media/MediaDiskConfigTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use Aura\Base\Livewire\MediaUploader;
+use Aura\Base\Resources\Attachment;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+// Default behaviour must not change: uploads still land on the `public`
+// disk under the `media/` folder.
+test('media uploader stores on the public disk under media by default', function () {
+    Storage::fake('public');
+    Storage::fake('tmp-for-tests');
+
+    $file = UploadedFile::fake()->image('default.png');
+
+    Livewire::test(MediaUploader::class)
+        ->set('media', [$file])
+        ->assertHasNoErrors();
+
+    $attachment = Attachment::first();
+
+    expect($attachment)->not->toBeNull();
+    expect($attachment->url)->toStartWith('media/');
+
+    Storage::disk('public')->assertExists($attachment->url);
+});
+
+// The configured disk + path are honored end-to-end: the file lands on the
+// custom disk under the custom folder and never touches the public disk.
+test('media uploader honors the configured disk and path', function () {
+    config([
+        'aura.media.disk' => 'custom-disk',
+        'aura.media.path' => 'uploads',
+    ]);
+
+    Storage::fake('custom-disk');
+    Storage::fake('public');
+    Storage::fake('tmp-for-tests');
+
+    $file = UploadedFile::fake()->image('custom.png');
+
+    Livewire::test(MediaUploader::class)
+        ->set('media', [$file])
+        ->assertHasNoErrors();
+
+    $attachment = Attachment::first();
+
+    expect($attachment)->not->toBeNull();
+    expect($attachment->url)->toStartWith('uploads/');
+
+    Storage::disk('custom-disk')->assertExists($attachment->url);
+    Storage::disk('public')->assertMissing($attachment->url);
+});
+
+// URL generation defers to the configured disk's public URL for non-public
+// disks instead of assuming the `public/storage` symlink.
+test('attachment path reflects the configured disk public url', function () {
+    config([
+        'aura.media.disk' => 'custom-disk',
+        'aura.media.path' => 'uploads',
+        'filesystems.disks.custom-disk' => [
+            'driver' => 'local',
+            'root' => storage_path('framework/testing/disks/custom-disk'),
+            'url' => 'http://localhost/media-cdn',
+        ],
+    ]);
+
+    $attachment = Attachment::create([
+        'url' => 'uploads/example.jpg',
+        'mime_type' => 'application/pdf',
+    ]);
+
+    expect($attachment->path())->toBe('http://localhost/media-cdn/uploads/example.jpg');
+});
+
+// Default disk keeps the exact legacy asset() URL so existing installs are
+// unaffected.
+test('attachment path keeps the public storage url on the default disk', function () {
+    $attachment = Attachment::create([
+        'url' => 'media/example.jpg',
+        'mime_type' => 'application/pdf',
+    ]);
+
+    expect($attachment->path())->toBe(asset('storage/media/example.jpg'));
+});
+
+// Serving / thumbnailing must read from the configured disk too.
+test('the image route serves and stores a thumbnail on the configured disk', function () {
+    config([
+        'aura.media.disk' => 'custom-disk',
+        'aura.media.path' => 'uploads',
+        'aura.media.restrict_to_dimensions' => true,
+        'aura.media.dimensions' => [['width' => 200]],
+    ]);
+
+    Storage::fake('custom-disk');
+
+    $image = imagecreatetruecolor(320, 240);
+    ob_start();
+    imagejpeg($image);
+    $bytes = ob_get_clean();
+    Storage::disk('custom-disk')->put('uploads/route-test.jpg', $bytes);
+
+    Attachment::create([
+        'url' => 'uploads/route-test.jpg',
+        'name' => 'route-test.jpg',
+        'title' => 'route-test.jpg',
+        'size' => strlen($bytes),
+        'mime_type' => 'image/jpeg',
+    ]);
+
+    $response = $this->get('/admin/img/uploads/route-test.jpg?width=200');
+
+    $response->assertOk();
+    expect($response->headers->get('content-type'))->toBe('image/jpeg');
+
+    // The generated thumbnail lives on the custom disk, not the public disk.
+    Storage::disk('custom-disk')->assertExists('thumbnails/uploads/200_auto_route-test.jpg');
+});


### PR DESCRIPTION
## Summary

`config/aura.php` exposed `aura.media.disk` (`public`) and `aura.media.path` (`media`), but the pipeline ignored them — `MediaUploader` hardcoded `store('media', 'public')`, and the serve/thumbnail/URL paths all assumed the public disk. This wires the config through the entire upload → store → serve → thumbnail → URL pipeline.

Decision per #65: **honor** the keys. Defaults stay `public` + `media`, so existing installs are byte-for-byte unchanged (verified with a regression test asserting the default disk still produces the exact legacy `asset('storage/...')` URL).

## Config keys

The keys already shipped in `config/aura.php` (`media.disk` = `public`, `media.path` = `media`); they were just never read. Added an explanatory comment above them.

## Pipeline sites wired

| Site | Change |
|------|--------|
| `src/Livewire/MediaUploader.php` | `store('media','public')` → `store(config('aura.media.path','media'), config('aura.media.disk','public'))` |
| `src/Http/Controllers/ImageController.php` | thumbnail `exists()`/`get()` now read from `config('aura.media.disk','public')` instead of a hardcoded `public` disk |
| `src/Services/ThumbnailGenerator.php` | all six `Storage::disk('public')` calls (read original, existence checks, makeDirectory, put thumbnail) now use the configured disk |
| `src/Resources/Attachment.php::import()` | imported files written/inspected on the configured disk |
| `src/Resources/Attachment.php::path()` | non-public disks resolve via the disk's own `->url()`; the default `public` disk keeps the exact `asset('storage/...')` output (served through the `public/storage` symlink) |
| `src/Resources/Attachment.php::thumbnail_path()` | same public-vs-configured-disk URL handling |
| `src/Resources/Attachment.php::filePath()` | honors the configured base path instead of a literal `media/` |
| `resources/views/components/fields/embed.blade.php` | uses the config-aware `Attachment::path()` (guarded with `method_exists` so generic Embed-field models keep working) |

### Intentionally left out of scope
- `src/Livewire/ImageUpload.php` (`store('photos','public')`) — a separate avatar/photo field, not driven by the media config.
- `aura:install` — there is no Aura-specific storage symlink publishing; media relies on the standard Laravel `storage:link`, unaffected here.

## Tests

New `tests/Feature/Media/MediaDiskConfigTest.php` (5 tests):
- default upload still lands on `public` under `media/`
- setting `aura.media.disk=custom-disk` + `aura.media.path=uploads` stores the upload on the faked custom disk under `uploads/` and **not** on `public`
- `Attachment::path()` resolves the custom disk's public URL for non-public disks
- `Attachment::path()` keeps the exact legacy `asset('storage/...')` URL on the default disk
- image route (`/admin/img/...`) serves **and** writes the thumbnail on the configured custom disk

Full suite: **1797 passed, 4 skipped**. PHPStan (level 3) clean; Pint clean.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SfSSvBDCogBXr2PfhC6MM