### PR TITLE
fix: Resource::__isset so meta attributes work with ?? and pluck() (#64)

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -56,6 +56,16 @@ class Resource extends Model implements DefinesFields
 
     protected $appends = ['fields'];
 
+    /**
+     * Re-entrancy guard for getFieldsAttribute(): true while the fields
+     * collection is mid-build. Building resolves each field value, which can
+     * read back into this accessor (e.g. relation loading dereferences the
+     * model's key via __get) before the cache is populated. The guard lets that
+     * nested read see an empty collection instead of triggering an unbounded
+     * rebuild.
+     */
+    protected bool $buildingFieldsAttribute = false;
+
     protected $fillable = ['title', 'content', 'type', 'status', 'fields', 'slug', 'user_id', 'parent_id', 'order', 'team_id', 'created_at', 'updated_at', 'deleted_at'];
 
     protected $hidden = ['meta'];
@@ -137,6 +147,34 @@ class Resource extends Model implements DefinesFields
     }
 
     /**
+     * Mirror __get's resolution order for isset()/empty()/null-coalescing.
+     *
+     * Eloquent's native Model::__isset only inspects real attributes and
+     * relations, so it reports meta-backed and computed field slugs as "unset"
+     * — which silently breaks `$model->metaField ?? 'default'`, `pluck()` and
+     * `empty()` for exactly those dynamic attributes. Since __get resolves a key
+     * through resolveDynamicAttribute() (Eloquent state → relation field →
+     * computed `fields` value), isset() must report true whenever that same
+     * ladder would yield a non-null value; resolving once here keeps __isset and
+     * __get in lock-step, including the empty-collection coercion for relation
+     * slugs.
+     *
+     * Recursion note: resolving a meta/computed slug builds the `fields`
+     * accessor, whose construction (resolveFieldValue) probes for a *real*
+     * Eloquent attribute. Those probes deliberately use parent::__isset() —
+     * native, meta-blind semantics — so this meta-aware resolution can never
+     * recurse into itself, and the table-display fast path is never forced into
+     * a full fields build just to test attribute presence.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        return ! is_null($this->resolveDynamicAttribute($key));
+    }
+
+    /**
      * @return HasMany
      */
     public function attachment()
@@ -171,7 +209,20 @@ class Resource extends Model implements DefinesFields
 
     public function getFieldsAttribute()
     {
-        if (! isset($this->fieldsAttributeCache) || $this->fieldsAttributeCache === null) {
+        if (isset($this->fieldsAttributeCache) && $this->fieldsAttributeCache !== null) {
+            return $this->fieldsAttributeCache;
+        }
+
+        // Re-entrancy guard: a nested read of this accessor while it is still
+        // building (before the cache is populated) gets an empty collection
+        // rather than kicking off an unbounded rebuild. See the property docblock.
+        if ($this->buildingFieldsAttribute) {
+            return collect();
+        }
+
+        $this->buildingFieldsAttribute = true;
+
+        try {
             // Get fields only once and store in a variable
             $fieldsWithoutLogic = $this->getFieldsWithoutConditionalLogic();
 
@@ -192,6 +243,8 @@ class Resource extends Model implements DefinesFields
 
                     return ConditionalLogic::shouldDisplayField($this, $field, ['fields' => $fieldsWithoutLogic]);
                 });
+        } finally {
+            $this->buildingFieldsAttribute = false;
         }
 
         return $this->fieldsAttributeCache;
@@ -334,11 +387,17 @@ class Resource extends Model implements DefinesFields
             return $class->get($class, $this->{$key}, $field);
         }
 
-        if ($class && isset($this->{$key}) && method_exists($class, 'get')) {
+        // Deliberately meta-BLIND probes: this method COMPUTES the value later
+        // surfaced (meta-aware) via __get/__isset, so it must ask only whether a
+        // *real* Eloquent attribute/relation exists for this slug. parent::__isset()
+        // is the native check (identical to the historical isset($this->{$key})
+        // before Resource declared its own __isset) — using the meta-aware isset()
+        // here would recurse into the fields build and defeat the display fast path.
+        if ($class && parent::__isset($key) && method_exists($class, 'get')) {
             return $class->get($class, $this->{$key}, $field);
         }
 
-        if (isset($this->{$key})) {
+        if (parent::__isset($key)) {
             return $this->{$key};
         }
 
@@ -356,7 +415,7 @@ class Resource extends Model implements DefinesFields
             return $this->{$method}($value);
         }
 
-        if ($class && isset(optional($this)->{$key}) && method_exists($class, 'get')) {
+        if ($class && parent::__isset($key) && method_exists($class, 'get')) {
             return $class->get($class, $this->{$key} ?? null, $field);
         }
 

--- a/tests/Feature/Resource/ResourceIssetTest.php
+++ b/tests/Feature/Resource/ResourceIssetTest.php
@@ -1,0 +1,206 @@
+<?php
+
+use Aura\Base\Fields\Field;
+use Aura\Base\Resource;
+use Illuminate\Support\Collection;
+
+/**
+ * Regression coverage for #64: Resource resolved meta / computed field slugs
+ * through __get but never implemented __isset. Because PHP consults __isset
+ * before __get for null-coalescing (`??`), isset()/empty(), and Collection
+ * pluck() (via data_get()'s `isset($target->{$segment})` guard), every one of
+ * those silently reported meta-backed attributes as "unset" — turning
+ * `$model->metaField ?? 'x'` into always-'x' and `pluck('metaField')` into
+ * all-nulls.
+ *
+ * These tests pin the NEW behaviour: __isset mirrors __get's resolution ladder
+ * exactly (real Eloquent state -> relation field slug -> computed `fields`
+ * value), reporting true whenever a non-null value would resolve, while leaving
+ * real attributes and relations behaving exactly as Eloquent always did.
+ */
+
+// A relation-type field: because ->type is 'relation', Field::isRelation() is
+// true, so a matching slug routes through getRelation() in __get/__isset.
+class IssetSpyField extends Field
+{
+    public static mixed $relationReturn = null;
+
+    public string $type = 'relation';
+
+    public function getRelation($model, $field)
+    {
+        return static::$relationReturn;
+    }
+}
+
+class IssetTestResource extends Resource
+{
+    public static ?string $slug = 'isset-test';
+
+    public static string $type = 'IssetTestResource';
+
+    public static function getFields()
+    {
+        return [
+            ['name' => 'Plain Text', 'slug' => 'plain_text', 'type' => 'Aura\\Base\\Fields\\Text', 'conditional_logic' => []],
+            ['name' => 'Count', 'slug' => 'count', 'type' => 'Aura\\Base\\Fields\\Number', 'conditional_logic' => []],
+            ['name' => 'Spy Rel', 'slug' => 'spy_rel', 'type' => IssetSpyField::class, 'conditional_logic' => []],
+        ];
+    }
+}
+
+beforeEach(function () {
+    $this->actingAs($this->user = createSuperAdmin());
+
+    IssetSpyField::$relationReturn = null;
+});
+
+/**
+ * Persist a meta-backed value and re-hydrate so the fields accessor cache is
+ * rebuilt from stored meta — the realistic path a loaded model takes.
+ */
+function makeIssetResource(array $meta = []): IssetTestResource
+{
+    $model = IssetTestResource::create(['type' => 'IssetTestResource']);
+
+    foreach ($meta as $key => $value) {
+        $model->meta()->create(['key' => $key, 'value' => $value]);
+    }
+
+    return IssetTestResource::find($model->id);
+}
+
+// --- the core bug: isset() on a meta field --------------------------------
+
+test('isset() is true for a meta field that has a value', function () {
+    $model = makeIssetResource(['plain_text' => 'hello']);
+
+    expect(isset($model->plain_text))->toBeTrue();
+});
+
+test('isset() is false for a meta field with no value', function () {
+    $model = makeIssetResource();
+
+    expect(isset($model->plain_text))->toBeFalse();
+});
+
+test('isset() is false for a completely unknown key', function () {
+    $model = makeIssetResource(['plain_text' => 'hello']);
+
+    expect(isset($model->totally_unknown_key))->toBeFalse();
+});
+
+// --- null-coalescing now sees the real value ------------------------------
+
+test('?? fallback returns the meta value when present (was always the fallback)', function () {
+    $model = makeIssetResource(['plain_text' => 'hello']);
+
+    expect($model->plain_text ?? 'default')->toBe('hello');
+});
+
+test('?? fallback returns the default only when the meta value is genuinely absent', function () {
+    $model = makeIssetResource();
+
+    expect($model->plain_text ?? 'default')->toBe('default');
+});
+
+// --- pluck() over a collection of resources -------------------------------
+
+test('pluck() on a collection of resources returns meta values (was all nulls)', function () {
+    makeIssetResource(['plain_text' => 'alpha']);
+    makeIssetResource(['plain_text' => 'beta']);
+    makeIssetResource(['plain_text' => 'gamma']);
+
+    $values = IssetTestResource::all()->pluck('plain_text');
+
+    expect($values->all())->toEqualCanonicalizing(['alpha', 'beta', 'gamma']);
+});
+
+// --- empty() semantics -----------------------------------------------------
+
+test('empty() is false for a non-empty meta value and true when absent', function () {
+    $withValue = makeIssetResource(['plain_text' => 'hello']);
+    $withoutValue = makeIssetResource();
+
+    expect(empty($withValue->plain_text))->toBeFalse()
+        ->and(empty($withoutValue->plain_text))->toBeTrue();
+});
+
+test('empty() honours falsy meta values (0 is empty even though isset is true)', function () {
+    $model = makeIssetResource(['count' => 0]);
+
+    // isset mirrors __get: a stored 0 resolves to a non-null value, so isset is
+    // true — but empty() still reports true for the falsy 0, exactly as PHP does
+    // for a real property.
+    expect(isset($model->count))->toBeTrue()
+        ->and(empty($model->count))->toBeTrue();
+});
+
+// --- regular Eloquent attributes are untouched -----------------------------
+
+test('regular Eloquent attributes keep native isset/?? behaviour', function () {
+    $model = IssetTestResource::create(['type' => 'IssetTestResource', 'title' => 'Real Title', 'parent_id' => null]);
+
+    // A set real column reads through parent::__get exactly as before; a null
+    // nullable column stays "unset" and falls through to the ?? default.
+    expect(isset($model->title))->toBeTrue()
+        ->and($model->title ?? 'default')->toBe('Real Title')
+        ->and(isset($model->parent_id))->toBeFalse()
+        ->and($model->parent_id ?? 'default')->toBe('default');
+});
+
+test('a falsy real attribute is reported as set, matching __get', function () {
+    $model = IssetTestResource::create(['type' => 'IssetTestResource', 'order' => 0]);
+
+    expect(isset($model->order))->toBeTrue()
+        ->and($model->order)->toBe(0);
+});
+
+// --- relations mirror __get (never regress to null) ------------------------
+
+test('a relation field slug is reported as set, mirroring __get', function () {
+    IssetSpyField::$relationReturn = collect(['related-a', 'related-b']);
+
+    $model = makeIssetResource();
+
+    // __get returns the relation collection, so isset() must agree.
+    expect(isset($model->spy_rel))->toBeTrue()
+        ->and($model->spy_rel)->toEqual(collect(['related-a', 'related-b']));
+});
+
+test('a relation field slug with a null relation still reads as set (empty collection)', function () {
+    IssetSpyField::$relationReturn = null;
+
+    $model = makeIssetResource();
+
+    // __get coerces a null relation to an empty (non-null) collection, so
+    // isset() mirrors that and reports true.
+    expect(isset($model->spy_rel))->toBeTrue()
+        ->and($model->spy_rel)->toBeInstanceOf(Collection::class)
+        ->and($model->spy_rel->isEmpty())->toBeTrue();
+});
+
+test('a loaded Eloquent relation is reported as set without hitting the field ladder', function () {
+    $model = makeIssetResource();
+    $loaded = collect(['loaded-item']);
+    $model->setRelation('spy_rel', $loaded);
+
+    expect(isset($model->spy_rel))->toBeTrue()
+        ->and($model->spy_rel)->toBe($loaded);
+});
+
+// --- teams-off compatibility (computed-fields path, no DB/team scope) -------
+
+test('isset resolves the computed fields path with teams disabled', function () {
+    config(['aura.teams' => false]);
+
+    // Prime the fields accessor cache directly: this exercises resolveDynamicAttribute
+    // step 4 (the computed `fields` value) without any team context or DB access,
+    // so it holds identically whether teams are on or off.
+    $model = new IssetTestResource;
+    $model->fieldsAttributeCache = collect(['plain_text' => 'primed-value']);
+
+    expect(isset($model->plain_text))->toBeTrue()
+        ->and($model->plain_text ?? 'default')->toBe('primed-value')
+        ->and(isset($model->plain_text_missing))->toBeFalse();
+});


### PR DESCRIPTION
## Problem

`Aura\Base\Resource` resolves meta-backed and computed field slugs through `__get` (via `resolveDynamicAttribute`) but never implemented `__isset`. PHP consults `__isset` *before* `__get` for null-coalescing (`??`), `isset()`/`empty()`, and `Collection::pluck()` (through `data_get()`'s `isset()` guard), so every one of those silently reported meta attributes as "unset":

```php
$attachment->name ?? ''      // always '' even when the meta value exists
$collection->pluck('name')   // all nulls
isset($model->metaField)     // false even when set
```

This bit the team three separate times during the media-library and access-control work (PRs #44, #57–#60) — each as a silent wrong-value bug, not an error.

## Fix

Implement `__isset()` mirroring `__get`'s resolution ladder (real Eloquent state → relation field slug → computed `fields` value), reporting `true` whenever that same ladder would yield a non-null value:

```php
public function __isset($key)
{
    return ! is_null($this->resolveDynamicAttribute($key));
}
```

Two internal seams are hardened so the new meta-aware `isset()` does not perturb existing behaviour or recurse:

- **`resolveFieldValue()`** probes for a *real* Eloquent attribute while it is *computing* the meta-aware value later surfaced via `__get`. Those probes now use `parent::__isset()` (native, meta-blind) — identical to the historical `isset($this->{$key})` before `Resource` declared its own `__isset`. Without this, resolving a meta slug would recurse into the fields build, and the table-display fast path would build the full `fields` collection just to test attribute presence.
- **`getFieldsAttribute()`** gains a re-entrancy guard: building the fields collection resolves each field value, and relation loading dereferences the model key via `__get`, which can read back into the accessor before its cache is populated. The guard returns an empty collection for that nested read instead of triggering an unbounded rebuild.

`empty()` and `??` continue to honour falsy values (`0`, `''`, `false`) exactly as PHP does for real properties, mirroring `__get`.

## Audit (code that depended on the broken behaviour)

Searched `src/` and `resources/views` for `??` fallbacks and `isset(`/`empty(` checks on resource attributes. **Nothing regressed** — every candidate targets something that is *not* a meta/computed field slug:

- Real DB columns — `global_admin`, `current_team_id`, `team_id`, `title`, `id`, `order` (`AuraServiceProvider`, `Fields/Roles`, `Widgets/Widget`, `InitialPostFields`, `Resources/Option`, …). Resolved identically by `parent::__get`, so `__isset` is unchanged for them. Meta-attribute-looking cases like `$user->global_admin ?? false` are actually real boolean columns — unaffected/improved.
- Declared public properties — `$post->metaFields` is `public array $metaFields = []`, so `isset()` reads the property directly and never routes through magic `__isset`.
- Arrays / non-Resource objects — `$this->settings[...]`, `$this->form['fields'][...]`, `$filter['name']`, `TransformSlugs`' `$parent` (an array item), Livewire component props (`$this->model`, `$this->userFilters`).

The `->map()`-instead-of-`pluck()` workarounds noted in #44 keep working (direct `__get` access is unchanged) and can now be simplified back to `pluck()`.

## Tests

Adds `tests/Feature/Resource/ResourceIssetTest.php` (14 tests): `isset()` true/false for meta fields, `??` now returning the stored value, `pluck()` over a collection of resources, `empty()` semantics (including falsy `0`), regular Eloquent attributes and relations unaffected, and the teams-off computed-fields path.

- New file: 14 passed (teams-on and via `phpunit-without-teams.xml`).
- Full suite (`composer test`): **1806 passed, 4 skipped, 0 failed**.
- `vendor/bin/pint --dirty`: clean. `composer analyse` (PHPStan level 3): no errors.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SfSSvBDCogBXr2PfhC6MM