### PR TITLE
Save pipeline immune to trait boot order; PHP 8.5 back in the CI matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,10 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # PHP 8.5 is allowed by composer.json (^8.4) but not yet gated in CI:
-        # it deterministically triggers pre-existing parallel-test isolation
-        # pollution (see the follow-up issue). Re-add '8.5' once that is fixed.
-        php: ['8.4']
+        php: ['8.4', '8.5']
         laravel: ['12', '13']
         include:
           - laravel: '12'

--- a/src/Traits/InitialPostFields.php
+++ b/src/Traits/InitialPostFields.php
@@ -7,36 +7,42 @@ use Illuminate\Support\Str;
 
 trait InitialPostFields
 {
-    protected static function bootInitialPostFields()
+    /**
+     * Fill the initial post columns (title, content, user, team, type, slug).
+     *
+     * Invoked as the first step of the save pipeline registered in
+     * SaveFieldAttributes::bootSaveFieldAttributes(). Deliberately not a
+     * trait boot method — see the pipeline comment there for why the three
+     * save steps must not be separate model-event listeners.
+     */
+    protected static function applyInitialPostFields($post): void
     {
-        static::saving(function ($post) {
-            if (! $post->title && $post::usesTitle()) {
-                $post->title = '';
-            }
+        if (! $post->title && $post::usesTitle()) {
+            $post->title = '';
+        }
 
-            if ($post instanceof User) {
-                return;
-            }
+        if ($post instanceof User) {
+            return;
+        }
 
-            if (! $post->content && ! $post::usesCustomTable()) {
-                $post->content = '';
-            }
+        if (! $post->content && ! $post::usesCustomTable()) {
+            $post->content = '';
+        }
 
-            if (! $post->user_id && auth()->user()) {
-                $post->user_id = auth()->user()->id;
-            }
+        if (! $post->user_id && auth()->user()) {
+            $post->user_id = auth()->user()->id;
+        }
 
-            if (config('aura.teams') && ! isset($post->team_id) && auth()->user()) {
-                $post->team_id = auth()->user()->current_team_id;
-            }
+        if (config('aura.teams') && ! isset($post->team_id) && auth()->user()) {
+            $post->team_id = auth()->user()->current_team_id;
+        }
 
-            if (! $post->type && ! $post::usesCustomTable()) {
-                $post->type = $post::$type;
-            }
+        if (! $post->type && ! $post::usesCustomTable()) {
+            $post->type = $post::$type;
+        }
 
-            if ($post->getTable() == 'posts' && ! $post->slug) {
-                $post->slug = Str::slug($post->title);
-            }
-        });
+        if ($post->getTable() == 'posts' && ! $post->slug) {
+            $post->slug = Str::slug($post->title);
+        }
     }
 }

--- a/src/Traits/SaveFieldAttributes.php
+++ b/src/Traits/SaveFieldAttributes.php
@@ -8,95 +8,119 @@ use Aura\Base\Fields\Password;
 trait SaveFieldAttributes
 {
     /**
-     * Set Fields Attributes
+     * Register the save pipeline as ONE listener per model event, with the
+     * step order hard-coded.
      *
-     * Take Fields Attributes and Put all fields from getFieldSlugs() in the Fields Column
+     * The three steps (initial post columns → pack field attributes into the
+     * `fields` array → persist `fields` as meta) used to be three separate
+     * `saving` listeners registered by three trait boot methods. Their order
+     * then depended on trait boot order — and Laravel ≥13 invokes trait boot
+     * methods in ReflectionClass::getMethods() order, which PHP 8.5 changed:
+     * a trait method re-imported by a subclass now reflects BEFORE inherited
+     * methods. A subclass re-`use`ing SaveMetaFields therefore booted the
+     * meta consumer before the packer, and the literal `fields` array leaked
+     * into the INSERT ("table posts has no column named fields", issue #37).
      *
-     * @param  $post
-     * @return void
+     * One listener, explicit order — immune to boot order.
      */
     protected static function bootSaveFieldAttributes()
     {
         static::saving(function ($post) {
+            static::applyInitialPostFields($post);
+            static::packFieldAttributes($post);
+            static::persistMetaFieldsOnSaving($post);
+        });
 
-            if (! optional($post->attributes)['fields']) {
-                $post->attributes['fields'] = [];
+        static::saved(function ($post) {
+            static::persistMetaFieldsOnSaved($post);
+        });
+    }
+
+    /**
+     * Set Fields Attributes
+     *
+     * Take Fields Attributes and Put all fields from getFieldSlugs() in the Fields Column
+     *
+     * @return void
+     */
+    protected static function packFieldAttributes($post)
+    {
+        if (! optional($post->attributes)['fields']) {
+            $post->attributes['fields'] = [];
+        }
+
+        collect($post->inputFieldsSlugs())->each(function ($slug) use ($post) {
+
+            if (array_key_exists($slug, $post->attributes)) {
+
+                $class = $post->fieldClassBySlug($slug);
+
+                if ($slug == 'password') {
+                }
+
+                // Do not continue if the Field is not found
+                if (! $class) {
+                    return;
+                }
+
+                // Do not set password fields manually, since they would overwrite the hashed password
+                if ($class instanceof Password) {
+
+                    // If the password is available in the $post->attributes, unset it
+                    // if (empty($post->attributes[$slug])) {
+                    //     unset($post->attributes[$slug]);
+                    // }
+
+                    // Check if the password field is dirty (i.e., has been modified)
+                    // if (! $post->isDirty($slug)) {
+                    //     // Remove it from attributes so it won't be saved
+                    //     unset($post->attributes[$slug]);
+
+                    //     return;
+                    // }
+
+                    // return;
+                }
+
+                if ($class instanceof ID) {
+                    return;
+                }
+
+                if (! array_key_exists($slug, $post->attributes['fields'])) {
+                    $post->attributes['fields'][$slug] = $post->attributes[$slug];
+                }
+
+                // Set the field value into nested fields array if it contains a dot
+                if (strpos($slug, '.') !== false) {
+                    self::setNestedFieldValue($post->attributes['fields'], $slug, $post->attributes[$slug]);
+                    // Unset the attribute from the main attributes array
+                    // unset($post->attributes[$slug]);
+                    unset($post->attributes['fields'][$slug]);
+                } else {
+                    // If no dot, set the attribute directly in fields
+                    // $post->attributes['fields'][$slug] = $post->attributes[$slug];
+                }
             }
 
-            collect($post->inputFieldsSlugs())->each(function ($slug) use ($post) {
+            if ($slug == 'title') {
+                return;
+            }
 
-                if (array_key_exists($slug, $post->attributes)) {
+            // Dont unset Field if it is in baseFillable
+            if (in_array($slug, $post->baseFillable)) {
+                return;
+            }
 
-                    $class = $post->fieldClassBySlug($slug);
+            // Dont unset Field if it is uses customTable
+            if ($post->usesCustomTable() && ! $post->usesMeta()) {
+                return;
+            }
+            // if ($post->usesCustomTable() && $post->usesCustomMeta()) {
+            //     return;
+            // }
 
-                    if ($slug == 'password') {
-                    }
-
-                    // Do not continue if the Field is not found
-                    if (! $class) {
-                        return;
-                    }
-
-                    // Do not set password fields manually, since they would overwrite the hashed password
-                    if ($class instanceof Password) {
-
-                        // If the password is available in the $post->attributes, unset it
-                        // if (empty($post->attributes[$slug])) {
-                        //     unset($post->attributes[$slug]);
-                        // }
-
-                        // Check if the password field is dirty (i.e., has been modified)
-                        // if (! $post->isDirty($slug)) {
-                        //     // Remove it from attributes so it won't be saved
-                        //     unset($post->attributes[$slug]);
-
-                        //     return;
-                        // }
-
-                        // return;
-                    }
-
-                    if ($class instanceof ID) {
-                        return;
-                    }
-
-                    if (! array_key_exists($slug, $post->attributes['fields'])) {
-                        $post->attributes['fields'][$slug] = $post->attributes[$slug];
-                    }
-
-                    // Set the field value into nested fields array if it contains a dot
-                    if (strpos($slug, '.') !== false) {
-                        self::setNestedFieldValue($post->attributes['fields'], $slug, $post->attributes[$slug]);
-                        // Unset the attribute from the main attributes array
-                        // unset($post->attributes[$slug]);
-                        unset($post->attributes['fields'][$slug]);
-                    } else {
-                        // If no dot, set the attribute directly in fields
-                        // $post->attributes['fields'][$slug] = $post->attributes[$slug];
-                    }
-                }
-
-                if ($slug == 'title') {
-                    return;
-                }
-
-                // Dont unset Field if it is in baseFillable
-                if (in_array($slug, $post->baseFillable)) {
-                    return;
-                }
-
-                // Dont unset Field if it is uses customTable
-                if ($post->usesCustomTable() && ! $post->usesMeta()) {
-                    return;
-                }
-                // if ($post->usesCustomTable() && $post->usesCustomMeta()) {
-                //     return;
-                // }
-
-                // Unset fields from the attributes
-                unset($post->attributes[$slug]);
-            });
-
+            // Unset fields from the attributes
+            unset($post->attributes[$slug]);
         });
     }
 

--- a/src/Traits/SaveMetaFields.php
+++ b/src/Traits/SaveMetaFields.php
@@ -3,154 +3,165 @@
 namespace Aura\Base\Traits;
 
 use Aura\Base\Fields\ID;
-use Aura\Base\Models\Meta;
 use Aura\Base\Resources\User;
 use Illuminate\Support\Str;
 
 trait SaveMetaFields
 {
-    protected static function bootSaveMetaFields()
+    /**
+     * Persist the queued meta fields after the row itself is saved.
+     *
+     * Invoked from the saved listener registered in
+     * SaveFieldAttributes::bootSaveFieldAttributes().
+     */
+    protected static function persistMetaFieldsOnSaved($post): void
     {
+        if (isset($post->metaFields)) {
 
-        static::saving(function ($post) {
+            foreach ($post->metaFields as $key => $value) {
 
-            if ($post instanceof User) {
-            }
+                // if there is a function set{Slug}Field on the model, use it
+                $method = 'set'.Str::studly($key).'Field';
 
-            if (isset($post->attributes['fields'])) {
+                if (method_exists($post, $method)) {
+                    $post = $post->{$method}($value);
 
-                // Dont save Meta Fields if it is uses customTable
-                if ($post->usesCustomTable() && ! $post->usesMeta()) {
-                    unset($post->attributes['fields']);
-
-                    return;
+                    continue;
                 }
 
-                foreach ($post->attributes['fields'] as $key => $value) {
-                    $key = (string) $key;
+                $field = $post->fieldBySlug($key);
+                $class = $post->fieldClassBySlug((string) $key);
 
-                    $class = $post->fieldClassBySlug($key);
-
-                    // Allow resources/plugins to consume custom form payloads that are
-                    // not regular Aura fields, e.g. "translations".
-                    $method = 'set'.Str::studly($key).'Field';
-
-                    if (! $class && method_exists($post, $method)) {
-                        $post->{$method}($value);
-
-                        continue;
-                    }
-
-                    // Do not continue if the Field is not found
-                    if (! $class) {
-                        continue;
-                    }
-
-                    // if there is a function set{Slug}Field on the model, use it
-                    if (method_exists($post, $method)) {
-                        $post->saveMetaField([$key => $value]);
-
-                        // $post = $post->{$method}($value);
-
-                        continue;
-                    }
-
-                    $field = $post->fieldBySlug($key);
-
-                    if (isset($field['set']) && $field['set'] instanceof \Closure) {
-                        $value = call_user_func($field['set'], $post, $field, $value);
-                    }
-
-                    if (method_exists($class, 'set')) {
-                        $value = $class->set($post, $field, $value);
-                    }
-
-                    if (method_exists($class, 'saving')) {
-                        // Store the result back to $post
-                        $modifiedPost = $class->saving($post, $field, $value);
-
-                        if ($modifiedPost) {
-                            $post = $modifiedPost;
-                        }
-
-                    }
-
-                    // Check if further processing should be skipped
-                    if (method_exists($class, 'shouldSkip') && $class->shouldSkip($post, $field)) {
-                        continue;
-                    }
-
-                    if ($class instanceof ID) {
-                        // $post->attributes[$key] = $value;
-
-                        // unset($post->attributes['fields'][$key]);
-
-                        continue;
-                    }
-
-                    // If the field exists in the $post->getBaseFillable(), it should be safed in the table instead of the meta table
-                    if (in_array($key, $post->getBaseFillable())) {
-                        $post->attributes[$key] = $value;
-
-                        continue;
-                    }
-
-                    if (in_array($key, $post->getFillable())) {
-                        // Save the meta field to the model, so it can be saved in the Meta table
-                        $post->saveMetaField([$key => $value]);
-                    }
-
-                    // Save the meta field to the model, so it can be saved in the Meta table
-                    // $post->saveMetaField([$key => $value]);
-                }
-
-                unset($post->attributes['fields']);
-
-                $post->clearFieldsAttributeCache();
-            }
-
-        });
-
-        static::saved(function ($post) {
-            if (isset($post->metaFields)) {
-
-                foreach ($post->metaFields as $key => $value) {
-
-                    // if there is a function set{Slug}Field on the model, use it
-                    $method = 'set'.Str::studly($key).'Field';
-
-                    if (method_exists($post, $method)) {
-                        $post = $post->{$method}($value);
-
-                        continue;
-                    }
-
-                    $field = $post->fieldBySlug($key);
-                    $class = $post->fieldClassBySlug((string) $key);
-
-                    // Do not continue if the Field is not found
-                    if (! $class) {
-                        if ($post->usesMeta()) {
-                            $post->meta()->updateOrCreate(['key' => $key], ['value' => $value]);
-                        }
-
-                        continue;
-                    }
-
-                    if (method_exists($class, 'saved')) {
-                        $value = $class->saved($post, $field, $value);
-
-                        continue;
-                    }
-
+                // Do not continue if the Field is not found
+                if (! $class) {
                     if ($post->usesMeta()) {
                         $post->meta()->updateOrCreate(['key' => $key], ['value' => $value]);
                     }
 
+                    continue;
                 }
 
-                $post->fireModelEvent('metaSaved');
+                if (method_exists($class, 'saved')) {
+                    $value = $class->saved($post, $field, $value);
+
+                    continue;
+                }
+
+                if ($post->usesMeta()) {
+                    $post->meta()->updateOrCreate(['key' => $key], ['value' => $value]);
+                }
+
             }
-        });
+
+            $post->fireModelEvent('metaSaved');
+        }
+    }
+
+    /**
+     * Consume the packed `fields` array during saving: route each value to
+     * its column, meta queue, or field-class handler, then remove `fields`
+     * from the attributes so it never reaches the SQL insert/update.
+     *
+     * Invoked as the last saving step of the pipeline registered in
+     * SaveFieldAttributes::bootSaveFieldAttributes(). Deliberately not a
+     * trait boot method — as a separate listener its order against the
+     * packer depended on trait boot order, which PHP 8.5 changed (issue #37).
+     */
+    protected static function persistMetaFieldsOnSaving($post): void
+    {
+        if ($post instanceof User) {
+        }
+
+        if (isset($post->attributes['fields'])) {
+
+            // Dont save Meta Fields if it is uses customTable
+            if ($post->usesCustomTable() && ! $post->usesMeta()) {
+                unset($post->attributes['fields']);
+
+                return;
+            }
+
+            foreach ($post->attributes['fields'] as $key => $value) {
+                $key = (string) $key;
+
+                $class = $post->fieldClassBySlug($key);
+
+                // Allow resources/plugins to consume custom form payloads that are
+                // not regular Aura fields, e.g. "translations".
+                $method = 'set'.Str::studly($key).'Field';
+
+                if (! $class && method_exists($post, $method)) {
+                    $post->{$method}($value);
+
+                    continue;
+                }
+
+                // Do not continue if the Field is not found
+                if (! $class) {
+                    continue;
+                }
+
+                // if there is a function set{Slug}Field on the model, use it
+                if (method_exists($post, $method)) {
+                    $post->saveMetaField([$key => $value]);
+
+                    // $post = $post->{$method}($value);
+
+                    continue;
+                }
+
+                $field = $post->fieldBySlug($key);
+
+                if (isset($field['set']) && $field['set'] instanceof \Closure) {
+                    $value = call_user_func($field['set'], $post, $field, $value);
+                }
+
+                if (method_exists($class, 'set')) {
+                    $value = $class->set($post, $field, $value);
+                }
+
+                if (method_exists($class, 'saving')) {
+                    // Store the result back to $post
+                    $modifiedPost = $class->saving($post, $field, $value);
+
+                    if ($modifiedPost) {
+                        $post = $modifiedPost;
+                    }
+
+                }
+
+                // Check if further processing should be skipped
+                if (method_exists($class, 'shouldSkip') && $class->shouldSkip($post, $field)) {
+                    continue;
+                }
+
+                if ($class instanceof ID) {
+                    // $post->attributes[$key] = $value;
+
+                    // unset($post->attributes['fields'][$key]);
+
+                    continue;
+                }
+
+                // If the field exists in the $post->getBaseFillable(), it should be safed in the table instead of the meta table
+                if (in_array($key, $post->getBaseFillable())) {
+                    $post->attributes[$key] = $value;
+
+                    continue;
+                }
+
+                if (in_array($key, $post->getFillable())) {
+                    // Save the meta field to the model, so it can be saved in the Meta table
+                    $post->saveMetaField([$key => $value]);
+                }
+
+                // Save the meta field to the model, so it can be saved in the Meta table
+                // $post->saveMetaField([$key => $value]);
+            }
+
+            unset($post->attributes['fields']);
+
+            $post->clearFieldsAttributeCache();
+        }
     }
 }

--- a/tests/Feature/Resource/SavePipelineBootOrderTest.php
+++ b/tests/Feature/Resource/SavePipelineBootOrderTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use Aura\Base\Resource;
+use Aura\Base\Traits\SaveMetaFields;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Regression coverage for #37: the save steps (initial post columns, packing
+ * field attributes into `fields`, persisting `fields` as meta) used to be
+ * three separate `saving` listeners registered by three trait boot methods.
+ *
+ * Laravel ≥13 invokes trait boot methods in ReflectionClass::getMethods()
+ * order, and PHP 8.5 changed that order: a trait method re-imported by a
+ * subclass reflects BEFORE inherited methods. A subclass re-`use`ing
+ * SaveMetaFields therefore booted the meta consumer before the packer — the
+ * consumer saw no `fields` yet, the packer then created it, and the literal
+ * `fields` array leaked into the INSERT:
+ *
+ *   SQLSTATE[HY000]: table posts has no column named fields
+ *
+ * The pipeline is now ONE saving listener with hard-coded step order
+ * (SaveFieldAttributes::bootSaveFieldAttributes), so trait boot order no
+ * longer matters. These tests pin that for both the plain and the
+ * re-`use`ing subclass — on every PHP version.
+ */
+beforeEach(function () {
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+class PipelinePlainModel extends Resource
+{
+    public static string $type = 'PipelinePlainModel';
+
+    public static function getFields()
+    {
+        return [
+            [
+                'name' => 'Note',
+                'type' => 'Aura\\Base\\Fields\\Text',
+                'slug' => 'note',
+            ],
+        ];
+    }
+}
+
+class PipelineReusesTraitModel extends Resource
+{
+    // Redundant on purpose: Resource already uses SaveMetaFields. Re-`use`ing
+    // it copies the trait's methods into this class, which is exactly the
+    // shape that inverted the boot order on PHP 8.5.
+    use SaveMetaFields;
+
+    public static string $type = 'PipelineReusesTraitModel';
+
+    public static function getFields()
+    {
+        return [
+            [
+                'name' => 'Note',
+                'type' => 'Aura\\Base\\Fields\\Text',
+                'slug' => 'note',
+            ],
+        ];
+    }
+}
+
+test('a plain resource save persists meta and never inserts a fields column', function () {
+    $model = new PipelinePlainModel;
+    $model->note = 'hello';
+    $model->save();
+
+    expect($model->exists)->toBeTrue();
+
+    $meta = DB::table('meta')
+        ->where('metable_id', $model->id)
+        ->where('key', 'note')
+        ->first();
+
+    expect($meta)->not->toBeNull()
+        ->and($meta->value)->toBe('hello');
+});
+
+test('a subclass re-using SaveMetaFields saves identically to the plain resource', function () {
+    $model = new PipelineReusesTraitModel;
+    $model->note = 'hello';
+    $model->save();
+
+    expect($model->exists)->toBeTrue();
+
+    $meta = DB::table('meta')
+        ->where('metable_id', $model->id)
+        ->where('key', 'note')
+        ->first();
+
+    expect($meta)->not->toBeNull()
+        ->and($meta->value)->toBe('hello');
+
+    // Update path stays clean too.
+    $model->note = 'changed';
+    $model->save();
+
+    expect(DB::table('meta')
+        ->where('metable_id', $model->id)
+        ->where('key', 'note')
+        ->value('value'))->toBe('changed');
+});
+
+test('the saving pipeline runs its steps in canonical order regardless of listener registration', function () {
+    $model = new PipelineReusesTraitModel;
+    $model->note = 'ordered';
+    $model->save();
+
+    $row = DB::table('posts')->where('id', $model->id)->first();
+
+    // Initial post columns were applied (step 1)...
+    expect($row->type)->toBe('PipelineReusesTraitModel')
+        ->and($row->user_id)->toBe($this->user->id);
+
+    // ...and the packed `fields` array was fully consumed (steps 2+3):
+    // it must exist neither as a column value nor as a lingering attribute.
+    expect(property_exists($row, 'fields'))->toBeFalse()
+        ->and($model->getAttributes())->not->toHaveKey('fields')
+        ->and($model->getAttributes())->not->toHaveKey('note');
+});


### PR DESCRIPTION
Closes #37.

## The real root cause (not parallel pollution)

The failure reproduces with `AdvancedSelectFieldVariationsTest` run **alone** on PHP 8.5 — the parallel-scheduling framing in the issue was a red herring (8.4 never fails, so parallelism looked causal).

- Laravel 13 rewrote `Model::bootTraits()` to iterate `ReflectionClass::getMethods()` (for `#[Boot]` attribute support) instead of `class_uses_recursive()` order.
- **PHP 8.5 changed reflection method ordering**: a trait method re-imported by a subclass now reflects *before* inherited methods (8.4 put it last). Minimal case in the PR discussion.
- The test file's `HasManyFieldOptionsModel5` re-`use`s `SaveMetaFields` (which base `Resource` already uses) → on 8.5 its boot method runs **first**, registering the meta consumer before the field packer. The consumer saw no `fields` yet; the packer then created it; nothing removed it → the literal `fields` array leaked into the INSERT: `table posts has no column named fields`.

## Fix

The three save steps (initial post columns → pack field attributes → persist meta) are now **one saving listener with hard-coded step order** (plus the saved-phase meta flush), registered in `SaveFieldAttributes::bootSaveFieldAttributes()`. `InitialPostFields` and `SaveMetaFields` keep their logic as named steps without boot methods — re-`use`ing them in a subclass is now inert. Logic bodies are unchanged verbatim; only the registration topology changed.

Registration deliberately stays in a trait boot (not `Resource::booted()`): `Option` and one test model override `booted()` without calling parent.

## Verification

- Full parallel suite green **3× consecutively on PHP 8.5.8** (1814 passed) — previously deterministic failure
- Full suite green on PHP 8.4, Teams-off suite green, Pint + PHPStan clean
- New `SavePipelineBootOrderTest` pins the scenario (plain subclass + re-`use`ing subclass + step-order assertions); the existing Model5 test remains as the organic regression case
- PHP **8.5 re-added to the CI matrix** for Laravel 12 and 13 (the other half of #37, the shared testbench app path, was already fixed in 2b41083a)

## Note for upstream

Laravel's reflection-order-dependent `bootTraits()` makes trait boot order PHP-version-dependent for any subclass re-using a parent trait — arguably worth a framework issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SfSSvBDCogBXr2PfhC6MM