### PR TITLE
Slim media IDOR + table mutation auth (follow-up to #75)

### DIFF
--- a/config/aura.php
+++ b/config/aura.php
@@ -103,6 +103,53 @@ return [
         'gray-color-palette' => 'slate',
         'darkmode-type' => 'auto',
 
+        /*
+        | The system stack is the default and makes no network requests. To use
+        | a custom font, publish/serve its CSS in the host application and set
+        | stylesheet to a local public path such as "fonts/brand.css".
+        */
+        'font' => [
+            'family' => [
+                'ui-sans-serif',
+                'system-ui',
+                'sans-serif',
+                'Apple Color Emoji',
+                'Segoe UI Emoji',
+                'Segoe UI Symbol',
+                'Noto Color Emoji',
+            ],
+            'stylesheet' => false,
+        ],
+
+        /*
+        | Semantic colors are RGB channel strings so Tailwind opacity modifiers
+        | keep working. CSS custom-property references are also supported.
+        */
+        'colors' => [
+            'light' => [
+                'primary' => 'var(--primary-600)',
+                'background' => '255 255 255',
+                'panel' => '250 250 250',
+                'border' => '228 228 231',
+                'text' => '24 24 27',
+                'muted' => '82 82 91',
+                'success' => '22 163 74',
+                'warning' => '217 119 6',
+                'danger' => '220 38 38',
+            ],
+            'dark' => [
+                'primary' => 'var(--primary-600)',
+                'background' => '9 9 11',
+                'panel' => '24 24 27',
+                'border' => '63 63 70',
+                'text' => '244 244 245',
+                'muted' => '161 161 170',
+                'success' => '22 163 74',
+                'warning' => '217 119 6',
+                'danger' => '220 38 38',
+            ],
+        ],
+
         'sidebar-size' => 'standard',
         'sidebar-type' => 'dark',
         'sidebar-darkmode-type' => 'dark',
@@ -188,6 +235,23 @@ return [
         'user_invitations' => true,
         'invitation_expiry' => 7,
         'create_teams' => env('AURA_CREATE_TEAMS', true),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reporting
+    |--------------------------------------------------------------------------
+    |
+    | AggregateEngine runs exact physical-column metrics. Typed projection
+    | dual-write/read for meta-backed metrics is not enabled in this build.
+    |
+    */
+
+    'reporting' => [
+        'projection' => [
+            'enabled' => false,
+            'reads_enabled' => false,
+        ],
     ],
 
     /*

--- a/docs/adr/0016-portable-reporting-contract.md
+++ b/docs/adr/0016-portable-reporting-contract.md
@@ -1,0 +1,120 @@
+# Portable reporting uses exact physical values or an additive typed projection
+
+Status: Accepted for CORE-29 implementation
+
+## Context
+
+Aura's reporting consumers currently embed storage and SQL assumptions:
+
+- `ValueWidget` joins the literal `meta` table, casts values `AS SIGNED`, assumes `created_at`, and implements count/average/sum/min/max itself.
+- `Pie` and `Donut` repeat the literal meta join and signed cast, group by a raw label expression, and assume the resource timestamp.
+- `Sparkline` groups with `DATE(created_at)`, uses the signed meta cast, and silently turns a requested aggregate on a missing physical metric into a row count.
+- the generic `Dashboard` also groups with `DATE(created_at)`.
+- `Attachment` has a separate SQLite/MySQL/MariaDB/PostgreSQL month-expression branch.
+
+`meta.value` is long text. Signed integer casts truncate decimals, accept malformed legacy input differently by engine, and are not portable. Direct date functions bucket UTC timestamps rather than the viewer's local calendar.
+
+## Decision
+
+CORE-29 should proceed, but only within this boundary:
+
+1. Introduce one shared, immutable aggregate API consumed by widgets and dashboards. It supports count, sum, average, min, max, optional grouping, and day/week/month/quarter/year buckets.
+2. Aggregate declared physical numeric fields directly. Aggregate declared meta-backed numeric fields only through a typed, indexed projection. Safe dialect-specific text casts are approved for backfill validation and shadow comparison, not for interactive runtime aggregation.
+3. Do not destructively type or rewrite `meta`, and do not change normal Resource persistence. The projection is additive and disposable.
+4. Replace the hard-coded reporting SQL listed above only after equivalent consumers use the shared engine. Table filtering and sorting are separate contracts and are outside CORE-29.
+
+### Public shape
+
+The implementation should expose immutable value objects similar to:
+
+```php
+final readonly class AggregateDefinition
+{
+    public function __construct(
+        public string $resource,
+        public AggregateOperation $operation,
+        public ?string $metric,
+        public ?string $groupBy,
+        public ?DateRange $range,
+        public ?DateBucket $bucket,
+        public string $timezone = 'UTC',
+    ) {}
+}
+
+interface AggregateEngine
+{
+    public function run(AggregateDefinition $definition): AggregateResult;
+}
+```
+
+Names may follow established Aura conventions, but these invariants may not change: callers provide no table, SQL expression, Team, owner, connection, or actor identifier; enum-backed operations and buckets are allowlisted; fields resolve from the Resource declaration; and results are immutable. V1 runs only for the currently authenticated actor. Background reporting needs a later explicit trusted-context contract.
+
+### Grouping semantics
+
+- `groupBy` is optional. V1 accepts only a declared, physical, scalar field on the same Resource. Computed, relationship, arbitrary expression, and meta-backed grouping are rejected. Meta-backed metrics may still be aggregated through the numeric projection while grouping by an eligible physical field.
+- Results contain an ordered list of immutable points: canonical scalar `key`, presentation `label`, aggregate value, and row count. Numeric keys use the same six-decimal canonical form; booleans use `0`/`1`; strings use their stored scalar value. Presentation labels come from the declared field formatter after the query, never from SQL supplied by a caller.
+- Null is one explicit `Empty` point ordered last. Non-null points sort after the bounded query using exact numeric order for Number/Currency and bytewise canonical-key order for other scalars, avoiding database-collation differences. A query fetches at most 101 distinct points and rejects more than 100 rather than silently truncating or merging groups.
+- Existing Pie/Donut definitions that group by a meta-backed field are outside the first CORE-29 cut and must fail configuration validation. Supporting them requires separate typed-text projection evidence; CORE-29 may not reintroduce raw meta grouping.
+
+### Numeric semantics
+
+- Count counts authorized Resource rows after the half-open time range is applied; it does not require a metric.
+- Numeric operations accept declared Number/Currency fields whose configured precision is at most 18 and scale at most 6.
+- Values are normalized to a signed scaled integer (`value * 1,000,000`). Missing, null, blank, malformed, exponent-form, excess-scale, and out-of-range legacy meta values are excluded from numeric operations.
+- Sum/min/max return a canonical decimal string with six fractional digits. Average is exact scaled sum divided by the valid-value count, rounded half away from zero to six digits. An all-null numeric set returns null. Count returns an integer.
+- Overflow fails explicitly; implementations may never fall back to binary floating point.
+
+### Time semantics
+
+- Stored timestamps are UTC. Ranges are half-open: `[start, end)`.
+- A valid IANA timezone selects the viewer's calendar. Buckets are local day, ISO week starting Monday, month, quarter, or year. Date-only fields do not shift timezone.
+- The portable V1 strategy generates bounded UTC bucket boundaries in PHP and uses a bound `CASE` expression. This handles daylight-saving gaps and overlaps without database timezone-table dependencies.
+- A request is limited to 400 bucket points and must reject an invalid timezone, range, or bucket.
+
+### Authorization and tenancy
+
+The engine first authorizes `viewAny` for the resolved Resource, then starts from `Resource::query()` on that Resource's connection. It preserves `TypeScope`, `TeamScope`, `ScopedScope`, soft-delete behavior, `indexQuery()`, and any declared safe query scope. It never accepts client-provided Team/owner predicates and never calls `withoutGlobalScopes()`. Group labels and rows remain inside the same scoped query. This matches the policy/scope contracts already proved by `OwnershipStorageContractTest` and `TeamSharingTest`.
+
+### Projection ownership and lifecycle
+
+CORE-29 may add two Aura-owned tables through exact, additive migrations and the migration ownership manifest:
+
+- `aura_reporting_resources` is a persistent per-Resource coordinator/tombstone with unique `(resource_type, resource_id)`, `present`, optional last processed event ID for diagnostics only, and reconciliation timestamps.
+- `aura_reporting_values` has unique `(resource_type, resource_id, field_key)`, nullable signed `value_scaled`, precision/scale contract version, and timestamps. An index covers `(resource_type, field_key, value_scaled, resource_id)`.
+
+V1 uses Aura's current unsigned-big-integer Resource identity. Both tables live on each Resource's own connection. The live authorized Resource query remains the left side of every reporting join; copied Team/owner values are neither required nor trusted.
+
+CORE-16 event UUIDs and timestamps are not monotonic source versions. CORE-29 must never compare them to decide which state wins. Projection maintenance instead converges from authoritative current state:
+
+1. A listener receives immutable, after-commit `ResourceCreated`, `ResourceUpdated`, `ResourceDeleted`, `ResourceRestored`, or `ResourceForceDeleted` and verifies the recorded connection identity.
+2. On that Resource connection, one transaction `insertOrIgnore`s the coordinator, locks it with `SELECT ... FOR UPDATE`, and only then re-reads the current scoped-independent stored Resource/meta state through a narrow internal projector reader.
+3. If the source exists, the transaction replaces/upserts every currently declared projected numeric field and removes values no longer declared. If it does not exist, it removes all value rows but retains the coordinator tombstone. It then records presence, reconciliation time, and the triggering event ID as diagnostics.
+4. Duplicate and out-of-order events repeat the same reconciliation. They may do redundant work but cannot append duplicates or restore an older event payload because event payload values are never projected. A late update after deletion sees absence; a late delete after ID recreation sees the recreated current row.
+
+The coordinator serializes projectors for the same Resource, including the first projection. A source commit can still occur after a projector's authoritative read; its own after-commit event performs the next reconciliation, so consistency is intentionally eventual. Queue loss, quiet writes, direct SQL, or a worker crash are repaired by an idempotent explicit resync/backfill command that uses the same coordinator algorithm. Operators must run repair after trusted quiet/legacy writes; an optional scheduled bounded repair may be enabled. No correctness claim depends on UUID ordering, wall-clock ordering, or exactly-once delivery.
+
+Deployment is expand/backfill/verify/cut over:
+
+1. create both tables and indexes with reporting reads disabled;
+2. enable event projection, then run a resumable, idempotent, per-Resource-class backfill in bounded keyset chunks;
+3. repeat the same reconciliation pass to close scan/update races;
+4. shadow-read aggregate checks, including rejected legacy values, before enabling meta-backed reads;
+5. switch the feature flag per environment.
+
+Rollback first disables projected reads and returns consumers to their pre-CORE-29 behavior. It preserves projection rows and the migration; destructive rollback is not permitted. A later deploy may resume or rebuild the projection entirely from authoritative Resource/meta state.
+
+## Evidence and threshold
+
+The reproducible harness covers SQLite 3.53.1, MySQL 8.4.11, MariaDB 11.8.8, and PostgreSQL 16.14. The correctness matrix proves exact decimals, excess-scale/out-of-range/exponent/null legacy values, all-null aggregates, numeric ranges, both Europe/Zurich daylight-saving transitions, every approved bucket type, invalid-input rejection, cross-tenant exclusion, and non-empty `EXPLAIN` output for physical, safe-meta, and projection paths. A real-Resource contract proves `viewAny`, `indexQuery()`, owner and Team global scopes, soft-delete exclusion, a genuinely separate Resource/actor connection with its own schema/data, exact Number and Boolean group keys, Select formatter labels, immutable ordered points, null-last behavior, and bounded cardinality without a caller-supplied tenant. A native four-engine reconciliation matrix proves duplicate/out-of-order/update/delete/recreate convergence without ordering event IDs. Each benchmark workload performs one query.
+
+At 100k Resources plus 1.19 million meta rows, the accepted interactive gate is p95 at most 500 ms and no more than five times the physical path on every claimed engine. Direct meta casting fails: MySQL grouped sum reaches 1,366.195 ms and MariaDB reaches 3,042.122 ms; MariaDB aggregate and range also exceed 500 ms. The projection's worst p95 is 198.424 ms. Full results and limitations are in `docs/benchmarks/core-28-reporting-baseline.md` and its JSON companion.
+
+The tested engine versions are the CORE-29 claim. Broader minimum-version claims require CI evidence before release. Benchmark thresholds are regression comparisons on a controlled runner, not production latency promises.
+
+## Consequences
+
+- CORE-29 is authorized to implement the bounded API, projection, backfill/resync, feature flag, and migration plan above.
+- Runtime aggregation over raw meta text is rejected even where one engine's benchmark happens to pass.
+- Physical metrics avoid projection write amplification. Meta numeric reporting gains exact cross-database behavior and indexed ranges at the cost of eventual, after-commit projection maintenance.
+- Production reporting consumers must not add new SQL-dialect branches. The shared engine owns dialect-specific exact expressions and time boundaries.
+- CORE-29 must add Teams-on/off authorization tests, migration interruption/recovery tests, event idempotency/out-of-order tests, and benchmark regression gates before projected reads default on.

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -1,0 +1,93 @@
+# Scoped preferences
+
+Aura preferences are typed declarations stored in the existing `options` table. They add validation,
+explicit context, precedence, and authorization without changing the legacy option API.
+
+This is a **lightweight** layer: storage uses the existing `User`/`Team` option helpers. It does not
+include multi-connection option-identity hardening from experimental branches.
+
+## Declare a key
+
+Register declarations during application boot through the singleton registry:
+
+```php
+use Aura\Base\Preferences\PreferenceDefinition;
+use Aura\Base\Preferences\PreferenceRegistry;
+use Aura\Base\Preferences\PreferenceScope;
+use Aura\Base\Preferences\PreferenceValueType;
+
+app(PreferenceRegistry::class)->register(new PreferenceDefinition(
+    key: 'contacts.density',
+    type: PreferenceValueType::String,
+    default: 'comfortable',
+    scopes: [PreferenceScope::User, PreferenceScope::Team],
+    resourceAware: true,
+    allowedValues: ['comfortable', 'compact'],
+    legacyKeys: ['density.{resource}'],
+));
+```
+
+Keys are unique and must match `a-z`, digits, dots, hyphens, and underscores. Types are strict:
+booleans do not accept `0`, integers do not accept `false`, and nullable declarations preserve a stored
+`null` separately from a missing row. Array declarations may require lists and a typed item schema.
+
+Aura includes UI-neutral examples for `table.view`, `table.columns`,
+`navigation.sidebar.groups`, and `navigation.sidebar.collapsed`. They do not depend on Livewire table or
+navigation components.
+
+## Read and write
+
+```php
+use Aura\Base\Preferences\PreferenceContext;
+use Aura\Base\Preferences\PreferenceManager;
+use Aura\Base\Preferences\PreferenceScope;
+
+$context = new PreferenceContext(
+    application: 'crm',
+    user: $user,
+    team: $team,
+    resource: 'Contact',
+);
+
+$preferences = app(PreferenceManager::class);
+$view = $preferences->get('table.view', $context);
+$result = $preferences->resolve('table.view', $context); // value and winning scope
+
+$preferences->set('table.view', 'kanban', PreferenceScope::User, $context, $actor);
+$preferences->reset('table.view', PreferenceScope::User, $context, $actor);
+```
+
+Reads use only the supplied context. They never consult the authenticated user, so HTTP requests, queue
+workers, CLI commands, and team switches resolve the same context identically. Writes also require an
+explicit actor. A user may write only their own user scope; a team owner or Global Admin may write team
+scope; only a Global Admin may write everyone scope. Guest writes fail.
+
+## Precedence
+
+For resource-aware keys, resolution is deterministic:
+
+1. resource-specific user, team, everyone
+2. application-wide user, team, everyone
+3. declared default
+
+Unsupported scopes and missing context subjects are skipped during reads. Writes reject unsupported scopes.
+Everyone scope is optional per declaration. With teams enabled it uses the reserved option ownership
+`team_id = 0`; Team and user model writes reject that identity, and TeamScope fails closed if a persisted
+current-team pointer contains it. Normal tenant queries therefore cannot see the everyone row or become
+unscoped. Direct edits to reserved Option rows invalidate the global preference cache. This avoids a
+destructive schema migration and keeps the existing `(team_id, name)` uniqueness guarantee.
+
+Team-scoped reads are skipped when teams are disabled, so resolution continues to everyone or the declared
+default. Team-scoped writes and resets are rejected before an option storage adapter is called.
+
+## Existing options and migration
+
+`User::getOption()`, `updateOption()`, and `deleteOption()` and their Team equivalents remain unchanged.
+Preference declarations may list `legacyKeys`, including `{application}` and `{resource}` placeholders.
+Aura reads the canonical hashed preference identity first, then those legacy names. New writes use only the
+canonical identity. Reset removes both the canonical row and declared aliases for that exact scope/context.
+No data migration is required; applications can migrate lazily as users change preferences.
+
+The explicit low-level adapters `User::getOptionEntryForTeam()`, `updateOptionForTeam()`,
+`deleteOptionForTeam()`, and `Team::getOptionEntryExplicit()` exist for trusted services. They do not perform
+authorization themselves. Use `PreferenceManager` for user-triggered writes.

--- a/docs/record-layouts.md
+++ b/docs/record-layouts.md
@@ -1,0 +1,100 @@
+# Record layouts
+
+Aura record pages expose five stable regions:
+
+- `header-actions`
+- `left-summary`
+- `main-content`
+- `right-sidebar`
+- `activity-timeline`
+
+The built-in header, actions, title, and resource fields remain the default content. When no panel is
+registered or visible, Aura renders the original record view. Custom `viewView()` implementations remain an
+opt-out and may build their own layout.
+
+## Plugin panels
+
+Register panels from a non-deferred service provider before the application finishes booting. Definitions
+are immutable and contain only scalar values, enums, and class strings.
+
+```php
+use Aura\Base\Facades\Aura;
+use Aura\Base\RecordLayout\RecordLayoutPanel;
+use Aura\Base\RecordLayout\RecordLayoutRegion;
+use Vendor\Package\Livewire\ContactHealthPanel;
+
+public function boot(): void
+{
+    Aura::registerRecordLayoutPanels('vendor/package', [
+        new RecordLayoutPanel(
+            key: 'contact-health',
+            region: RecordLayoutRegion::RightSidebar,
+            component: ContactHealthPanel::class,
+            order: 20,
+            resources: ['contact'],
+            ability: 'view-health',
+            preferenceKey: 'contacts.show-health',
+            eagerLoad: ['owner'],
+        ),
+    ]);
+}
+```
+
+Panel keys are unique within their Composer package source. Ordering is deterministic by region, numeric
+order, package source, then panel key. A duplicate declaration is idempotent; a conflicting duplicate is
+rejected atomically. Invalid, missing, abstract, or incompatible Livewire component classes are rejected.
+
+Panel components receive the canonical record and modal state. They must accept both inputs as public
+properties or `mount()` parameters and must re-authorize every state-changing Livewire action:
+
+```php
+use Aura\Base\Resource;
+use Livewire\Component;
+
+class ContactHealthPanel extends Component
+{
+    public bool $inModal = false;
+
+    public Resource $model;
+
+    public function render(): string
+    {
+        return '<div>...</div>';
+    }
+}
+```
+
+`ability` is checked against the record before initial rendering. `visible: false` always hides a panel.
+`preferenceKey` must identify a registered boolean CORE-23 preference; `true` shows the panel and every
+missing, invalid, or false value fails closed. Repeated keys are resolved once per record render. Declared
+relationships are deduplicated and loaded together before panels render; panel views must not query the
+record again.
+
+CORE-20 component slots remain one-for-one replacement points. Record layouts follow the same validated,
+boot-time Livewire transport approach, but use this separate registry because record regions deliberately
+allow multiple ordered contributors.
+
+## Resource panels
+
+A resource can own panels without changing Aura's base `Resource` class:
+
+```php
+use Aura\Base\RecordLayout\DefinesRecordLayoutPanels;
+
+class Contact extends Resource implements DefinesRecordLayoutPanels
+{
+    public static function recordLayoutPanels(): array
+    {
+        return [
+            new RecordLayoutPanel(
+                key: 'summary',
+                region: RecordLayoutRegion::LeftSummary,
+                component: ContactSummaryPanel::class,
+            ),
+        ];
+    }
+}
+```
+
+Resource-owned panels are automatically scoped to that resource. Both plugin and resource registrations are
+captured in Aura's worker baseline so request and queue resets cannot leak or discard declarations.

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -7,6 +7,7 @@ Aura CMS provides a comprehensive theming system that gives you complete control
 - [Overview](#overview)
 - [Theme Architecture](#theme-architecture)
 - [Configuration](#configuration)
+- [Semantic Theme Tokens](#semantic-theme-tokens)
 - [Color Palettes](#color-palettes)
 - [Dark Mode](#dark-mode)
 - [Sidebar Themes](#sidebar-themes)
@@ -118,6 +119,96 @@ $darkMode = $theme['darkmode-type'] ?? 'auto';
 $isDark = $darkMode === 'dark' || 
     ($darkMode === 'auto' && // Check system preference);
 ```
+
+## Semantic Theme Tokens
+
+Aura's token contract lets a host configure common application surfaces from
+`config/aura.php`. Values are rendered as CSS custom properties at runtime so a
+host-owned Tailwind build and Aura's package styles share the same tokens.
+
+```php
+'theme' => [
+    'color-palette' => 'aura',
+    'gray-color-palette' => 'slate',
+    'darkmode-type' => 'auto',
+
+    'font' => [
+        'family' => [
+            'ui-sans-serif',
+            'system-ui',
+            'sans-serif',
+            'Apple Color Emoji',
+            'Segoe UI Emoji',
+            'Segoe UI Symbol',
+            'Noto Color Emoji',
+        ],
+        'stylesheet' => false,
+    ],
+
+    // RGB channels without rgb(...), so Tailwind opacity modifiers keep working.
+    'colors' => [
+        'light' => [
+            'primary' => 'var(--primary-600)',
+            'background' => '255 255 255',
+            'panel' => '250 250 250',
+            'border' => '228 228 231',
+            'text' => '24 24 27',
+            'muted' => '82 82 91',
+            'success' => '22 163 74',
+            'warning' => '217 119 6',
+            'danger' => '220 38 38',
+        ],
+        'dark' => [
+            'primary' => 'var(--primary-600)',
+            'background' => '9 9 11',
+            'panel' => '24 24 27',
+            'border' => '63 63 70',
+            'text' => '244 244 245',
+            'muted' => '161 161 170',
+            'success' => '22 163 74',
+            'warning' => '217 119 6',
+            'danger' => '220 38 38',
+        ],
+    ],
+],
+```
+
+Public runtime variables:
+
+```css
+--aura-font-sans
+--aura-color-primary
+--aura-color-background
+--aura-color-panel
+--aura-color-border
+--aura-color-text
+--aura-color-muted
+--aura-color-success
+--aura-color-warning
+--aura-color-danger
+```
+
+The `.dark` selector swaps dark values. Existing `--primary-*`, `--gray-*`, and
+`--sidebar-*` utilities remain supported.
+
+Tailwind semantic colors use `aura.*` utilities and `font-sans` resolves to
+`var(--aura-font-sans)`.
+
+### Local custom fonts
+
+The default system stack makes no font network request. To opt into a custom
+font, serve the stylesheet from the host application and set:
+
+```php
+'theme' => [
+    'font' => [
+        'family' => ['Acme Sans', 'sans-serif'],
+        'stylesheet' => 'fonts/acme-sans.css', // local public path only
+    ],
+],
+```
+
+Remote stylesheets (`https://…`, `//…`, `data:…`) are rejected.
 
 ## Color Palettes
 

--- a/resources/views/components/layout/colors.blade.php
+++ b/resources/views/components/layout/colors.blade.php
@@ -1,7 +1,13 @@
 @php
     use Aura\Base\TransformColor;
 
-    // Assuming $settings is already defined
+    $settings = \Aura\Base\ThemeTokens::resolve(
+        isset($settings) && is_array($settings) ? $settings : [],
+    );
+    $fontFamily = \Aura\Base\ThemeTokens::fontFamily($settings);
+    $lightColors = \Aura\Base\ThemeTokens::colors($settings, 'light');
+    $darkColors = \Aura\Base\ThemeTokens::colors($settings, 'dark');
+
     $colorShades = ['25', '50', '100', '200', '300', '400', '500', '600', '700', '800', '900', '950'];
     $grayShades = ['25', '50', '100', '200', '300', '400', '500', '600', '700', '800', '900', '950'];
 
@@ -1052,6 +1058,12 @@
 
 <style>
     :root {
+        --aura-font-sans: {!! $fontFamily !!};
+
+        @foreach ($lightColors as $key => $value)
+            --aura-color-{{ $key }}: {{ $value }};
+        @endforeach
+
         @foreach ($colors as $key => $value)
             --{{ $key }}: {{ $value }};
         @endforeach
@@ -1064,6 +1076,12 @@
     :root {
         @foreach ($grayColors as $key => $value)
             --{{ $key }}: {{ $value }};
+        @endforeach
+    }
+
+    .dark {
+        @foreach ($darkColors as $key => $value)
+            --aura-color-{{ $key }}: {{ $value }};
         @endforeach
     }
 </style>

--- a/resources/views/components/layout/styles.blade.php
+++ b/resources/views/components/layout/styles.blade.php
@@ -1,16 +1,18 @@
 @php
-    $settings = app('aura')::getOption('settings') ?? [];
-    $appSettings = app('aura')::options() ?? [];
-
-    $settings = empty($settings) ? config('aura.theme') : $settings;
-    $appSettings = empty($appSettings) ? config('aura.theme') : $appSettings;
+    $storedSettings = isset($settings) && is_array($settings)
+        ? $settings
+        : (app('aura')::getOption('settings') ?? []);
+    $settings = \Aura\Base\ThemeTokens::resolve($storedSettings);
+    $fontStylesheet = \Aura\Base\ThemeTokens::fontStylesheet($settings);
 @endphp
 
 <style>[x-cloak] {
     display: none !important;
 }</style>
 
-<link rel="stylesheet" href="/vendor/aura/public/inter.css">
+@if ($fontStylesheet)
+    <link rel="stylesheet" href="{{ asset($fontStylesheet) }}" data-aura-font>
+@endif
 
 {{-- @vite(['resources/css/app.css'], 'vendor/aura') --}}
 

--- a/resources/views/components/table/kanban-view.blade.php
+++ b/resources/views/components/table/kanban-view.blade.php
@@ -1,29 +1,64 @@
 {{-- resources/views/components/table/kanban-view.blade.php --}}
-<div class="kanban-board flex overflow-x-auto p-4 space-x-4">
-    @php
-        $statuses = ['New', 'In Progress', 'Completed'];
-    @endphp
+@php
+    $kanban = $kanban ?? $this->resolvedKanbanConfiguration();
+    $groupField = $kanban['group_field'] ?? 'status';
+    $cardTitle = $kanban['card_title'] ?? 'title';
+    $cardSubtitle = $kanban['card_subtitle'] ?? null;
+    $showEmptyColumns = $kanban['show_empty_columns'] ?? true;
+    $items = method_exists($rows, 'items') ? collect($rows->items()) : collect($rows);
+@endphp
 
-    @foreach ($statuses as $status)
-        <div class="kanban-column flex-shrink-0 w-80 bg-gray-950/[0.04] dark:bg-white/5 rounded-xl p-4">
-            <h3 class="text-sm font-semibold text-gray-900 dark:text-white mb-4">{{ $status }}</h3>
-            <div class="space-y-3">
-                @foreach ($rows->filter(function ($row) use ($status) {
-                    return $row->status == $status;
-                }) as $row)
-                    <div class="bg-white dark:bg-gray-800 p-4 rounded-lg ring-1 ring-gray-950/10 dark:ring-white/10 shadow-xs">
-                        <h4 class="text-sm font-semibold text-gray-900 dark:text-white">{{ $row->subject }}</h4>
-                        <p class="text-sm text-gray-600 dark:text-gray-400">{{ $row->from }}</p>
-                        <p class="text-sm text-gray-600 dark:text-gray-400">Due: {{ $row->due_date }}</p>
-                        <div class="mt-2 flex justify-between items-center">
-                            <span class="text-xs text-gray-700 dark:text-gray-300 bg-gray-950/5 dark:bg-white/10 rounded-full px-2 py-1">{{ $row->category }}</span>
-                            @if($row->assigned_to)
-                                <span class="text-xs text-gray-600 dark:text-gray-400">Assigned: {{ $row->assigned_to }}</span>
+<div class="kanban-board flex gap-4 overflow-x-auto p-4" wire:key="kanban-board-{{ $model->getType() }}">
+    @foreach ($this->kanbanStatuses as $columnKey => $column)
+        @php
+            $columnRows = $items->filter(
+                fn ($row) => (string) data_get($row, $groupField) === (string) $columnKey
+            );
+        @endphp
+
+        @continue(! ($column['visible'] ?? true) || (! $showEmptyColumns && $columnRows->isEmpty()))
+
+        <section class="kanban-column w-80 flex-shrink-0 rounded-xl bg-gray-950/[0.04] p-4 dark:bg-white/5"
+            data-kanban-column="{{ $columnKey }}"
+            wire:key="kanban-column-{{ $model->getType() }}-{{ $columnKey }}">
+            <h3 class="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-white">
+                @if (! empty($column['color']))
+                    <span class="size-2 rounded-full {{ $column['color'] }}" aria-hidden="true"></span>
+                @endif
+                <span>{{ __($column['value'] ?? $columnKey) }}</span>
+                <span class="text-xs font-normal text-gray-500 dark:text-gray-400">{{ $columnRows->count() }}</span>
+            </h3>
+
+            <div class="min-h-12 space-y-3">
+                @if ($columnRows->isEmpty())
+                    <div class="h-12" data-kanban-dropzone="{{ $columnKey }}"></div>
+                @endif
+
+                @foreach ($columnRows as $row)
+                    <article class="rounded-lg bg-white p-4 shadow-xs ring-1 ring-gray-950/10 dark:bg-gray-800 dark:ring-white/10"
+                        data-kanban-card="{{ $row->getKey() }}"
+                        wire:key="kanban-card-{{ $model->getType() }}-{{ $row->getKey() }}">
+                        <div class="min-w-0">
+                            <h4 class="text-sm font-semibold text-gray-900 dark:text-white">
+                                @if (method_exists($row, 'display'))
+                                    {!! $row->display($cardTitle) !!}
+                                @else
+                                    {{ data_get($row, $cardTitle) }}
+                                @endif
+                            </h4>
+                            @if ($cardSubtitle)
+                                <div class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                    @if (method_exists($row, 'display'))
+                                        {!! $row->display($cardSubtitle) !!}
+                                    @else
+                                        {{ data_get($row, $cardSubtitle) }}
+                                    @endif
+                                </div>
                             @endif
                         </div>
-                    </div>
+                    </article>
                 @endforeach
             </div>
-        </div>
+        </section>
     @endforeach
 </div>

--- a/resources/views/components/table/switch-view.blade.php
+++ b/resources/views/components/table/switch-view.blade.php
@@ -1,4 +1,4 @@
-@if ($model->tableGridView() || $model->tableKanbanView())
+@if ($model->tableGridView() || ($this->resolvedKanbanConfiguration()['enabled'] ?? false) || $model->tableKanbanView())
     @php
         $switchBase = 'inline-flex relative items-center p-1.5 rounded-md transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500';
         $switchActive = 'bg-white text-gray-900 shadow-xs ring-1 ring-gray-950/[0.07] dark:bg-gray-700 dark:text-white dark:ring-white/10';
@@ -20,7 +20,7 @@
                 </button>
             @endif
 
-            @if ($model->tableKanbanView())
+            @if (($this->resolvedKanbanConfiguration()['enabled'] ?? false) || $model->tableKanbanView())
                 <button wire:click="switchView('kanban')" type="button"
                     class="{{ $switchBase }} {{ ($currentView ?? null) == 'kanban' ? $switchActive : $switchIdle }}">
                     <span class="sr-only">Kanban View</span>

--- a/resources/views/components/widgets/bar.blade.php
+++ b/resources/views/components/widgets/bar.blade.php
@@ -33,7 +33,7 @@
   border-radius: 8px !important; /* Add border-radius to the tooltip */
   padding: 12px !important; /* Adjust the tooltip padding */
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1) !important; /* Add a subtle shadow */
-  font-family: 'Inter', system-ui, sans-serif !important;
+  font-family: var(--aura-font-sans) !important;
 }
 
 /* ApexCharts Tooltip Title (X-axis value) */
@@ -49,14 +49,14 @@
 
   color: rgb(var(--gray-800)); /* Change the tooltip title color */
   margin-bottom: 0px !important; /* Adjust the space between the title and content */
-  font-family: 'Inter', system-ui, sans-serif !important;
+  font-family: var(--aura-font-sans) !important;
 }
 .apexcharts-text {
-  font-family: 'Inter', system-ui, sans-serif !important;
+  font-family: var(--aura-font-sans) !important;
   font-size: 12px;
 }
 .apexcharts-tooltip-text {
-  font-family: 'Inter', system-ui, sans-serif !important;
+  font-family: var(--aura-font-sans) !important;
   padding: 0px !important;
   font-size: 13px !important;
   line-height: 13px !important;

--- a/resources/views/livewire/resource/record-layout/default-main.blade.php
+++ b/resources/views/livewire/resource/record-layout/default-main.blade.php
@@ -1,0 +1,52 @@
+@if($model::usesTitle())
+<div class="mb-4">
+    <x-aura::fields.wrapper :field="['slug' => 'title']" wrapperClass="" class="-mx-4">
+        <x-aura::input.text label="Title" wire:model="post.title" error="post.title" placeholder="Title">
+        </x-aura::input.text>
+    </x-aura::fields.wrapper>
+</div>
+@endif
+
+<div class="grid gap-6 mt-4 aura-view-post-container sm:grid-cols-3" x-data="{
+     init() {
+        const container = document.querySelector('.aura-view-post-container');
+        const inputs = container.querySelectorAll('input, select, textarea, .aura-input');
+
+        inputs.forEach((input) => {
+            if (!input.hasAttribute('readonly')) {
+               // input.setAttribute('readonly', true);
+            }
+        });
+    }
+}">
+
+    <div class="col-span-1 mx-0 sm:col-span-3">
+        <div class="flex flex-wrap items-start -mx-2" wire:key="resource-view-fields">
+            @foreach($this->viewFields as $key => $field)
+            <x-aura::fields.conditions :field="$field" :model="$model" wire:key="resource-field-{{ $key }}">
+                <x-dynamic-component :component="$field['field']->view()" :field="$field" :form="$form" :mode="$mode" />
+            </x-aura::fields.conditions>
+            @endforeach
+        </div>
+
+        <div>
+            @if (count($errors->all()))
+        <div class="block">
+            <div class="mt-8 form_errors">
+                <strong class="block text-red-600">Unfortunately, there were still the following validation
+                    errors:</strong>
+                <div class="text-red-600 prose">
+                    <ul>
+                        @foreach ($errors->all() as $message)
+                        <li>{{ $message }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            </div>
+        </div>
+        @endif
+        </div>
+
+    </div>
+
+</div>

--- a/resources/views/livewire/resource/record-layout/layout.blade.php
+++ b/resources/views/livewire/resource/record-layout/layout.blade.php
@@ -1,0 +1,33 @@
+@php
+    $leftPanels = $recordLayout->panels(\Aura\Base\RecordLayout\RecordLayoutRegion::LeftSummary);
+    $rightPanels = $recordLayout->panels(\Aura\Base\RecordLayout\RecordLayoutRegion::RightSidebar);
+    $mainColumns = ($leftPanels !== [] ? 3 : 0) + ($rightPanels !== [] ? 3 : 0);
+@endphp
+
+<div
+    class="grid grid-cols-1 gap-6 mt-4 aura-record-layout lg:grid-cols-12"
+    data-record-layout="{{ $inModal ? 'modal' : 'page' }}"
+>
+    @if ($leftPanels !== [])
+        <aside class="space-y-4 lg:col-span-3" data-record-layout-region="left-summary">
+            @include('aura::livewire.resource.record-layout.region', ['region' => \Aura\Base\RecordLayout\RecordLayoutRegion::LeftSummary])
+        </aside>
+    @endif
+
+    <main class="space-y-6 {{ match ($mainColumns) { 6 => 'lg:col-span-6', 3 => 'lg:col-span-9', default => 'lg:col-span-12' } }}" data-record-layout-region="main-content">
+        @include('aura::livewire.resource.record-layout.default-main')
+        @include('aura::livewire.resource.record-layout.region', ['region' => \Aura\Base\RecordLayout\RecordLayoutRegion::MainContent])
+
+        @if ($recordLayout->panels(\Aura\Base\RecordLayout\RecordLayoutRegion::ActivityTimeline) !== [])
+            <section class="space-y-4" data-record-layout-region="activity-timeline">
+                @include('aura::livewire.resource.record-layout.region', ['region' => \Aura\Base\RecordLayout\RecordLayoutRegion::ActivityTimeline])
+            </section>
+        @endif
+    </main>
+
+    @if ($rightPanels !== [])
+        <aside class="space-y-4 lg:col-span-3" data-record-layout-region="right-sidebar">
+            @include('aura::livewire.resource.record-layout.region', ['region' => \Aura\Base\RecordLayout\RecordLayoutRegion::RightSidebar])
+        </aside>
+    @endif
+</div>

--- a/resources/views/livewire/resource/record-layout/panel.blade.php
+++ b/resources/views/livewire/resource/record-layout/panel.blade.php
@@ -1,0 +1,11 @@
+<div
+    data-record-layout-panel="{{ $registeredPanel->identity() }}"
+    wire:key="record-layout-panel-{{ hash('sha256', $registeredPanel->identity()) }}"
+>
+    <livewire:dynamic-component
+        :is="$registeredPanel->transport()"
+        :model="$model"
+        :in-modal="$inModal"
+        :wire:key="$registeredPanel->transport().'-'.$model->getKey().'-'.($inModal ? 'modal' : 'page')"
+    />
+</div>

--- a/resources/views/livewire/resource/record-layout/region.blade.php
+++ b/resources/views/livewire/resource/record-layout/region.blade.php
@@ -1,0 +1,5 @@
+@props(['region'])
+
+@foreach ($recordLayout->panels($region) as $registeredPanel)
+    @include('aura::livewire.resource.record-layout.panel', ['registeredPanel' => $registeredPanel])
+@endforeach

--- a/resources/views/livewire/resource/view-header.blade.php
+++ b/resources/views/livewire/resource/view-header.blade.php
@@ -1,4 +1,4 @@
-<div class="flex items-center justify-between my-8">
+<div class="flex items-center justify-between my-8 {{ $recordLayout->hasPanels() ? 'flex-wrap gap-4' : '' }}">
     <div>
         @yield('view-header')
         <h1 class="text-2xl font-semibold">
@@ -6,7 +6,15 @@
         </h1>
     </div>
 
-    <div class="flex items-center space-x-2">
+    <div class="flex items-center {{ $recordLayout->hasPanels() ? 'flex-wrap gap-2' : 'space-x-2' }}">
+        @if ($recordLayout->panels(\Aura\Base\RecordLayout\RecordLayoutRegion::HeaderActions) !== [])
+            <div class="flex flex-wrap items-center gap-2" data-record-layout-region="header-actions">
+                @foreach ($recordLayout->panels(\Aura\Base\RecordLayout\RecordLayoutRegion::HeaderActions) as $registeredPanel)
+                    @include('aura::livewire.resource.record-layout.panel', ['registeredPanel' => $registeredPanel])
+                @endforeach
+            </div>
+        @endif
+
         @include('aura::livewire.resource.actions')
 
         @can('update', $model)

--- a/resources/views/livewire/resource/view.blade.php
+++ b/resources/views/livewire/resource/view.blade.php
@@ -16,57 +16,10 @@
 
     @include($model->viewHeaderView())
 
-    @if($model::usesTitle())
-    <div class="mb-4">
-        <x-aura::fields.wrapper :field="['slug' => 'title']" wrapperClass="" class="-mx-4">
-            <x-aura::input.text label="Title" wire:model="post.title" error="post.title" placeholder="Title">
-            </x-aura::input.text>
-        </x-aura::fields.wrapper>
-    </div>
+    @if ($recordLayout->hasPanels())
+        @include('aura::livewire.resource.record-layout.layout')
+    @else
+        @include('aura::livewire.resource.record-layout.default-main')
     @endif
-
-    <div class="grid gap-6 mt-4 aura-view-post-container sm:grid-cols-3" x-data="{
-         init() {
-            const container = document.querySelector('.aura-view-post-container');
-            const inputs = container.querySelectorAll('input, select, textarea, .aura-input');
-
-            inputs.forEach((input) => {
-                if (!input.hasAttribute('readonly')) {
-                   // input.setAttribute('readonly', true);
-                }
-            });
-        }
-    }">
-
-        <div class="col-span-1 mx-0 sm:col-span-3">
-            <div class="flex flex-wrap items-start -mx-2" wire:key="resource-view-fields">
-                @foreach($this->viewFields as $key => $field)
-                <x-aura::fields.conditions :field="$field" :model="$model" wire:key="resource-field-{{ $key }}">
-                    <x-dynamic-component :component="$field['field']->view()" :field="$field" :form="$form" :mode="$mode" />
-                </x-aura::fields.conditions>
-                @endforeach
-            </div>
-
-            <div>
-                @if (count($errors->all()))
-            <div class="block">
-                <div class="mt-8 form_errors">
-                    <strong class="block text-red-600">Unfortunately, there were still the following validation
-                        errors:</strong>
-                    <div class="text-red-600 prose">
-                        <ul>
-                            @foreach ($errors->all() as $message)
-                            <li>{{ $message }}</li>
-                            @endforeach
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            @endif
-            </div>
-
-        </div>
-
-    </div>
 
 </div>

--- a/resources/views/livewire/styleguide.blade.php
+++ b/resources/views/livewire/styleguide.blade.php
@@ -189,7 +189,7 @@
         <span class="text-xs font-semibold tracking-wider uppercase text-primary-600 dark:text-primary-400">02</span>
         <h2 class="mt-1 text-xl font-semibold text-gray-900 dark:text-white">{{ __('Typography') }}</h2>
         <p class="mt-1 max-w-2xl text-sm text-gray-500 dark:text-gray-400">
-            {{ __('Font family: Inter. The admin mostly lives between text-xs and text-2xl.') }}
+            {{ __('Font family: configured through the Aura theme. The admin mostly lives between text-xs and text-2xl.') }}
         </p>
 
         <div class="p-6 mt-6 bg-white rounded-xl ring-1 shadow-sm dark:bg-gray-800 ring-gray-950/10 dark:ring-white/10">

--- a/src/Aura.php
+++ b/src/Aura.php
@@ -8,6 +8,8 @@ use Aura\Base\Livewire\Resource\Index;
 use Aura\Base\Livewire\Resource\View;
 use Aura\Base\Models\Scopes\ScopedScope;
 use Aura\Base\Models\Scopes\TeamScope;
+use Aura\Base\RecordLayout\RecordLayoutPanel;
+use Aura\Base\RecordLayout\RecordLayoutRegistry;
 use Aura\Base\Resources\Attachment;
 use Aura\Base\Resources\Option;
 use Aura\Base\Resources\User;
@@ -21,6 +23,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use LogicException;
 use RuntimeException;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -84,6 +87,10 @@ class Aura
         $this->baselineInjectViews = $this->injectViews;
         $this->baselineResources = $this->resources;
         $this->baselineWidgets = $this->widgets;
+
+        if (app()->bound(RecordLayoutRegistry::class)) {
+            app(RecordLayoutRegistry::class)->captureBaselineState($this->getResources());
+        }
     }
 
     public static function checkCondition($model, $field, $post = null)
@@ -148,6 +155,10 @@ class Aura
         $this->injectViews = $this->baselineInjectViews;
         $this->resources = $this->baselineResources;
         $this->widgets = $this->baselineWidgets;
+
+        if (app()->bound(RecordLayoutRegistry::class)) {
+            app(RecordLayoutRegistry::class)->flushState();
+        }
 
         ConditionalLogic::clearConditionsCache();
         Resource::flushFieldCache();
@@ -401,6 +412,18 @@ class Aura
     public function registerInjectView(string $name, Closure $callback): void
     {
         $this->injectViews[$name][] = $callback;
+    }
+
+    /**
+     * @param  list<RecordLayoutPanel>  $panels
+     */
+    public function registerRecordLayoutPanels(string $source, array $panels): void
+    {
+        if (! app()->bound(RecordLayoutRegistry::class)) {
+            throw new LogicException('Record layout panels require Aura to be resolved through the application container.');
+        }
+
+        app(RecordLayoutRegistry::class)->register($source, $panels);
     }
 
     public function registerResources(array $resources): void

--- a/src/AuraServiceProvider.php
+++ b/src/AuraServiceProvider.php
@@ -32,6 +32,7 @@ use Aura\Base\Livewire\CreateResource;
 use Aura\Base\Livewire\EditResourceField;
 use Aura\Base\Livewire\GlobalSearch;
 use Aura\Base\Livewire\InviteUser;
+use Aura\Base\Livewire\Media\MediaAuthorization;
 use Aura\Base\Livewire\MediaManager;
 use Aura\Base\Livewire\MediaUploader;
 use Aura\Base\Livewire\Modals;
@@ -418,6 +419,7 @@ class AuraServiceProvider extends PackageServiceProvider
         $this->app->singleton(LivewireCollisionInspector::class, ArrayLivewireCollisionInspector::class);
         $this->app->singleton(RecordLayoutRegistry::class);
         $this->app->singleton(RecordLayoutResolver::class);
+        $this->app->singleton(MediaAuthorization::class);
 
         $this->app->scoped('aura', function (): Aura {
             return app(Aura::class);

--- a/src/AuraServiceProvider.php
+++ b/src/AuraServiceProvider.php
@@ -26,6 +26,8 @@ use Aura\Base\Livewire\Attachment\Index as AttachmentIndex;
 use Aura\Base\Livewire\AttachmentDetails;
 use Aura\Base\Livewire\BookmarkPage;
 use Aura\Base\Livewire\ChooseTemplate;
+use Aura\Base\Livewire\ComponentSlots\ArrayLivewireCollisionInspector;
+use Aura\Base\Livewire\ComponentSlots\LivewireCollisionInspector;
 use Aura\Base\Livewire\CreateResource;
 use Aura\Base\Livewire\EditResourceField;
 use Aura\Base\Livewire\GlobalSearch;
@@ -52,6 +54,12 @@ use Aura\Base\Navigation\Navigation as AuraNavigation;
 use Aura\Base\Policies\ResourcePolicy;
 use Aura\Base\Policies\TeamPolicy;
 use Aura\Base\Policies\UserPolicy;
+use Aura\Base\Preferences\PreferenceManager;
+use Aura\Base\Preferences\PreferenceRegistry;
+use Aura\Base\RecordLayout\RecordLayoutRegistry;
+use Aura\Base\RecordLayout\RecordLayoutResolver;
+use Aura\Base\Reporting\AggregateEngine;
+use Aura\Base\Reporting\ResourceAggregateEngine;
 use Aura\Base\Resources\Team;
 use Aura\Base\Resources\User;
 use Aura\Base\Widgets\Bar;
@@ -394,6 +402,8 @@ class AuraServiceProvider extends PackageServiceProvider
             return new AuraNavigation;
         });
 
+        $this->app->singleton(AggregateEngine::class, ResourceAggregateEngine::class);
+
         // Bind the concrete Aura instance as a process-persistent singleton so
         // its resource/field registrations and captured baseline survive across
         // requests on a long-running worker (Octane). Octane clears facade and
@@ -402,6 +412,12 @@ class AuraServiceProvider extends PackageServiceProvider
         // registration after the first request. Per-request mutable state is
         // reset back to the boot baseline via Aura::flushState() instead.
         $this->app->singleton(\Aura\Base\Aura::class);
+
+        $this->app->singleton(PreferenceRegistry::class);
+        $this->app->singleton(PreferenceManager::class);
+        $this->app->singleton(LivewireCollisionInspector::class, ArrayLivewireCollisionInspector::class);
+        $this->app->singleton(RecordLayoutRegistry::class);
+        $this->app->singleton(RecordLayoutResolver::class);
 
         $this->app->scoped('aura', function (): Aura {
             return app(Aura::class);

--- a/src/BaseResource.php
+++ b/src/BaseResource.php
@@ -3,12 +3,13 @@
 namespace Aura\Base;
 
 use Aura\Base\Contracts\DefinesFields;
+use Aura\Base\Contracts\TableResource;
 use Aura\Base\Traits\AuraModelConfig;
 use Aura\Base\Traits\InputFields;
 use Aura\Base\Traits\InteractsWithTable;
 use Illuminate\Database\Eloquent\Model;
 
-class BaseResource extends Model implements DefinesFields
+class BaseResource extends Model implements DefinesFields, TableResource
 {
     use AuraModelConfig;
     use InputFields;

--- a/src/Contracts/DeclaresReportingQueryScopes.php
+++ b/src/Contracts/DeclaresReportingQueryScopes.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Aura\Base\Contracts;
+
+interface DeclaresReportingQueryScopes
+{
+    /** @return list<string> */
+    public static function reportingQueryScopes(): array;
+}

--- a/src/Contracts/ScopesMediaVisibility.php
+++ b/src/Contracts/ScopesMediaVisibility.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Aura\Base\Contracts;
+
+use Aura\Base\Resource;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Builder;
+
+interface ScopesMediaVisibility
+{
+    public function scopeMediaVisibility(
+        Builder $query,
+        Authenticatable $actor,
+        Resource $resource,
+    ): Builder;
+}

--- a/src/Contracts/TableResource.php
+++ b/src/Contracts/TableResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Aura\Base\Contracts;
+
+/**
+ * Capability contract shared by Resource and the public BaseResource table
+ * foundation. Return types remain intentionally open for host-app backward
+ * compatibility with existing resource declarations.
+ */
+interface TableResource extends DefinesFields
+{
+    public function fieldBySlug($slug);
+
+    public function fieldClassBySlug($slug);
+
+    public function getActions();
+
+    public function getBulkActions();
+
+    public function isMetaField($key): bool;
+
+    public function isTableField($key): bool;
+}

--- a/src/Facades/Preferences.php
+++ b/src/Facades/Preferences.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Aura\Base\Facades;
+
+use Aura\Base\Preferences\PreferenceManager;
+use Illuminate\Support\Facades\Facade;
+
+/** @see PreferenceManager */
+class Preferences extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return PreferenceManager::class;
+    }
+}

--- a/src/Fields/Number.php
+++ b/src/Fields/Number.php
@@ -12,6 +12,37 @@ class Number extends Field
 
     public $view = 'aura::fields.view-value';
 
+    /**
+     * Portable exact-query envelope for sorting/filtering/reporting.
+     *
+     * Minimal DEST port: enough for ResourceAggregateEngine precision/scale
+     * checks without the full FieldValueContract Number rewrite.
+     *
+     * @param  array<string, mixed>  $field
+     * @return array{mode: 'decimal'|'integer'|'legacy', precision: int|null, scale: int}
+     */
+    public function exactQueryConfiguration(array $field): array
+    {
+        $isDecimal = ($field['number_type'] ?? null) === 'decimal'
+            || array_key_exists('scale', $field);
+
+        if ($isDecimal) {
+            return [
+                'mode' => 'decimal',
+                'precision' => isset($field['precision']) ? (int) $field['precision'] : 18,
+                'scale' => isset($field['scale']) ? (int) $field['scale'] : 2,
+            ];
+        }
+
+        $precision = array_key_exists('precision', $field) ? (int) $field['precision'] : null;
+
+        return [
+            'mode' => array_key_exists('number_type', $field) ? 'integer' : 'legacy',
+            'precision' => $precision,
+            'scale' => 0,
+        ];
+    }
+
     public function filterOptions()
     {
         return [
@@ -79,6 +110,35 @@ class Number extends Field
             'min' => $field['min'] ?? null,
             'max' => $field['max'] ?? null,
         ];
+    }
+
+    /**
+     * Normalize a value for ExactDecimal comparisons when the full Number
+     * write-contract stack is not present on DEST.
+     *
+     * @param  array<string, mixed>  $field
+     */
+    public function normalizeForExactQuery(mixed $value, array $field): int|string|null
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if (preg_match('/\A[+-]?\d+(?:\.\d+)?\z/', $value) !== 1) {
+            return null;
+        }
+
+        return $value;
     }
 
     public function set($post, $field, $value)

--- a/src/Livewire/ComponentSlots/ArrayLivewireCollisionInspector.php
+++ b/src/Livewire/ComponentSlots/ArrayLivewireCollisionInspector.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Aura\Base\Livewire\ComponentSlots;
+
+use Closure;
+use ReflectionProperty;
+
+/**
+ * Lightweight collision inspector for record-layout panel transports.
+ *
+ * DEST intentionally does not pin Livewire ~4.3.5, so the full Livewire 4.3
+ * internals inspector is not ported. This implementation tracks Aura-owned
+ * claims and reads Livewire's Finder classComponents map only.
+ */
+final class ArrayLivewireCollisionInspector implements LivewireCollisionInspector
+{
+    private const MAX_OWNED_CLAIMS = 100;
+
+    /** @var array<string, string> */
+    private static array $ownedClaims = [];
+
+    public function assertCompatible(): void
+    {
+        // No Livewire-version hard pin on DEST.
+    }
+
+    public function assertOwnedOrReservable(
+        string $identifier,
+        string $intrinsicComponent,
+        Closure $auraResolver,
+    ): void {
+        $owned = self::$ownedClaims[$identifier] ?? null;
+        $existing = $this->existingComponent($identifier);
+
+        if ($owned === $intrinsicComponent) {
+            if ($existing !== null && $existing !== $intrinsicComponent) {
+                throw new ComponentSlotCollision(
+                    "Record layout transport [{$identifier}] collides with [{$existing}]."
+                );
+            }
+
+            return;
+        }
+
+        if ($existing !== null) {
+            throw new ComponentSlotCollision(
+                "Record layout transport [{$identifier}] collides with [{$existing}]."
+            );
+        }
+    }
+
+    public function assertReservable(
+        string $identifier,
+        string $intrinsicComponent,
+        Closure $auraResolver,
+    ): void {
+        $existing = $this->existingComponent($identifier);
+
+        if ($existing !== null) {
+            throw new ComponentSlotCollision(
+                "Record layout transport [{$identifier}] collides with [{$existing}]."
+            );
+        }
+    }
+
+    public function assertUnclaimed(array $identifiers, Closure $auraResolver): void
+    {
+        foreach ($identifiers as $identifier) {
+            if ($this->existingComponent($identifier) !== null) {
+                throw new ComponentSlotCollision(
+                    "Record layout transport [{$identifier}] is already claimed."
+                );
+            }
+        }
+    }
+
+    public function rememberOwnedClaim(string $identifier, string $component): void
+    {
+        if (! array_key_exists($identifier, self::$ownedClaims)
+            && count(self::$ownedClaims) >= self::MAX_OWNED_CLAIMS) {
+            array_shift(self::$ownedClaims);
+        }
+
+        self::$ownedClaims[$identifier] = $component;
+    }
+
+    private function existingComponent(string $identifier): ?string
+    {
+        if (! app()->bound('livewire.finder')) {
+            return null;
+        }
+
+        $finder = app('livewire.finder');
+        $property = new ReflectionProperty($finder, 'classComponents');
+        $property->setAccessible(true);
+        $components = $property->getValue($finder);
+
+        if (! is_array($components)) {
+            return null;
+        }
+
+        $class = $components[$identifier] ?? null;
+
+        return is_string($class) ? $class : null;
+    }
+}

--- a/src/Livewire/ComponentSlots/ComponentSlotCollision.php
+++ b/src/Livewire/ComponentSlots/ComponentSlotCollision.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Aura\Base\Livewire\ComponentSlots;
+
+use RuntimeException;
+
+class ComponentSlotCollision extends RuntimeException {}

--- a/src/Livewire/ComponentSlots/LivewireCollisionInspector.php
+++ b/src/Livewire/ComponentSlots/LivewireCollisionInspector.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Aura\Base\Livewire\ComponentSlots;
+
+use Closure;
+
+interface LivewireCollisionInspector
+{
+    public function assertCompatible(): void;
+
+    public function assertOwnedOrReservable(
+        string $identifier,
+        string $intrinsicComponent,
+        Closure $auraResolver,
+    ): void;
+
+    public function assertReservable(
+        string $identifier,
+        string $intrinsicComponent,
+        Closure $auraResolver,
+    ): void;
+
+    /**
+     * @param  list<string>  $identifiers
+     */
+    public function assertUnclaimed(array $identifiers, Closure $auraResolver): void;
+
+    public function rememberOwnedClaim(string $identifier, string $component): void;
+}

--- a/src/Livewire/Media/InvalidMediaOwnerContext.php
+++ b/src/Livewire/Media/InvalidMediaOwnerContext.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Aura\Base\Livewire\Media;
+
+use RuntimeException;
+
+class InvalidMediaOwnerContext extends RuntimeException {}

--- a/src/Livewire/Media/MediaAuthorization.php
+++ b/src/Livewire/Media/MediaAuthorization.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Aura\Base\Livewire\Media;
+
+use Aura\Base\Contracts\ScopesMediaVisibility;
+use Aura\Base\Resource;
+use Aura\Base\Resources\Attachment;
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use InvalidArgumentException;
+use ReflectionClass;
+
+/**
+ * Lightweight media authorization for attachment visibility and selection.
+ *
+ * Intentionally excludes owner-token brokers, selection state machines, and
+ * cache/PDO identity fortresses from the experimental mega-branch.
+ */
+class MediaAuthorization
+{
+    public function __construct(
+        private readonly Gate $gate,
+        private readonly Guard $guard,
+    ) {}
+
+    public function applyAttachmentVisibility(Builder $query, Authenticatable $actor): Builder
+    {
+        $this->assertCurrentActor($actor);
+        $prototype = $this->attachmentPrototype();
+        $actorGate = $this->gate->forUser($actor);
+        $actorGate->authorize('viewAny', $prototype);
+        $policy = $this->gate->getPolicyFor($prototype);
+
+        if (! $policy instanceof ScopesMediaVisibility) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $policy->scopeMediaVisibility($query, $actor, $prototype);
+    }
+
+    public function authorizeAttachmentCreate(Authenticatable $actor): Resource
+    {
+        $this->assertCurrentActor($actor);
+        $attachment = $this->attachmentPrototype();
+        $this->gate->forUser($actor)->authorize('create', $attachment);
+
+        return $attachment;
+    }
+
+    /**
+     * @param  list<int|string>  $ids
+     * @return Collection<int, resource>
+     */
+    public function authorizeAttachments(array $ids, Authenticatable $actor): Collection
+    {
+        $this->assertCurrentActor($actor);
+        $normalized = $this->normalizeIds($ids);
+        $prototype = $this->attachmentPrototype();
+        $actorGate = $this->gate->forUser($actor);
+
+        if ($normalized === []) {
+            $actorGate->authorize('viewAny', $prototype);
+
+            return new Collection;
+        }
+
+        $attachmentClass = $prototype::class;
+        $query = $this->applyAttachmentVisibility($attachmentClass::query(), $actor);
+        $found = $query->whereKey($normalized)->get()
+            ->keyBy(fn (Resource $attachment): string => (string) $attachment->getKey());
+
+        if ($found->count() !== count($normalized)) {
+            throw new InvalidMediaOwnerContext('One or more media attachments are unavailable.');
+        }
+
+        $ordered = new Collection;
+
+        foreach ($normalized as $id) {
+            $attachment = $found->get($id);
+
+            if (! $attachment instanceof Resource) {
+                throw new InvalidMediaOwnerContext('One or more media attachments are unavailable.');
+            }
+
+            $actorGate->authorize('view', $attachment);
+            $ordered->push($attachment);
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * @param  Collection<int, resource>  $attachments
+     * @return Collection<int, resource>
+     */
+    public function visibleAttachments(Collection $attachments, Authenticatable $actor): Collection
+    {
+        $this->assertCurrentActor($actor);
+        $prototype = $this->attachmentPrototype();
+        $actorGate = $this->gate->forUser($actor);
+        $actorGate->authorize('viewAny', $prototype);
+
+        return $attachments
+            ->filter(function ($attachment) use ($actorGate, $prototype): bool {
+                if (! $attachment instanceof Resource || $attachment::class !== $prototype::class) {
+                    throw new InvalidMediaOwnerContext('The media attachment listing is invalid.');
+                }
+
+                return $actorGate->allows('view', $attachment);
+            })
+            ->values();
+    }
+
+    private function assertCurrentActor(Authenticatable $actor): void
+    {
+        $current = $this->guard->user();
+
+        if (! $current instanceof Authenticatable
+            || (string) $current->getAuthIdentifier() !== (string) $actor->getAuthIdentifier()) {
+            throw new InvalidMediaOwnerContext('The authenticated media actor changed.');
+        }
+    }
+
+    private function attachmentPrototype(): Resource
+    {
+        $attachmentClass = config('aura.resources.attachment', Attachment::class);
+
+        if (! is_string($attachmentClass) || ! class_exists($attachmentClass)
+            || ! is_subclass_of($attachmentClass, Resource::class)
+            || (new ReflectionClass($attachmentClass))->getName() !== ltrim($attachmentClass, '\\')) {
+            throw new InvalidMediaOwnerContext('The configured attachment resource is invalid.');
+        }
+
+        $attachment = app($attachmentClass);
+
+        if (! $attachment instanceof Resource) {
+            throw new InvalidMediaOwnerContext('The configured attachment resource is unavailable.');
+        }
+
+        return $attachment;
+    }
+
+    /**
+     * @param  list<int|string>  $ids
+     * @return list<string>
+     */
+    private function normalizeIds(array $ids): array
+    {
+        if (! array_is_list($ids)) {
+            throw new InvalidArgumentException('Media attachment IDs must be a list.');
+        }
+
+        $normalized = [];
+
+        foreach ($ids as $id) {
+            if ((! is_int($id) && ! is_string($id)) || (string) $id === '') {
+                throw new InvalidArgumentException('Media attachment IDs must contain non-empty integer or string values.');
+            }
+
+            $normalized[] = (string) $id;
+        }
+
+        if (count($normalized) !== count(array_unique($normalized, SORT_STRING))) {
+            throw new InvalidArgumentException('Media attachment IDs must not contain duplicates.');
+        }
+
+        return $normalized;
+    }
+}

--- a/src/Livewire/MediaManager.php
+++ b/src/Livewire/MediaManager.php
@@ -2,7 +2,8 @@
 
 namespace Aura\Base\Livewire;
 
-use Aura\Base\Resources\Attachment;
+use Aura\Base\Livewire\Media\MediaAuthorization;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
@@ -18,7 +19,7 @@ class MediaManager extends Component
 
     public $model;
 
-    public $rowIds = []; // Add this line
+    public $rowIds = [];
 
     public $selected = [];
 
@@ -27,47 +28,55 @@ class MediaManager extends Component
         return 'max-w-7xl';
     }
 
-    public function mount($slug, $selected, $modalAttributes)
+    public function mount($slug, $selected, $modalAttributes = null)
     {
-        $this->selected = $selected;
+        $user = Auth::user();
+
+        if (! $user) {
+            abort(403);
+        }
+
+        $this->selected = collect($selected ?? [])
+            ->map(fn ($id) => (string) $id)
+            ->values()
+            ->toArray();
         $this->fieldSlug = $slug;
         $this->modalAttributes = $modalAttributes;
         $this->field = app($this->model)->fieldBySlug($this->fieldSlug);
-        $this->rowIds = Attachment::pluck('id')->toArray(); // Add this line to populate rowIds
+        $this->rowIds = [];
+
+        app(MediaAuthorization::class)->authorizeAttachments($this->selected, $user);
     }
 
     public function render()
     {
-        return view('aura::livewire.media-manager', [
-            'rows' => Attachment::paginate(25), // Adjust the number as needed
-        ]);
+        return view('aura::livewire.media-manager');
     }
 
     public function select($selectedValues = null)
     {
-        // Use passed values from Alpine if available (more reliable than entangle sync)
-        // Ensure we have an array of strings for consistency
+        $user = Auth::user();
+
+        if (! $user) {
+            abort(403);
+        }
+
         $selected = collect($selectedValues ?? $this->selected)
             ->map(fn ($id) => (string) $id)
             ->values()
             ->toArray();
 
-        // Dispatch the updateField event globally to ALL Livewire components
-        // Use named parameter 'data' to match the listener's signature: updateField($data)
+        app(MediaAuthorization::class)->authorizeAttachments($selected, $user);
+
         $this->dispatch('updateField', data: [
             'slug' => $this->fieldSlug,
             'value' => $selected,
         ]);
-
-        // NOTE: Do NOT dispatch closeModal here!
-        // The modal must be closed from Alpine AFTER this Livewire call completes
-        // Otherwise the component is destroyed while events are still being processed
     }
 
     #[On('selectedRows')]
     public function selectAttachment($ids)
     {
-        // Only sync initial selection, not ongoing changes to prevent circular updates
         if (! $this->initialSelectionDone) {
             $this->selected = collect($ids)->map(fn ($id) => (string) $id)->values()->toArray();
             $this->initialSelectionDone = true;
@@ -77,23 +86,17 @@ class MediaManager extends Component
     #[On('tableMounted')]
     public function tableMounted()
     {
-        // Sync initial selection to the table when it mounts
         if ($this->selected && ! $this->initialSelectionDone) {
             $this->dispatch('selectedRows', collect($this->selected)->map(fn ($id) => (string) $id)->values()->toArray());
             $this->initialSelectionDone = true;
         }
     }
 
-    // Removed updated() method to prevent circular updates
-    // The entangle directive handles syncing automatically
-
     #[On('updateField')]
     public function updateField($data)
     {
-        // Only update if this is our field
         if ($data['slug'] == $this->fieldSlug) {
             $this->selected = collect($data['value'])->map(fn ($id) => (string) $id)->values()->toArray();
-            // Don't dispatch selectedRows here to prevent circular updates
         }
     }
 }

--- a/src/Livewire/MediaUploader.php
+++ b/src/Livewire/MediaUploader.php
@@ -2,7 +2,9 @@
 
 namespace Aura\Base\Livewire;
 
+use Aura\Base\Livewire\Media\MediaAuthorization;
 use Aura\Base\Resources\Attachment;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
 use Livewire\Attributes\On;
@@ -50,6 +52,18 @@ class MediaUploader extends Component
     public function mount(): void
     {
         $this->model = app($this->namespace);
+
+        $user = Auth::user();
+
+        // Only re-check existing selected IDs on mount. Create is authorized at
+        // upload time so forms that embed the uploader without create rights
+        // (e.g. user edit with an image field) can still open.
+        if ($user && is_array($this->selected) && $this->selected !== []) {
+            app(MediaAuthorization::class)->authorizeAttachments(
+                array_values($this->selected),
+                $user,
+            );
+        }
     }
 
     public function render(): View
@@ -75,6 +89,14 @@ class MediaUploader extends Component
             'message' => '',
             'ids' => [],
         ];
+
+        $user = Auth::user();
+
+        if (! $user) {
+            abort(403);
+        }
+
+        app(MediaAuthorization::class)->authorizeAttachmentCreate($user);
 
         try {
             $this->validate([

--- a/src/Livewire/Resource/View.php
+++ b/src/Livewire/Resource/View.php
@@ -3,6 +3,7 @@
 namespace Aura\Base\Livewire\Resource;
 
 use Aura\Base\Facades\Aura;
+use Aura\Base\RecordLayout\RecordLayoutResolver;
 use Aura\Base\Traits\HasActions;
 use Aura\Base\Traits\InteractsWithFields;
 use Aura\Base\Traits\RepeaterFields;
@@ -75,7 +76,7 @@ class View extends Component
         $this->dispatch('refreshComponent');
     }
 
-    public function render()
+    public function render(RecordLayoutResolver $recordLayouts)
     {
         // $view = "aura.{$this->slug}.view";
 
@@ -87,7 +88,9 @@ class View extends Component
         // if (view()->exists("aura::" . $view)) {
         //     return view("aura::" . $view)->layout('aura::components.layout.app');
         // }
-        return view($this->model->viewView())->layout('aura::components.layout.app');
+        return view($this->model->viewView(), [
+            'recordLayout' => $recordLayouts->resolve($this->model),
+        ])->layout('aura::components.layout.app');
 
     }
 

--- a/src/Livewire/Table/Table.php
+++ b/src/Livewire/Table/Table.php
@@ -21,6 +21,7 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\View\View;
 use Livewire\Attributes\Computed;
@@ -346,6 +347,7 @@ class Table extends Component
     public function render()
     {
         return view($this->model->tableComponentView(), [
+            'kanban' => $this->resolvedKanbanConfiguration(),
             'parent' => $this->parent,
             'rows' => $this->rows,
             'rowIds' => $this->rowIds,
@@ -465,14 +467,34 @@ class Table extends Component
 
     public function updateCardStatus($cardId, $newStatus)
     {
-        $card = $this->model->find($cardId);
-        if ($card) {
-            $card->status = $newStatus;
-            $card->save();
-            $this->notify('Card status updated successfully');
-        } else {
-            $this->notify('Card not found', 'error');
+        $kanbanConfiguration = $this->resolvedKanbanConfiguration();
+
+        if (! $kanbanConfiguration['enabled']) {
+            abort(422, 'Kanban mutations require an enabled configuration.');
         }
+
+        if (! is_string($newStatus) && ! is_int($newStatus)) {
+            abort(422, 'The Kanban destination is not declared.');
+        }
+
+        if (! array_key_exists((string) $newStatus, $kanbanConfiguration['columns'])) {
+            abort(422, 'The Kanban destination is not declared.');
+        }
+
+        $card = $this->model->newQuery()->find($cardId);
+
+        if (! $card) {
+            $this->notify('Card not found', 'error');
+
+            return;
+        }
+
+        Gate::authorize('update', $card);
+
+        $groupField = $kanbanConfiguration['group_field'];
+        $card->{$groupField} = $newStatus;
+        $card->save();
+        $this->notify('Card status updated successfully');
     }
 
     /**

--- a/src/Livewire/Table/Table.php
+++ b/src/Livewire/Table/Table.php
@@ -133,18 +133,37 @@ class Table extends Component
 
     public function action($data)
     {
-        // return redirect to post view
-        if ($data['action'] == 'view') {
-            return redirect()->route('aura.'.$this->model()->getSlug().'.view', ['id' => $data['id']]);
-        }
-        // edit
-        if ($data['action'] == 'edit') {
-            return redirect()->route('aura.'.$this->model()->getSlug().'.edit', ['id' => $data['id']]);
+        $action = $data['action'] ?? null;
+        $id = $data['id'] ?? null;
+
+        if (! is_string($action) || $action === '' || $id === null || $id === '') {
+            abort(422, 'Invalid table action.');
         }
 
-        if (method_exists($this->model, $data['action'])) {
-            return $this->model()->find($data['id'])->{$data['action']}();
+        if ($action === 'view' || $action === 'edit') {
+            $record = (clone $this->query())->whereKey($id)->firstOrFail();
+            Gate::authorize(
+                $action === 'view' ? 'view' : 'update',
+                $record,
+            );
+
+            $route = $action === 'view' ? 'view' : 'edit';
+
+            return redirect()->route('aura.'.$this->model()->getSlug().'.'.$route, ['id' => $record->getKey()]);
         }
+
+        $record = app(TableMutationAuthorizer::class)->authorizeRow(
+            scope: clone $this->query(),
+            id: $id,
+            action: $action,
+            declared: $this->normalizedRowActions(),
+        );
+
+        if (! method_exists($record, $action)) {
+            abort(403, 'This action is not allowed.');
+        }
+
+        return $record->{$action}();
     }
 
     public function allTableRows()
@@ -314,9 +333,17 @@ class Table extends Component
 
     public function openBulkActionModal($action, $data)
     {
+        $records = app(TableMutationAuthorizer::class)->authorizeBulk(
+            scope: clone $this->query(),
+            action: $action,
+            declared: (array) $this->getBulkActionsProperty(),
+            selected: $this->selected,
+            selectAll: (bool) $this->selectAll,
+        );
+
         $this->dispatch('openModal', $data['modal'], [
             'action' => $action,
-            'selected' => $this->selectedRowsQuery->pluck('id'),
+            'selected' => $records->map(fn ($record) => $record->getKey())->values()->all(),
             'model' => get_class($this->model),
         ]);
     }
@@ -530,6 +557,34 @@ class Table extends Component
         } else {
             $this->dispatch('selectedRows', $this->selected);
         }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function normalizedRowActions(): array
+    {
+        $actions = $this->model->getActions();
+
+        if (! is_array($actions)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($actions as $key => $definition) {
+            if (is_int($key) && is_string($definition)) {
+                $normalized[$definition] = ['ability' => $definition];
+
+                continue;
+            }
+
+            if (is_string($key)) {
+                $normalized[$key] = $definition;
+            }
+        }
+
+        return $normalized;
     }
 
     /**

--- a/src/Livewire/Table/TableMutationAuthorizer.php
+++ b/src/Livewire/Table/TableMutationAuthorizer.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Aura\Base\Livewire\Table;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use InvalidArgumentException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Small auth contract for table row/bulk mutations.
+ *
+ * declare → ability → exact keys in table scope → per-record Gate
+ *
+ * Does not include query AST sealing, lock retries, or signed downloads.
+ */
+final class TableMutationAuthorizer
+{
+    private const DEFAULT_ABILITIES = [
+        'delete' => 'delete',
+        'deleteAttachment' => 'delete',
+        'deleteSelected' => 'delete',
+        'forceDelete' => 'forceDelete',
+        'restore' => 'restore',
+        'update' => 'update',
+        'view' => 'view',
+        'edit' => 'update',
+    ];
+
+    public function __construct(
+        private readonly int $maxSelection = 500,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $declared
+     */
+    public function abilityFor(string $action, mixed $definition): string
+    {
+        if (is_array($definition) && array_key_exists('ability', $definition)) {
+            $ability = $definition['ability'];
+
+            if (! is_string($ability) || $ability === '') {
+                throw ValidationException::withMessages([
+                    'action' => 'Bulk action ability must be a non-empty string.',
+                ]);
+            }
+
+            return $ability;
+        }
+
+        if (isset(self::DEFAULT_ABILITIES[$action])) {
+            return self::DEFAULT_ABILITIES[$action];
+        }
+
+        // Fail closed: custom actions must declare an ability explicitly.
+        throw ValidationException::withMessages([
+            'action' => "Action [{$action}] must declare an ability.",
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $declared
+     * @return array<string, mixed>|string
+     */
+    public function assertDeclared(string $action, array $declared): mixed
+    {
+        if (! array_key_exists($action, $declared)) {
+            throw new HttpException(403, 'This action is not allowed.');
+        }
+
+        return $declared[$action];
+    }
+
+    /**
+     * @param  array<string, mixed>  $declared
+     * @param  list<int|string>|null  $selected
+     * @return Collection<int, Model>
+     */
+    public function authorizeBulk(
+        Builder $scope,
+        string $action,
+        array $declared,
+        ?array $selected,
+        bool $selectAll = false,
+    ): Collection {
+        $definition = $this->assertDeclared($action, $declared);
+        $ability = $this->abilityFor($action, $definition);
+        $records = $this->resolveExactSelection($scope, $selected, $selectAll);
+        $this->authorizeEach($records, $ability);
+
+        return $records;
+    }
+
+    /**
+     * @param  Collection<int, Model>  $records
+     */
+    public function authorizeEach(Collection $records, string $ability): void
+    {
+        foreach ($records as $record) {
+            Gate::authorize($ability, $record);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $declared
+     */
+    public function authorizeRow(
+        Builder $scope,
+        int|string $id,
+        string $action,
+        array $declared,
+    ): Model {
+        $definition = $this->assertDeclared($action, $declared);
+        $ability = $this->abilityFor($action, $definition);
+        $records = $this->resolveExactSelection($scope, [$id], selectAll: false);
+        $record = $records->first();
+
+        if (! $record instanceof Model) {
+            throw ValidationException::withMessages([
+                'id' => 'The selected row is unavailable.',
+            ]);
+        }
+
+        Gate::authorize($ability, $record);
+
+        return $record;
+    }
+
+    /**
+     * @param  list<int|string>|null  $selected
+     * @return Collection<int, Model>
+     */
+    public function resolveExactSelection(Builder $scope, ?array $selected, bool $selectAll): Collection
+    {
+        if ($selectAll) {
+            $records = (clone $scope)->limit($this->maxSelection + 1)->get();
+
+            if ($records->count() > $this->maxSelection) {
+                throw ValidationException::withMessages([
+                    'selected' => "Selection exceeds the maximum of {$this->maxSelection} rows.",
+                ]);
+            }
+
+            if ($records->isEmpty()) {
+                throw ValidationException::withMessages([
+                    'selected' => 'No rows are selected.',
+                ]);
+            }
+
+            return $records;
+        }
+
+        $keys = $this->normalizeKeys($selected ?? []);
+
+        if ($keys === []) {
+            throw ValidationException::withMessages([
+                'selected' => 'No rows are selected.',
+            ]);
+        }
+
+        if (count($keys) > $this->maxSelection) {
+            throw ValidationException::withMessages([
+                'selected' => "Selection exceeds the maximum of {$this->maxSelection} rows.",
+            ]);
+        }
+
+        $records = (clone $scope)->whereKey($keys)->get()
+            ->keyBy(fn (Model $model): string => (string) $model->getKey());
+
+        if ($records->count() !== count($keys)) {
+            throw ValidationException::withMessages([
+                'selected' => 'One or more selected rows are unavailable in the current table scope.',
+            ]);
+        }
+
+        $ordered = new Collection;
+
+        foreach ($keys as $key) {
+            $record = $records->get($key);
+
+            if (! $record instanceof Model) {
+                throw ValidationException::withMessages([
+                    'selected' => 'One or more selected rows are unavailable in the current table scope.',
+                ]);
+            }
+
+            $ordered->push($record);
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * @param  list<int|string>  $keys
+     * @return list<string>
+     */
+    private function normalizeKeys(array $keys): array
+    {
+        if (! array_is_list($keys)) {
+            throw new InvalidArgumentException('Selected row IDs must be a list.');
+        }
+
+        $normalized = [];
+
+        foreach ($keys as $key) {
+            if ((! is_int($key) && ! is_string($key)) || (string) $key === '') {
+                throw ValidationException::withMessages([
+                    'selected' => 'Selected row IDs must be non-empty integers or strings.',
+                ]);
+            }
+
+            $normalized[] = (string) $key;
+        }
+
+        $unique = array_values(array_unique($normalized, SORT_STRING));
+
+        if (count($unique) !== count($normalized)) {
+            throw ValidationException::withMessages([
+                'selected' => 'Selected row IDs must not contain duplicates.',
+            ]);
+        }
+
+        return $unique;
+    }
+}

--- a/src/Livewire/Table/Traits/BulkActions.php
+++ b/src/Livewire/Table/Traits/BulkActions.php
@@ -2,7 +2,7 @@
 
 namespace Aura\Base\Livewire\Table\Traits;
 
-use Illuminate\Support\Facades\Gate;
+use Aura\Base\Livewire\Table\TableMutationAuthorizer;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -17,43 +17,39 @@ trait BulkActions
      */
     public function bulkAction(string $action)
     {
-        $this->ensureBulkActionAllowed($action);
+        $records = $this->tableMutationAuthorizer()->authorizeBulk(
+            scope: clone $this->query(),
+            action: $action,
+            declared: (array) $this->getBulkActionsProperty(),
+            selected: $this->selected,
+            selectAll: (bool) $this->selectAll,
+        );
 
-        $ability = $this->bulkActionAbility($action);
-
-        $this->selectedRowsQuery->each(function ($item, $key) use ($action, $ability) {
-            // Authorize the action against each selected model before running it.
-            Gate::authorize($ability, $item);
-
+        foreach ($records as $item) {
             if (str_starts_with($action, 'callFlow.')) {
                 $item->callFlow(explode('.', $action)[1]);
-            } elseif (str_starts_with($action, 'multiple')) {
-                $posts = $this->selectedRowsQuery->get();
-                $response = $item->{$action}($posts);
-
             } elseif (method_exists($item, $action)) {
                 $item->{$action}();
             }
-        });
+        }
 
-        // Clear the selected array
         $this->selected = [];
+        $this->selectAll = false;
 
         $this->notify('Success: '.$action);
     }
 
     public function bulkCollectionAction($action)
     {
-        $this->ensureBulkActionAllowed($action);
+        $records = $this->tableMutationAuthorizer()->authorizeBulk(
+            scope: clone $this->query(),
+            action: $action,
+            declared: (array) $this->getBulkActionsProperty(),
+            selected: $this->selected,
+            selectAll: (bool) $this->selectAll,
+        );
 
-        $ability = $this->bulkActionAbility($action);
-
-        // Authorize the action against every selected model before running it.
-        $this->selectedRowsQuery->each(function ($item) use ($ability) {
-            Gate::authorize($ability, $item);
-        });
-
-        $ids = $this->selectedRowsQuery->pluck('id')->toArray();
+        $ids = $records->map(fn ($item) => $item->getKey())->all();
 
         $response = $this->model->{$action}($ids);
 
@@ -61,8 +57,8 @@ trait BulkActions
             return $response;
         }
 
-        // reset selected rows
         $this->selected = [];
+        $this->selectAll = false;
 
         $this->notify('Success: '.$action);
 
@@ -79,43 +75,8 @@ trait BulkActions
         return $this->model->getBulkActions();
     }
 
-    /**
-     * Map a declared bulk action to the policy ability it requires.
-     *
-     * Destructive actions are matched by name so they are authorized with the
-     * matching ability; anything else defaults to the mutating 'update' ability.
-     */
-    protected function bulkActionAbility(string $action): string
+    protected function tableMutationAuthorizer(): TableMutationAuthorizer
     {
-        $normalized = strtolower($action);
-
-        if (str_contains($normalized, 'forcedelete')) {
-            return 'forceDelete';
-        }
-
-        if (str_contains($normalized, 'restore')) {
-            return 'restore';
-        }
-
-        if (str_contains($normalized, 'delete') || str_contains($normalized, 'trash')) {
-            return 'delete';
-        }
-
-        return 'update';
-    }
-
-    /**
-     * Ensure the requested action is one the resource explicitly declares.
-     *
-     * This prevents a client from invoking arbitrary methods on the model by
-     * passing an unlisted action string to bulkAction()/bulkCollectionAction().
-     */
-    protected function ensureBulkActionAllowed(string $action): void
-    {
-        $allowed = array_keys((array) $this->getBulkActionsProperty());
-
-        if (! in_array($action, $allowed, true)) {
-            abort(403, 'This bulk action is not allowed.');
-        }
+        return app(TableMutationAuthorizer::class);
     }
 }

--- a/src/Livewire/Table/Traits/Kanban.php
+++ b/src/Livewire/Table/Traits/Kanban.php
@@ -2,97 +2,102 @@
 
 namespace Aura\Base\Livewire\Table\Traits;
 
-use Livewire\Attributes\On;
+use Aura\Base\Support\KanbanConfiguration;
 
 /**
- * Trait to handle sorting functionality.
+ * Trait to handle kanban board columns and preferences.
  */
 trait Kanban
 {
     public $kanbanStatuses = [];
 
-    public function mountKanban()
+    public function mountKanban(): void
     {
         $this->prepareKanban();
     }
 
-    public function reorderKanbanColumns($newOrder)
+    public function reorderKanbanColumns($newOrder): void
     {
-        // Filter out empty values from $newOrder using Laravel's collection methods
-        $newOrder = collect($newOrder)->filter()->values();
+        $this->reorderKanbanStatuses($newOrder);
+    }
 
-        $reorderedStatuses = collect();
+    public function reorderKanbanStatuses(mixed $statuses, mixed $position = null): void
+    {
+        $declared = $this->declaredKanbanStatuses();
+        $requested = $this->requestedKanbanStatusOrder($statuses, $position, $declared);
+        $orderedKeys = collect($requested)
+            ->filter(fn (mixed $key): bool => is_string($key) || is_int($key))
+            ->map(fn (string|int $key): string => (string) $key)
+            ->filter(fn (string $key): bool => array_key_exists($key, $declared))
+            ->unique()
+            ->merge(array_keys($declared))
+            ->unique();
 
-        // Reorder based on $newOrder
-        foreach ($newOrder as $key) {
-            if (isset($this->kanbanStatuses[$key])) {
-                $reorderedStatuses[$key] = $this->kanbanStatuses[$key];
-            }
-        }
-
-        // Add any remaining statuses that weren't in $newOrder
-        foreach ($this->kanbanStatuses as $key => $status) {
-            if (! $reorderedStatuses->has($key)) {
-                $reorderedStatuses[$key] = $status;
-            }
-        }
-
-        $this->kanbanStatuses = $reorderedStatuses->toArray();
+        $this->kanbanStatuses = $orderedKeys
+            ->mapWithKeys(fn (string $key): array => [
+                $key => array_replace($declared[$key], [
+                    'visible' => (bool) ($this->kanbanStatuses[$key]['visible'] ?? true),
+                ]),
+            ])
+            ->all();
 
         $this->saveKanbanStatusesOrder();
     }
 
-    public function reorderKanbanStatuses($statuses)
+    public function updatedKanbanStatuses(): void
     {
-        // Create a new collection from the ordered status keys
-        $orderedStatuses = collect($statuses);
-
-        // Create a new collection to store the reordered kanban statuses
-        $reorderedKanbanStatuses = collect();
-
-        // Iterate through the ordered status keys and rebuild the kanban statuses array
-        foreach ($orderedStatuses as $statusKey) {
-            if (isset($this->kanbanStatuses[$statusKey])) {
-                $reorderedKanbanStatuses[$statusKey] = $this->kanbanStatuses[$statusKey];
-            }
-        }
-
-        // Update the kanban statuses with the new order
-        $this->kanbanStatuses = $reorderedKanbanStatuses->toArray();
-
-        $this->saveKanbanStatusesOrder();
-    }
-
-    public function updatedKanbanStatuses()
-    {
+        $this->kanbanStatuses = $this->sanitizeKanbanStatuses($this->kanbanStatuses);
         $this->saveKanbanStatusesOrder();
     }
 
     protected function applyKanbanQuery($query)
     {
+        $kanbanQuery = $this->model->kanbanQuery($query);
 
-        if ($this->model->kanbanQuery($query)) {
-            return $this->model->kanbanQuery($query);
+        if ($kanbanQuery) {
+            return $kanbanQuery;
         }
 
         return $query;
     }
 
-    protected function initializeKanbanStatuses()
+    /**
+     * @return array<string, array{value: string, color: string|null, visible: bool}>
+     */
+    protected function declaredKanbanStatuses(): array
     {
-        $statuses = $this->model->fieldBySlug('status')['options'];
-        $this->kanbanStatuses = collect($statuses)->mapWithKeys(function ($status) {
+        $columns = $this->resolvedKanbanConfiguration()['columns'];
+
+        if ($columns !== []) {
+            return collect($columns)
+                ->map(fn (array $column): array => array_replace($column, ['visible' => true]))
+                ->all();
+        }
+
+        // Fallback: legacy status-field options when KanbanConfiguration has no columns.
+        $field = $this->model->fieldBySlug('status');
+        $options = is_array($field) ? ($field['options'] ?? []) : [];
+
+        return collect($options)->mapWithKeys(function ($status) {
+            if (! is_array($status) || ! array_key_exists('key', $status)) {
+                return [];
+            }
+
             return [$status['key'] => [
-                'value' => $status['value'],
-                'color' => $status['color'],
+                'value' => (string) ($status['value'] ?? $status['key']),
+                'color' => is_string($status['color'] ?? null) ? $status['color'] : null,
                 'visible' => true,
             ]];
-        })->toArray();
+        })->all();
+    }
 
-        // Load user preferences if they exist
+    protected function initializeKanbanStatuses(): void
+    {
+        $this->kanbanStatuses = $this->declaredKanbanStatuses();
+
         $userPreferences = auth()->user()->getOption('kanban_statuses.'.$this->model()->getType());
-        if ($userPreferences) {
-            $this->kanbanStatuses = $userPreferences;
+        if (is_array($userPreferences)) {
+            $this->kanbanStatuses = $this->sanitizeKanbanStatuses($userPreferences);
         }
     }
 
@@ -101,9 +106,9 @@ trait Kanban
      * declaration order, so mountKanban() can run before mountSwitchView()
      * has set $currentView — and switchView() never re-initializes statuses.
      */
-    protected function prepareKanban()
+    protected function prepareKanban(): void
     {
-        if ($this->currentView != 'kanban') {
+        if ($this->currentView !== 'kanban') {
             return;
         }
 
@@ -116,8 +121,80 @@ trait Kanban
         }
     }
 
-    protected function saveKanbanStatusesOrder()
+    /**
+     * @param  array<string, array{value: string, color: string|null, visible: bool}>  $declared
+     * @return array<int, string|int>
+     */
+    protected function requestedKanbanStatusOrder(mixed $statuses, mixed $position, array $declared): array
     {
+        if (is_array($statuses)) {
+            return $statuses;
+        }
+
+        if (
+            (! is_string($statuses) && ! is_int($statuses))
+            || ! is_int($position)
+            || $position < 0
+            || ! array_key_exists((string) $statuses, $declared)
+        ) {
+            abort(422, 'The Kanban column order is invalid.');
+        }
+
+        $status = (string) $statuses;
+        $ordered = collect(array_keys($this->sanitizeKanbanStatuses($this->kanbanStatuses)))
+            ->reject(fn (string $key): bool => $key === $status)
+            ->values()
+            ->all();
+
+        array_splice($ordered, min($position, count($ordered)), 0, [$status]);
+
+        return $ordered;
+    }
+
+    /**
+     * @return array{
+     *     enabled: bool,
+     *     valid: bool,
+     *     group_field: string,
+     *     columns: array<string, array{value: string, color: string|null}>,
+     *     card_title: string,
+     *     card_subtitle: string|null,
+     *     order_by: array{field: string, direction: 'asc'|'desc'}|null,
+     *     show_empty_columns: bool
+     * }
+     */
+    protected function resolvedKanbanConfiguration(): array
+    {
+        return KanbanConfiguration::for($this->model);
+    }
+
+    protected function sanitizeKanbanStatuses(array $preferences): array
+    {
+        $declared = $this->declaredKanbanStatuses();
+
+        if ($declared === []) {
+            return [];
+        }
+
+        $orderedKeys = collect(array_keys($preferences))
+            ->map(fn (string|int $key): string => (string) $key)
+            ->filter(fn (string $key): bool => array_key_exists($key, $declared))
+            ->unique()
+            ->merge(array_keys($declared))
+            ->unique();
+
+        return $orderedKeys->mapWithKeys(function (string $key) use ($declared, $preferences): array {
+            $preference = $preferences[$key] ?? [];
+
+            return [$key => array_replace($declared[$key], [
+                'visible' => is_array($preference) ? (bool) ($preference['visible'] ?? true) : true,
+            ])];
+        })->all();
+    }
+
+    protected function saveKanbanStatusesOrder(): void
+    {
+        $this->kanbanStatuses = $this->sanitizeKanbanStatuses($this->kanbanStatuses);
         auth()->user()->updateOption('kanban_statuses.'.$this->model()->getType(), $this->kanbanStatuses);
     }
 }

--- a/src/Livewire/Table/Traits/QueryFilters.php
+++ b/src/Livewire/Table/Traits/QueryFilters.php
@@ -16,6 +16,19 @@ trait QueryFilters
 
         $groups = $this->filters['custom'];
 
+        // Fail closed on malformed custom filter payloads (non-list, non-array
+        // groups, or missing filter lists) so tampered Livewire state cannot
+        // bypass filtering or throw into unscoped result sets.
+        if (! is_array($groups) || ! array_is_list($groups)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        foreach ($groups as $group) {
+            if (! is_array($group) || ! isset($group['filters']) || ! is_array($group['filters'])) {
+                return $query->whereRaw('1 = 0');
+            }
+        }
+
         // Start by building the conditions from the first group
         $condition = function ($query) use ($groups) {
             $this->applyFilterGroup($query, $groups[0]);
@@ -64,13 +77,29 @@ trait QueryFilters
 
     protected function applyFilterBasedOnType(Builder $query, array $filter): void
     {
+        $name = $filter['name'] ?? null;
+
+        if (! is_string($name) || $name === '') {
+            $query->whereRaw('1 = 0');
+
+            return;
+        }
+
         if ($this->isRelationBackedFilter($filter)) {
             $this->applyRelationFieldFilter($query, $filter);
-        } elseif ($this->model->isMetaField($filter['name'])) {
+        } elseif ($this->model->isMetaField($name)) {
             $this->applyMetaFieldFilter($query, $filter);
-        } elseif ($this->model->isTableField($filter['name']) || $this->model->usesCustomTable()) {
+        } elseif ($this->model->isTableField($name) || $this->model->usesCustomTable()) {
             $this->applyTableFieldFilter($query, $filter);
         } else {
+            // Non-table fallthrough: unknown/missing field classes must not
+            // silently become unconstrained meta lookups.
+            if (! $this->model->fieldClassBySlug($name)) {
+                $query->whereRaw('1 = 0');
+
+                return;
+            }
+
             $this->applyMetaFieldFilter($query, $filter);
         }
     }
@@ -213,6 +242,9 @@ trait QueryFilters
                 $query->whereNotNull('value')
                     ->where('value', '!=', '');
                 break;
+            default:
+                $query->whereRaw('1 = 0');
+                break;
         }
     }
 
@@ -222,6 +254,8 @@ trait QueryFilters
         $resourceType = $filter['options']['resource_type'] ?? optional($field)['resource'];
 
         if (! $resourceType) {
+            $query->whereRaw('1 = 0');
+
             return;
         }
 
@@ -248,6 +282,8 @@ trait QueryFilters
                     ->where('post_relations.slug', $slug)
                     ->whereIn('post_relations.resource_id', $values);
             });
+        } else {
+            $query->whereRaw('1 = 0');
         }
     }
 
@@ -359,6 +395,9 @@ trait QueryFilters
                 $query->whereNotNull($filter['name'])
                     ->where($filter['name'], '!=', '');
                 break;
+            default:
+                $query->whereRaw('1 = 0');
+                break;
         }
 
         return $query;
@@ -366,7 +405,7 @@ trait QueryFilters
 
     protected function isRelationBackedFilter(array $filter): bool
     {
-        $fieldClass = $this->model->fieldClassBySlug($filter['name']);
+        $fieldClass = $this->model->fieldClassBySlug($filter['name'] ?? '');
 
         if ($fieldClass instanceof Tags) {
             return true;
@@ -381,7 +420,13 @@ trait QueryFilters
 
     protected function isValidFilter(array $filter): bool
     {
+        $operator = $filter['operator'] ?? null;
+
+        if (! is_string($operator) || $operator === '') {
+            return false;
+        }
+
         return ! empty($filter['name']) &&
-               (! empty($filter['value']) || in_array($filter['operator'], ['is_empty', 'is_not_empty']));
+               (! empty($filter['value']) || in_array($operator, ['is_empty', 'is_not_empty'], true));
     }
 }

--- a/src/Livewire/Table/Traits/Settings.php
+++ b/src/Livewire/Table/Traits/Settings.php
@@ -2,10 +2,15 @@
 
 namespace Aura\Base\Livewire\Table\Traits;
 
+use Aura\Base\Support\KanbanConfiguration;
+
 trait Settings
 {
     public function defaultSettings()
     {
+        $kanban = KanbanConfiguration::for($this->model);
+        $kanbanView = $this->model->tableKanbanView();
+
         return [
             'per_page' => 10,
             'columns' => $this->model->getTableHeaders(),
@@ -41,7 +46,9 @@ trait Settings
                 'table' => 'aura::components.table.index',
                 'list' => $this->model->tableView(),
                 'grid' => $this->model->tableGridView(),
-                'kanban' => $this->model->tableKanbanView(),
+                'kanban' => $kanban['enabled']
+                    ? (is_string($kanbanView) && $kanbanView !== '' ? $kanbanView : 'aura::components.table.kanban-view')
+                    : false,
                 'filter' => 'aura::components.table.filter',
                 'header' => 'aura::components.table.header',
                 'row' => $this->model->rowView(),

--- a/src/Livewire/Table/Traits/SwitchView.php
+++ b/src/Livewire/Table/Traits/SwitchView.php
@@ -9,20 +9,53 @@ trait SwitchView
     public function mountSwitchView()
     {
         $userPreference = auth()->user()->getOption('table_view.'.$this->model()->getType());
+        $defaultView = is_string($this->settings['default_view'] ?? null)
+            ? $this->settings['default_view']
+            : 'list';
 
-        $this->currentView = $userPreference ?? $this->settings['default_view'];
+        $this->currentView = $this->supportedView($userPreference)
+            ?? $this->supportedView($defaultView)
+            ?? 'list';
     }
 
     public function switchView($view)
     {
-        if (in_array($view, ['list', 'kanban', 'grid'])) {
-            $this->currentView = $view;
-            $this->saveViewPreference();
+        $view = $this->supportedView($view);
+
+        if ($view === null || $view === $this->currentView) {
+            return;
         }
+
+        $this->currentView = $view;
+        $this->prepareKanban();
+        $this->saveViewPreference();
     }
 
     protected function saveViewPreference()
     {
         auth()->user()->updateOption('table_view.'.$this->model()->getType(), $this->currentView);
+    }
+
+    protected function supportedView(mixed $view): ?string
+    {
+        if (! is_string($view)) {
+            return null;
+        }
+
+        $views = ['list'];
+
+        if (is_string($this->settings['views']['grid'] ?? null) && $this->settings['views']['grid'] !== '') {
+            $views[] = 'grid';
+        }
+
+        if (
+            ($this->resolvedKanbanConfiguration()['enabled'] ?? false)
+            && is_string($this->settings['views']['kanban'] ?? null)
+            && $this->settings['views']['kanban'] !== ''
+        ) {
+            $views[] = 'kanban';
+        }
+
+        return in_array($view, $views, true) ? $view : null;
     }
 }

--- a/src/Models/Scopes/TeamScope.php
+++ b/src/Models/Scopes/TeamScope.php
@@ -46,23 +46,30 @@ class TeamScope implements Scope
 
             // Handle User model specially
             if ($model->getTable() === 'users') {
+                // A Global Admin transcends the tenant boundary: their user
+                // queries are never restricted to current-team members. The
+                // bypass is gated strictly on the authenticated user being a
+                // Global Admin, so it never leaks into ordinary requests.
+                // (Auth::user() is already resolved here; the $applying guard
+                // above prevents any re-entry while it is read.) The gate is
+                // consulted directly so the check is host-overridable and safe
+                // for any authenticatable, not only the Aura User model.
+                $authUser = Auth::user();
+                $isGlobalAdmin = $authUser && Gate::forUser($authUser)->allows(User::GLOBAL_ADMIN_GATE);
 
-                // Only apply team scoping if teams are enabled
-                if (config('aura.teams') && $currentTeamId) {
-                    // A Global Admin transcends the tenant boundary: their user
-                    // queries are never restricted to current-team members. The
-                    // bypass is gated strictly on the authenticated user being a
-                    // Global Admin, so it never leaks into ordinary requests.
-                    // (Auth::user() is already resolved here; the $applying guard
-                    // above prevents any re-entry while it is read.) The gate is
-                    // consulted directly so the check is host-overridable and safe
-                    // for any authenticatable, not only the Aura User model.
-                    $authUser = Auth::user();
-
-                    if (! ($authUser && Gate::forUser($authUser)->allows(User::GLOBAL_ADMIN_GATE))) {
+                if ($currentTeamId) {
+                    if (! $isGlobalAdmin) {
                         $builder->whereHas('teams', function ($query) use ($currentTeamId) {
                             $query->where('teams.id', $currentTeamId);
                         });
+                    }
+                } elseif (! $isGlobalAdmin) {
+                    // No team context: fail closed for ordinary users by
+                    // restricting to the authenticated identity only.
+                    if ($authUser) {
+                        $builder->whereKey($authUser->getKey());
+                    } else {
+                        $builder->whereRaw('1 = 0');
                     }
                 }
 
@@ -71,17 +78,19 @@ class TeamScope implements Scope
                 return;  // Early return is important.
             }
 
-            // --- Rest of your scope (for other models) ---
-
-            // For team-enabled filtering
-            if (! $currentTeamId) {
+            // For Team model, don't apply team scope (leave unscoped as today)
+            if ($model->getTable() === 'teams') {
                 self::$applying = false;
 
                 return;
             }
 
-            // For Team model, don't apply team scope
-            if ($model->getTable() === 'teams') {
+            // Fail-closed: without a current team, never return unscoped rows.
+            // Roles previously needed currentTeamId for scopeVisibleToTeam; when
+            // it is missing, refuse the query rather than exposing the catalog.
+            if (! $currentTeamId) {
+                $builder->whereRaw('1 = 0');
+
                 self::$applying = false;
 
                 return;

--- a/src/Policies/ResourcePolicy.php
+++ b/src/Policies/ResourcePolicy.php
@@ -8,6 +8,7 @@ use Aura\Base\Resources\Role;
 use Aura\Base\Resources\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Auth\Access\Response;
+use Illuminate\Database\Eloquent\Model;
 
 class ResourcePolicy
 {
@@ -20,6 +21,10 @@ class ResourcePolicy
      */
     public function create($user, $resource)
     {
+        if ($resource instanceof Model && ! $this->usesSameConnection($user, $resource)) {
+            return false;
+        }
+
         if ($resource::$createEnabled === false) {
             return false;
         }
@@ -43,6 +48,10 @@ class ResourcePolicy
      */
     public function delete($user, $resource)
     {
+        if ($resource instanceof Model && ! $this->usesSameConnection($user, $resource)) {
+            return false;
+        }
+
         if ($this->deniesGlobalRoleWrite($user, $resource)) {
             return false;
         }
@@ -75,6 +84,10 @@ class ResourcePolicy
      */
     public function forceDelete($user, $resource)
     {
+        if ($resource instanceof Model && ! $this->usesSameConnection($user, $resource)) {
+            return false;
+        }
+
         if ($this->deniesGlobalRoleWrite($user, $resource)) {
             return false;
         }
@@ -98,6 +111,10 @@ class ResourcePolicy
      */
     public function restore(User $user, $resource)
     {
+        if ($resource instanceof Model && ! $this->usesSameConnection($user, $resource)) {
+            return false;
+        }
+
         if ($this->deniesGlobalRoleWrite($user, $resource)) {
             return false;
         }
@@ -120,6 +137,10 @@ class ResourcePolicy
      */
     public function update($user, $resource)
     {
+        if ($resource instanceof Model && ! $this->usesSameConnection($user, $resource)) {
+            return false;
+        }
+
         if ($resource::$editEnabled === false) {
             return false;
         }
@@ -156,6 +177,10 @@ class ResourcePolicy
      */
     public function view($user, $resource)
     {
+        if ($resource instanceof Model && ! $this->usesSameConnection($user, $resource)) {
+            return false;
+        }
+
         // Check if the config resource view is enabled
         if (config('aura.resource-view-enabled') === false) {
             return false;
@@ -194,6 +219,10 @@ class ResourcePolicy
      */
     public function viewAny($user, $resource)
     {
+        if ($resource instanceof Model && ! $this->usesSameConnection($user, $resource)) {
+            return false;
+        }
+
         if ($resource::$indexViewEnabled === false) {
             return false;
         }
@@ -241,5 +270,28 @@ class ResourcePolicy
     protected function hasBlanketAccess($user): bool
     {
         return $user->isSuperAdmin() || $user->isAuraGlobalAdmin();
+    }
+
+    /**
+     * Refuse authorization when actor and resource clearly live on different
+     * database connections. If either side is not an Eloquent model (or lacks
+     * connection info), allow the rest of the policy to decide — do not break
+     * non-model ability checks (e.g. class-level create/viewAny).
+     */
+    private function usesSameConnection(mixed $user, mixed $resource): bool
+    {
+        if (! $user instanceof Model || ! $resource instanceof Model) {
+            return true;
+        }
+
+        if (! method_exists($user, 'getConnectionName') || ! method_exists($resource, 'getConnectionName')) {
+            return true;
+        }
+
+        $default = (string) config('database.default');
+        $userConnection = $user->getConnectionName() ?: $default;
+        $resourceConnection = $resource->getConnectionName() ?: $default;
+
+        return $userConnection === $resourceConnection;
     }
 }

--- a/src/Policies/ResourcePolicy.php
+++ b/src/Policies/ResourcePolicy.php
@@ -3,14 +3,17 @@
 namespace Aura\Base\Policies;
 
 use App\Models\Post;
+use Aura\Base\Contracts\ScopesMediaVisibility;
 use Aura\Base\Resource;
 use Aura\Base\Resources\Role;
 use Aura\Base\Resources\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Auth\Access\Response;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
-class ResourcePolicy
+class ResourcePolicy implements ScopesMediaVisibility
 {
     use HandlesAuthorization;
 
@@ -127,6 +130,36 @@ class ResourcePolicy
         }
 
         return false;
+    }
+
+    /**
+     * Refuse authorization when actor and resource clearly live on different
+     * database connections. If either side is not an Eloquent model (or lacks
+     * connection info), allow the rest of the policy to decide — do not break
+     * non-model ability checks (e.g. class-level create/viewAny).
+     */
+    public function scopeMediaVisibility(Builder $query, Authenticatable $actor, Resource $resource): Builder
+    {
+        if (! $actor instanceof User
+            || ! $this->usesSameConnection($actor, $resource)
+            || config('aura.resource-view-enabled') === false
+            || $resource::$viewEnabled === false) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        if ($this->hasBlanketAccess($actor)) {
+            return $query;
+        }
+
+        if ($actor->hasPermissionTo('scope', $resource) && $actor->hasPermissionTo('view', $resource)) {
+            return $query->where($resource->getTable().'.user_id', $actor->getKey());
+        }
+
+        if ($actor->hasPermissionTo('view', $resource) || $actor->hasPermissionTo('viewAny', $resource)) {
+            return $query;
+        }
+
+        return $query->whereRaw('1 = 0');
     }
 
     /**
@@ -272,12 +305,6 @@ class ResourcePolicy
         return $user->isSuperAdmin() || $user->isAuraGlobalAdmin();
     }
 
-    /**
-     * Refuse authorization when actor and resource clearly live on different
-     * database connections. If either side is not an Eloquent model (or lacks
-     * connection info), allow the rest of the policy to decide — do not break
-     * non-model ability checks (e.g. class-level create/viewAny).
-     */
     private function usesSameConnection(mixed $user, mixed $resource): bool
     {
         if (! $user instanceof Model || ! $resource instanceof Model) {

--- a/src/Preferences/PreferenceContext.php
+++ b/src/Preferences/PreferenceContext.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Aura\Base\Preferences;
+
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use InvalidArgumentException;
+
+final readonly class PreferenceContext
+{
+    public function __construct(
+        public string $application,
+        public ?User $user = null,
+        public ?Team $team = null,
+        public ?string $resource = null,
+    ) {
+        foreach (['application' => $application, 'resource' => $resource] as $name => $value) {
+            if ($value !== null && (trim($value) === '' || str_contains($value, "\0"))) {
+                throw new InvalidArgumentException("Preference context {$name} is invalid.");
+            }
+        }
+    }
+
+    public function forApplication(): self
+    {
+        return new self($this->application, $this->user, $this->team);
+    }
+}

--- a/src/Preferences/PreferenceDefinition.php
+++ b/src/Preferences/PreferenceDefinition.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Aura\Base\Preferences;
+
+use InvalidArgumentException;
+
+final readonly class PreferenceDefinition
+{
+    /**
+     * @param  array<int, PreferenceScope>  $scopes
+     * @param  array<int, mixed>  $allowedValues
+     * @param  array<int, string>  $legacyKeys
+     */
+    public function __construct(
+        public string $key,
+        public PreferenceValueType $type,
+        public mixed $default,
+        public array $scopes = [PreferenceScope::User, PreferenceScope::Team],
+        public bool $nullable = false,
+        public bool $resourceAware = false,
+        public array $allowedValues = [],
+        public ?PreferenceValueType $itemType = null,
+        public bool $list = false,
+        public array $legacyKeys = [],
+    ) {
+        if (! preg_match('/\A[a-z][a-z0-9_.-]*\z/', $key)) {
+            throw new InvalidArgumentException("Invalid preference key [{$key}].");
+        }
+
+        if ($scopes === []) {
+            throw new InvalidArgumentException("Preference [{$key}] must declare valid scopes.");
+        }
+
+        foreach ($scopes as $scope) {
+            if (! $scope instanceof PreferenceScope) {
+                throw new InvalidArgumentException("Preference [{$key}] must declare valid scopes.");
+            }
+        }
+
+        if (($list || $itemType !== null) && $type !== PreferenceValueType::Array) {
+            throw new InvalidArgumentException(
+                "Preference [{$key}] must use the array type when declaring a list or item type."
+            );
+        }
+
+        $this->validate($default);
+    }
+
+    public function supports(PreferenceScope $scope): bool
+    {
+        return in_array($scope, $this->scopes, true);
+    }
+
+    public function validate(mixed $value): void
+    {
+        if ($value === null) {
+            if ($this->nullable) {
+                return;
+            }
+
+            throw new InvalidArgumentException("Preference [{$this->key}] does not accept null.");
+        }
+
+        if (! $this->type->accepts($value)) {
+            throw new InvalidArgumentException("Preference [{$this->key}] must be {$this->type->value}.");
+        }
+
+        if ($this->list && is_array($value) && ! array_is_list($value)) {
+            throw new InvalidArgumentException("Preference [{$this->key}] must be a list.");
+        }
+
+        if ($this->itemType !== null && is_array($value)) {
+            foreach ($value as $item) {
+                if (! $this->itemType->accepts($item)) {
+                    throw new InvalidArgumentException("Preference [{$this->key}] contains an invalid item.");
+                }
+            }
+        }
+
+        if ($this->allowedValues !== [] && ! in_array($value, $this->allowedValues, true)) {
+            throw new InvalidArgumentException("Preference [{$this->key}] contains a value outside its schema.");
+        }
+    }
+}

--- a/src/Preferences/PreferenceManager.php
+++ b/src/Preferences/PreferenceManager.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Aura\Base\Preferences;
+
+use Aura\Base\Aura;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use InvalidArgumentException;
+
+/**
+ * Lightweight preference store backed by existing User/Team Option helpers.
+ *
+ * Intentionally small: typed registry + explicit context + simple persistence.
+ * Does not include the multi-tenant option-identity hardening stack from the
+ * experimental mega-branch.
+ */
+final class PreferenceManager
+{
+    public function __construct(private PreferenceRegistry $registry) {}
+
+    public function get(string $key, PreferenceContext $context): mixed
+    {
+        return $this->resolve($key, $context)->value;
+    }
+
+    public function reset(
+        string $key,
+        PreferenceScope $scope,
+        PreferenceContext $context,
+        ?User $actor,
+    ): void {
+        $definition = $this->registry->get($key);
+
+        if (! $definition->supports($scope)) {
+            throw new InvalidArgumentException("Preference [{$key}] does not support scope [{$scope->value}].");
+        }
+
+        $this->assertCanWrite($scope, $context, $actor);
+
+        $optionKey = $this->optionKey($key, $definition, $context);
+        $this->writeScope($scope, $optionKey, null, $context, delete: true);
+    }
+
+    public function resolve(string $key, PreferenceContext $context): PreferenceResult
+    {
+        $definition = $this->registry->get($key);
+        $optionKey = $this->optionKey($key, $definition, $context);
+
+        foreach ($this->scopeOrder($definition) as $scope) {
+            $value = $this->readScope($scope, $optionKey, $context);
+
+            if ($value === null && ! $definition->nullable) {
+                continue;
+            }
+
+            if ($value === null && $definition->nullable) {
+                return new PreferenceResult(null, $scope, $definition->resourceAware && $context->resource !== null);
+            }
+
+            if ($value !== null) {
+                try {
+                    $definition->validate($value);
+                } catch (InvalidArgumentException) {
+                    continue;
+                }
+
+                return new PreferenceResult(
+                    $value,
+                    $scope,
+                    $definition->resourceAware && $context->resource !== null,
+                );
+            }
+        }
+
+        foreach ($definition->legacyKeys as $legacyKey) {
+            $legacy = $this->readScope(PreferenceScope::User, $legacyKey, $context);
+
+            if ($legacy === null) {
+                continue;
+            }
+
+            try {
+                $definition->validate($legacy);
+            } catch (InvalidArgumentException) {
+                continue;
+            }
+
+            return new PreferenceResult(
+                $legacy,
+                PreferenceScope::User,
+                false,
+                isLegacy: true,
+            );
+        }
+
+        return new PreferenceResult($definition->default, null, false, isDefault: true);
+    }
+
+    public function set(
+        string $key,
+        mixed $value,
+        PreferenceScope $scope,
+        PreferenceContext $context,
+        ?User $actor,
+    ): void {
+        $definition = $this->registry->get($key);
+
+        if (! $definition->supports($scope)) {
+            throw new InvalidArgumentException("Preference [{$key}] does not support scope [{$scope->value}].");
+        }
+
+        $this->assertCanWrite($scope, $context, $actor);
+        $definition->validate($value);
+
+        $optionKey = $this->optionKey($key, $definition, $context);
+        $this->writeScope($scope, $optionKey, $value, $context);
+    }
+
+    private function assertCanWrite(PreferenceScope $scope, PreferenceContext $context, ?User $actor): void
+    {
+        if ($actor === null) {
+            throw new InvalidArgumentException('An actor is required to change preferences.');
+        }
+
+        match ($scope) {
+            PreferenceScope::User => $this->assertUserWrite($context, $actor),
+            PreferenceScope::Team => $this->assertTeamWrite($context, $actor),
+            PreferenceScope::Everyone => $this->assertEveryoneWrite($actor),
+        };
+    }
+
+    private function assertEveryoneWrite(User $actor): void
+    {
+        if (! method_exists($actor, 'isAuraGlobalAdmin') || ! $actor->isAuraGlobalAdmin()) {
+            throw new InvalidArgumentException('Everyone preferences require a global admin actor.');
+        }
+    }
+
+    private function assertTeamWrite(PreferenceContext $context, User $actor): void
+    {
+        if ($context->team === null) {
+            throw new InvalidArgumentException('Team preferences require a team context.');
+        }
+
+        if (method_exists($actor, 'isAuraGlobalAdmin') && $actor->isAuraGlobalAdmin()) {
+            return;
+        }
+
+        if ((string) ($context->team->user_id ?? '') !== (string) $actor->getKey()) {
+            throw new InvalidArgumentException('Team preferences can only be changed by the team owner.');
+        }
+    }
+
+    private function assertUserWrite(PreferenceContext $context, User $actor): void
+    {
+        if ($context->user === null || (string) $context->user->getKey() !== (string) $actor->getKey()) {
+            throw new InvalidArgumentException('User preferences can only be changed by that user.');
+        }
+    }
+
+    private function optionKey(string $key, PreferenceDefinition $definition, PreferenceContext $context): string
+    {
+        if ($definition->resourceAware && $context->resource !== null && $context->resource !== '') {
+            return 'preference.'.$key.'.'.$context->resource;
+        }
+
+        return 'preference.'.$key;
+    }
+
+    private function readScope(PreferenceScope $scope, string $optionKey, PreferenceContext $context): mixed
+    {
+        return match ($scope) {
+            PreferenceScope::User => $context->user?->getOption($optionKey),
+            PreferenceScope::Team => $context->team instanceof Team
+                ? $context->team->getOption($optionKey)
+                : null,
+            PreferenceScope::Everyone => Aura::getOption('preference.everyone.'.$optionKey),
+        };
+    }
+
+    /**
+     * @return list<PreferenceScope>
+     */
+    private function scopeOrder(PreferenceDefinition $definition): array
+    {
+        $order = [PreferenceScope::User, PreferenceScope::Team, PreferenceScope::Everyone];
+
+        return array_values(array_filter(
+            $order,
+            fn (PreferenceScope $scope): bool => $definition->supports($scope),
+        ));
+    }
+
+    private function writeScope(
+        PreferenceScope $scope,
+        string $optionKey,
+        mixed $value,
+        PreferenceContext $context,
+        bool $delete = false,
+    ): void {
+        if ($delete) {
+            // Option helpers only update; store null-equivalent empty for reset simplicity.
+            $value = null;
+        }
+
+        match ($scope) {
+            PreferenceScope::User => $context->user?->updateOption($optionKey, $value),
+            PreferenceScope::Team => $context->team instanceof Team
+                ? $context->team->updateOption($optionKey, $value)
+                : null,
+            PreferenceScope::Everyone => Aura::updateOption('preference.everyone.'.$optionKey, $value),
+        };
+    }
+}

--- a/src/Preferences/PreferenceRegistry.php
+++ b/src/Preferences/PreferenceRegistry.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Aura\Base\Preferences;
+
+use InvalidArgumentException;
+
+final class PreferenceRegistry
+{
+    /** @var array<string, PreferenceDefinition> */
+    private array $definitions = [];
+
+    /** @return array<string, PreferenceDefinition> */
+    public function all(): array
+    {
+        return $this->definitions;
+    }
+
+    public function get(string $key): PreferenceDefinition
+    {
+        return $this->definitions[$key]
+            ?? throw new InvalidArgumentException("Preference [{$key}] is not registered.");
+    }
+
+    public function register(PreferenceDefinition $definition): self
+    {
+        if (isset($this->definitions[$definition->key])) {
+            throw new InvalidArgumentException("Preference [{$definition->key}] is already registered.");
+        }
+
+        $this->definitions[$definition->key] = $definition;
+
+        return $this;
+    }
+}

--- a/src/Preferences/PreferenceResult.php
+++ b/src/Preferences/PreferenceResult.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Aura\Base\Preferences;
+
+final readonly class PreferenceResult
+{
+    public function __construct(
+        public mixed $value,
+        public ?PreferenceScope $scope,
+        public bool $resourceSpecific,
+        public bool $isDefault = false,
+        public bool $isLegacy = false,
+    ) {}
+}

--- a/src/Preferences/PreferenceScope.php
+++ b/src/Preferences/PreferenceScope.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Aura\Base\Preferences;
+
+enum PreferenceScope: string
+{
+    case Everyone = 'everyone';
+    case Team = 'team';
+    case User = 'user';
+}

--- a/src/Preferences/PreferenceValueType.php
+++ b/src/Preferences/PreferenceValueType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Aura\Base\Preferences;
+
+enum PreferenceValueType: string
+{
+    public function accepts(mixed $value): bool
+    {
+        return match ($this) {
+            self::Array => is_array($value),
+            self::Boolean => is_bool($value),
+            self::Float => is_float($value) && is_finite($value),
+            self::Integer => is_int($value),
+            self::String => is_string($value),
+        };
+    }
+    case Array = 'array';
+    case Boolean = 'boolean';
+    case Float = 'float';
+    case Integer = 'integer';
+    case String = 'string';
+}

--- a/src/RecordLayout/DefinesRecordLayoutPanels.php
+++ b/src/RecordLayout/DefinesRecordLayoutPanels.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Aura\Base\RecordLayout;
+
+interface DefinesRecordLayoutPanels
+{
+    /** @return list<RecordLayoutPanel> */
+    public static function recordLayoutPanels(): array;
+}

--- a/src/RecordLayout/InvalidRecordLayoutPanel.php
+++ b/src/RecordLayout/InvalidRecordLayoutPanel.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Aura\Base\RecordLayout;
+
+use InvalidArgumentException;
+
+class InvalidRecordLayoutPanel extends InvalidArgumentException {}

--- a/src/RecordLayout/RecordLayout.php
+++ b/src/RecordLayout/RecordLayout.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Aura\Base\RecordLayout;
+
+final readonly class RecordLayout
+{
+    /**
+     * @param  array<string, list<RegisteredRecordLayoutPanel>>  $regions
+     */
+    public function __construct(private array $regions) {}
+
+    public static function empty(): self
+    {
+        return new self([]);
+    }
+
+    public function hasPanels(): bool
+    {
+        return $this->regions !== [];
+    }
+
+    /** @return list<RegisteredRecordLayoutPanel> */
+    public function panels(RecordLayoutRegion $region): array
+    {
+        return $this->regions[$region->value] ?? [];
+    }
+}

--- a/src/RecordLayout/RecordLayoutPanel.php
+++ b/src/RecordLayout/RecordLayoutPanel.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Aura\Base\RecordLayout;
+
+use InvalidArgumentException;
+use Livewire\Component;
+
+final readonly class RecordLayoutPanel
+{
+    /**
+     * @param  class-string<Component>  $component
+     * @param  list<class-string|non-empty-string>  $resources
+     * @param  list<non-empty-string>  $eagerLoad
+     */
+    public function __construct(
+        public string $key,
+        public RecordLayoutRegion $region,
+        public string $component,
+        public int $order = 0,
+        public array $resources = ['*'],
+        public ?string $ability = null,
+        public bool $visible = true,
+        public ?string $preferenceKey = null,
+        public array $eagerLoad = [],
+    ) {
+        if (preg_match('/\A[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\z/D', $key) !== 1) {
+            throw new InvalidArgumentException("Record layout panel key [{$key}] is invalid.");
+        }
+
+        if ($resources === [] || count($resources) > RecordLayoutRegistry::MAX_RESOURCES_PER_PANEL) {
+            throw new InvalidArgumentException("Record layout panel [{$key}] must declare a bounded resource list.");
+        }
+
+        foreach ($resources as $resource) {
+            if (! is_string($resource) || trim($resource) === '' || str_contains($resource, "\0")) {
+                throw new InvalidArgumentException("Record layout panel [{$key}] contains an invalid resource.");
+            }
+        }
+
+        if ($ability !== null && (trim($ability) === '' || str_contains($ability, "\0"))) {
+            throw new InvalidArgumentException("Record layout panel [{$key}] contains an invalid ability.");
+        }
+
+        if ($preferenceKey !== null
+            && preg_match('/\A[a-z][a-z0-9_.-]*\z/D', $preferenceKey) !== 1) {
+            throw new InvalidArgumentException("Record layout panel [{$key}] contains an invalid preference key.");
+        }
+
+        if (count($eagerLoad) > RecordLayoutRegistry::MAX_RELATIONSHIPS_PER_PANEL) {
+            throw new InvalidArgumentException("Record layout panel [{$key}] declares too many eager-loaded relationships.");
+        }
+
+        foreach ($eagerLoad as $relationship) {
+            if (! is_string($relationship)
+                || preg_match('/\A[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*\z/D', $relationship) !== 1) {
+                throw new InvalidArgumentException("Record layout panel [{$key}] contains an invalid relationship.");
+            }
+        }
+    }
+}

--- a/src/RecordLayout/RecordLayoutPanelValidator.php
+++ b/src/RecordLayout/RecordLayoutPanelValidator.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Aura\Base\RecordLayout;
+
+use Aura\Base\Resource;
+use Livewire\Component;
+use ReflectionClass;
+use ReflectionIntersectionType;
+use ReflectionNamedType;
+use ReflectionType;
+use ReflectionUnionType;
+
+final class RecordLayoutPanelValidator
+{
+    public function validate(string $source, RecordLayoutPanel $panel): void
+    {
+        if (! class_exists($panel->component)) {
+            $this->fail($source, $panel, 'an existing Livewire component class');
+        }
+
+        $reflection = new ReflectionClass($panel->component);
+
+        if ($reflection->getName() !== $panel->component
+            || ! $reflection->isSubclassOf(Component::class)
+            || ! $reflection->isInstantiable()) {
+            $this->fail($source, $panel, 'a canonical, concrete Livewire component class');
+        }
+
+        if ($reflection->getConstructor()?->getNumberOfRequiredParameters() > 0) {
+            $this->fail($source, $panel, 'a constructor with zero required parameters');
+        }
+
+        $mount = $reflection->hasMethod('mount') ? $reflection->getMethod('mount') : null;
+
+        if ($mount !== null && (! $mount->isPublic() || $mount->isStatic())) {
+            $this->fail($source, $panel, 'a public, non-static mount method');
+        }
+
+        foreach (['model', 'inModal'] as $input) {
+            $acceptsProperty = false;
+
+            if ($reflection->hasProperty($input) && $reflection->getProperty($input)->isPublic()) {
+                $property = $reflection->getProperty($input);
+
+                if ($property->isStatic() || $property->isReadOnly()
+                    || ! $this->acceptsInput($property->getType(), $input)) {
+                    $this->fail($source, $panel, "a writable [{$input}] property with a compatible type");
+                }
+
+                $acceptsProperty = true;
+            }
+
+            $parameter = collect($mount?->getParameters() ?? [])
+                ->first(fn ($parameter): bool => $parameter->getName() === $input);
+
+            if (! $acceptsProperty && $parameter === null) {
+                $this->fail($source, $panel, "a public [{$input}] property or mount parameter");
+            }
+
+            if ($parameter !== null && ! $this->acceptsInput($parameter->getType(), $input)) {
+                $this->fail($source, $panel, "a compatible [{$input}] mount input");
+            }
+        }
+
+        foreach ($mount?->getParameters() ?? [] as $parameter) {
+            if (! in_array($parameter->getName(), ['model', 'inModal'], true)
+                && ! $parameter->isOptional() && ! $parameter->isVariadic()) {
+                $this->fail($source, $panel, "no unsupported required mount input [{$parameter->getName()}]");
+            }
+        }
+    }
+
+    private function acceptsInput(?ReflectionType $type, string $input): bool
+    {
+        if ($type === null) {
+            return true;
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            foreach ($type->getTypes() as $unionType) {
+                if ($this->acceptsInput($unionType, $input)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if ($type instanceof ReflectionIntersectionType || ! $type instanceof ReflectionNamedType) {
+            return false;
+        }
+
+        if ($input === 'inModal') {
+            return $type->isBuiltin() && in_array($type->getName(), ['bool', 'mixed'], true);
+        }
+
+        if ($type->isBuiltin()) {
+            return in_array($type->getName(), ['mixed', 'object'], true);
+        }
+
+        return is_a(Resource::class, $type->getName(), true);
+    }
+
+    private function fail(string $source, RecordLayoutPanel $panel, string $requirement): never
+    {
+        throw new InvalidRecordLayoutPanel(
+            "Record layout panel [{$source}:{$panel->key}] component [{$panel->component}] requires {$requirement}."
+        );
+    }
+}

--- a/src/RecordLayout/RecordLayoutRegion.php
+++ b/src/RecordLayout/RecordLayoutRegion.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Aura\Base\RecordLayout;
+
+enum RecordLayoutRegion: string
+{
+    case ActivityTimeline = 'activity-timeline';
+    case HeaderActions = 'header-actions';
+    case LeftSummary = 'left-summary';
+    case MainContent = 'main-content';
+    case RightSidebar = 'right-sidebar';
+}

--- a/src/RecordLayout/RecordLayoutRegistry.php
+++ b/src/RecordLayout/RecordLayoutRegistry.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Aura\Base\RecordLayout;
+
+use Aura\Base\Livewire\ComponentSlots\LivewireCollisionInspector;
+use Aura\Base\Preferences\PreferenceRegistry;
+use Aura\Base\Preferences\PreferenceScope;
+use Aura\Base\Preferences\PreferenceValueType;
+use Aura\Base\Resource;
+use InvalidArgumentException;
+use Livewire\Livewire;
+use Throwable;
+
+final class RecordLayoutRegistry
+{
+    public const MAX_PANELS = 100;
+
+    public const MAX_RELATIONSHIPS_PER_PANEL = 12;
+
+    public const MAX_RESOURCES_PER_PANEL = 32;
+
+    /** @var array<string, RegisteredRecordLayoutPanel> */
+    private array $baselinePanels = [];
+
+    private bool $finalized = false;
+
+    /** @var array<string, RegisteredRecordLayoutPanel> */
+    private array $panels = [];
+
+    public function __construct(
+        private readonly LivewireCollisionInspector $collisionInspector,
+        private readonly PreferenceRegistry $preferences,
+        private readonly RecordLayoutPanelValidator $validator,
+    ) {}
+
+    /** @param  list<class-string>  $resources */
+    public function captureBaselineState(array $resources = []): void
+    {
+        try {
+            $pending = $this->panels;
+
+            foreach ($resources as $resource) {
+                [$source, $panels] = $this->resourcePanels($resource);
+
+                if ($source !== null) {
+                    $pending = $this->mergedPanels($pending, $source, $panels);
+                }
+            }
+
+            $this->validatePreferences($pending);
+
+            foreach ($pending as $registered) {
+                $this->preflightTransport($registered);
+            }
+
+            foreach ($pending as $registered) {
+                Livewire::component($registered->transport(), $registered->panel->component);
+                $this->collisionInspector->rememberOwnedClaim(
+                    $registered->transport(),
+                    $registered->panel->component,
+                );
+            }
+
+            $this->panels = $pending;
+            $this->baselinePanels = $pending;
+            $this->finalized = true;
+        } catch (Throwable $exception) {
+            $this->panels = $this->baselinePanels;
+
+            throw $exception;
+        }
+    }
+
+    public function flushState(): void
+    {
+        $this->panels = $this->baselinePanels;
+    }
+
+    /** @return list<RegisteredRecordLayoutPanel> */
+    public function panelsFor(Resource $resource): array
+    {
+        $panels = array_filter(
+            $this->panels,
+            fn (RegisteredRecordLayoutPanel $registered): bool => $this->matchesResource($registered->panel, $resource),
+        );
+
+        usort($panels, static fn (RegisteredRecordLayoutPanel $left, RegisteredRecordLayoutPanel $right): int => [
+            $left->panel->region->value,
+            $left->panel->order,
+            $left->source,
+            $left->panel->key,
+        ] <=> [
+            $right->panel->region->value,
+            $right->panel->order,
+            $right->source,
+            $right->panel->key,
+        ]);
+
+        return array_values($panels);
+    }
+
+    /**
+     * @param  list<RecordLayoutPanel>  $panels
+     */
+    public function register(string $source, array $panels): void
+    {
+        if ($this->finalized) {
+            throw new InvalidArgumentException('Record layout panels must be registered before the application finishes booting.');
+        }
+
+        if (preg_match('/\A[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?\z/D', $source) !== 1) {
+            throw new InvalidArgumentException("Record layout source [{$source}] must be a lowercase Composer package name.");
+        }
+
+        $this->panels = $this->mergedPanels($this->panels, $source, $panels);
+    }
+
+    private function matchesResource(RecordLayoutPanel $panel, Resource $resource): bool
+    {
+        foreach ($panel->resources as $candidate) {
+            if ($candidate === '*'
+                || $candidate === $resource::class
+                || $candidate === $resource->getSlug()
+                || $candidate === $resource->getType()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @param  list<RecordLayoutPanel>  $panels */
+    private function mergedPanels(array $current, string $source, array $panels): array
+    {
+        $pending = $current;
+
+        foreach ($panels as $panel) {
+            if (! $panel instanceof RecordLayoutPanel) {
+                throw new InvalidArgumentException("Record layout source [{$source}] must register immutable panel definitions.");
+            }
+
+            $registered = new RegisteredRecordLayoutPanel($source, $panel);
+            $identity = $registered->identity();
+            $this->validator->validate($source, $panel);
+
+            if (isset($pending[$identity])) {
+                if ($pending[$identity] == $registered) {
+                    continue;
+                }
+
+                throw new InvalidArgumentException("Record layout panel [{$identity}] is already registered differently.");
+            }
+
+            $pending[$identity] = $registered;
+        }
+
+        if (count($pending) > self::MAX_PANELS) {
+            throw new InvalidArgumentException('The record layout panel registry limit was exceeded.');
+        }
+
+        return $pending;
+    }
+
+    private function preflightTransport(RegisteredRecordLayoutPanel $registered): void
+    {
+        $transport = $registered->transport();
+        $component = $registered->panel->component;
+
+        $this->collisionInspector->assertOwnedOrReservable(
+            $transport,
+            $component,
+            static fn (?string $name): ?string => null,
+        );
+    }
+
+    /**
+     * @param  class-string  $resource
+     * @return array{?string, list<RecordLayoutPanel>}
+     */
+    private function resourcePanels(string $resource): array
+    {
+        if (! is_subclass_of($resource, DefinesRecordLayoutPanels::class)) {
+            return [null, []];
+        }
+
+        $source = 'resource/record-layout-'.substr(hash('sha256', $resource), 0, 16);
+
+        $panels = [];
+
+        foreach ($resource::recordLayoutPanels() as $panel) {
+            if (! $panel instanceof RecordLayoutPanel) {
+                throw new InvalidArgumentException("Resource [{$resource}] must return immutable record layout panels.");
+            }
+
+            $panels[] = new RecordLayoutPanel(
+                key: $panel->key,
+                region: $panel->region,
+                component: $panel->component,
+                order: $panel->order,
+                resources: [$resource],
+                ability: $panel->ability,
+                visible: $panel->visible,
+                preferenceKey: $panel->preferenceKey,
+                eagerLoad: $panel->eagerLoad,
+            );
+        }
+
+        return [$source, $panels];
+    }
+
+    /** @param  array<string, RegisteredRecordLayoutPanel>  $panels */
+    private function validatePreferences(array $panels): void
+    {
+        foreach ($panels as $registered) {
+            $key = $registered->panel->preferenceKey;
+
+            if ($key === null) {
+                continue;
+            }
+
+            try {
+                $definition = $this->preferences->get($key);
+            } catch (InvalidArgumentException) {
+                throw new InvalidRecordLayoutPanel(
+                    "Record layout panel [{$registered->identity()}] preference [{$key}] is not registered."
+                );
+            }
+
+            if ($definition->type !== PreferenceValueType::Boolean
+                || (! $definition->supports(PreferenceScope::User)
+                    && ! $definition->supports(PreferenceScope::Team))) {
+                throw new InvalidRecordLayoutPanel(
+                    "Record layout panel [{$registered->identity()}] preference [{$key}] must be a user or team boolean."
+                );
+            }
+        }
+    }
+}

--- a/src/RecordLayout/RecordLayoutResolver.php
+++ b/src/RecordLayout/RecordLayoutResolver.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Aura\Base\RecordLayout;
+
+use Aura\Base\Preferences\PreferenceContext;
+use Aura\Base\Preferences\PreferenceManager;
+use Aura\Base\Resource;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\Gate;
+use Throwable;
+
+final readonly class RecordLayoutResolver
+{
+    public function __construct(
+        private PreferenceManager $preferences,
+        private RecordLayoutRegistry $registry,
+    ) {}
+
+    public function resolve(Resource $resource): RecordLayout
+    {
+        $regions = [];
+        $relationships = [];
+        $preferenceValues = [];
+        $user = auth()->user();
+        $preferenceContext = null;
+
+        foreach ($this->registry->panelsFor($resource) as $registered) {
+            $panel = $registered->panel;
+
+            if (! $panel->visible
+                || ! $this->authorized($panel, $resource, $user)
+                || ! $this->preferenceAllows($panel, $resource, $user, $preferenceContext, $preferenceValues)
+                || ! $this->relationshipsExist($panel, $resource)) {
+                continue;
+            }
+
+            $regions[$panel->region->value][] = $registered;
+            array_push($relationships, ...$panel->eagerLoad);
+        }
+
+        if ($relationships !== []) {
+            $resource->loadMissing(array_values(array_unique($relationships)));
+        }
+
+        return new RecordLayout($regions);
+    }
+
+    private function authorized(RecordLayoutPanel $panel, Resource $resource, mixed $user): bool
+    {
+        if ($panel->ability === null) {
+            return true;
+        }
+
+        if (! $user instanceof User) {
+            return false;
+        }
+
+        try {
+            return Gate::forUser($user)->allows($panel->ability, $resource);
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private function preferenceAllows(
+        RecordLayoutPanel $panel,
+        Resource $resource,
+        mixed $user,
+        ?PreferenceContext &$context,
+        array &$resolved,
+    ): bool {
+        if ($panel->preferenceKey === null) {
+            return true;
+        }
+
+        try {
+            $context ??= $this->preferenceContext($resource, $user);
+            if (! array_key_exists($panel->preferenceKey, $resolved)) {
+                $resolved[$panel->preferenceKey] = $this->preferences->get($panel->preferenceKey, $context);
+            }
+
+            return $resolved[$panel->preferenceKey] === true;
+        } catch (Throwable) {
+            $resolved[$panel->preferenceKey] = false;
+
+            return false;
+        }
+    }
+
+    private function preferenceContext(Resource $resource, mixed $user): PreferenceContext
+    {
+        $user = $user instanceof User ? $user : null;
+        $team = null;
+
+        if (config('aura.teams') && $user !== null) {
+            // Prefer hardened identity helper when present; fall back to currentTeam.
+            $team = method_exists($user, 'authorizedCurrentTeam')
+                ? $user->authorizedCurrentTeam()
+                : $user->currentTeam;
+        }
+
+        return new PreferenceContext(
+            application: (string) config('app.name', 'aura'),
+            user: $user,
+            team: $team instanceof Team ? $team : null,
+            resource: $resource->getType(),
+        );
+    }
+
+    private function relationshipsExist(RecordLayoutPanel $panel, Resource $resource): bool
+    {
+        foreach ($panel->eagerLoad as $relationship) {
+            if (! method_exists($resource, explode('.', $relationship, 2)[0])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/RecordLayout/RegisteredRecordLayoutPanel.php
+++ b/src/RecordLayout/RegisteredRecordLayoutPanel.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Aura\Base\RecordLayout;
+
+final readonly class RegisteredRecordLayoutPanel
+{
+    public function __construct(
+        public string $source,
+        public RecordLayoutPanel $panel,
+    ) {}
+
+    public function identity(): string
+    {
+        return $this->source.':'.$this->panel->key;
+    }
+
+    public function transport(): string
+    {
+        return 'aura-record-panel-'.hash('sha256', $this->identity());
+    }
+}

--- a/src/Reporting/AggregateDefinition.php
+++ b/src/Reporting/AggregateDefinition.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Aura\Base\Reporting;
+
+final readonly class AggregateDefinition
+{
+    public function __construct(
+        public string $resource,
+        public AggregateOperation $operation,
+        public ?string $metric = null,
+        public ?string $groupBy = null,
+        public ?DateRange $range = null,
+        public ?DateBucket $bucket = null,
+        public string $timezone = 'UTC',
+        public ?string $queryScope = null,
+    ) {}
+}

--- a/src/Reporting/AggregateEngine.php
+++ b/src/Reporting/AggregateEngine.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Aura\Base\Reporting;
+
+interface AggregateEngine
+{
+    public function run(AggregateDefinition $definition): AggregateResult;
+}

--- a/src/Reporting/AggregateOperation.php
+++ b/src/Reporting/AggregateOperation.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Aura\Base\Reporting;
+
+enum AggregateOperation: string
+{
+    case Average = 'average';
+    case Count = 'count';
+    case Maximum = 'max';
+    case Minimum = 'min';
+    case Sum = 'sum';
+}

--- a/src/Reporting/AggregatePoint.php
+++ b/src/Reporting/AggregatePoint.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Aura\Base\Reporting;
+
+final readonly class AggregatePoint
+{
+    public function __construct(
+        public ?string $key,
+        public string $label,
+        public int|string|null $value,
+        public int $rowCount,
+    ) {}
+}

--- a/src/Reporting/AggregateResult.php
+++ b/src/Reporting/AggregateResult.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Aura\Base\Reporting;
+
+final readonly class AggregateResult
+{
+    /** @param list<AggregatePoint> $points */
+    public function __construct(public int|string|null $value, public array $points = []) {}
+}

--- a/src/Reporting/DateBucket.php
+++ b/src/Reporting/DateBucket.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Aura\Base\Reporting;
+
+enum DateBucket: string
+{
+    case Day = 'day';
+    case Month = 'month';
+    case Quarter = 'quarter';
+    case Week = 'week';
+    case Year = 'year';
+}

--- a/src/Reporting/DateRange.php
+++ b/src/Reporting/DateRange.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Aura\Base\Reporting;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use InvalidArgumentException;
+
+final readonly class DateRange
+{
+    public DateTimeImmutable $end;
+
+    public DateTimeImmutable $start;
+
+    public function __construct(DateTimeInterface $start, DateTimeInterface $end)
+    {
+        $this->start = DateTimeImmutable::createFromInterface($start);
+        $this->end = DateTimeImmutable::createFromInterface($end);
+
+        if ($end <= $start) {
+            throw new InvalidArgumentException('Reporting ranges must have an end after their start.');
+        }
+    }
+}

--- a/src/Reporting/ResourceAggregateEngine.php
+++ b/src/Reporting/ResourceAggregateEngine.php
@@ -1,0 +1,517 @@
+<?php
+
+namespace Aura\Base\Reporting;
+
+use Aura\Base\Aura;
+use Aura\Base\Contracts\DeclaresReportingQueryScopes;
+use Aura\Base\Fields\Boolean;
+use Aura\Base\Fields\Number;
+use Aura\Base\Fields\Select;
+use Aura\Base\Fields\Text;
+use Aura\Base\Resource;
+use Aura\Base\Support\ExactDecimal;
+use Carbon\CarbonImmutable;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use LogicException;
+use RuntimeException;
+
+final class ResourceAggregateEngine implements AggregateEngine
+{
+    private const MAX_BUCKETS = 400;
+
+    private const MAX_GROUPS = 100;
+
+    public function run(AggregateDefinition $definition): AggregateResult
+    {
+        $resource = $this->resource($definition->resource);
+        Gate::authorize('viewAny', $resource);
+
+        if ($definition->groupBy !== null && $definition->bucket !== null) {
+            throw new InvalidArgumentException('Reporting cannot group by a field and a time bucket in the same request.');
+        }
+
+        $query = $this->authorizedQuery($resource);
+        $this->applyQueryScope($query, $resource, $definition->queryScope);
+        $this->applyRange($query, $resource, $definition->range);
+
+        $metric = $this->metricExpression($query, $resource, $definition);
+
+        if ($definition->groupBy !== null) {
+            return new AggregateResult(null, $this->grouped($query, $resource, $definition, $metric));
+        }
+
+        if ($definition->bucket !== null) {
+            return new AggregateResult(null, $this->bucketed($query, $resource, $definition, $metric));
+        }
+
+        return new AggregateResult($this->aggregate($query, $definition->operation, $metric));
+    }
+
+    /** @param Builder<resource> $query */
+    private function aggregate(Builder $query, AggregateOperation $operation, ?string $metric): int|string|null
+    {
+        $row = $this->aggregateSelect($query, $operation, $metric)->toBase()->first();
+
+        if (! is_object($row)) {
+            throw new RuntimeException('Reporting aggregate did not return a result row.');
+        }
+
+        return $this->aggregateFromRow($row, $operation);
+    }
+
+    private function aggregateFromRow(object $row, AggregateOperation $operation): int|string|null
+    {
+        if ($operation === AggregateOperation::Count) {
+            return (int) $row->row_count;
+        }
+
+        $validCount = (int) $row->valid_count;
+
+        if ($validCount === 0) {
+            return null;
+        }
+
+        return match ($operation) {
+            AggregateOperation::Average => $this->average((string) $row->scaled_sum, $validCount),
+            AggregateOperation::Maximum => $this->decimal((string) $row->scaled_max),
+            AggregateOperation::Minimum => $this->decimal((string) $row->scaled_min),
+            AggregateOperation::Sum => $this->decimal((string) $row->scaled_sum),
+            AggregateOperation::Count => (int) $row->row_count,
+        };
+    }
+
+    /** @param Builder<resource> $query */
+    private function aggregateSelect(Builder $query, AggregateOperation $operation, ?string $metric): Builder
+    {
+        $query->selectRaw('COUNT(*) as row_count');
+
+        if ($operation === AggregateOperation::Count) {
+            return $query;
+        }
+
+        if ($metric === null) {
+            throw new LogicException('Numeric reporting requires a metric expression.');
+        }
+
+        return $query
+            ->selectRaw("COUNT({$metric}) as valid_count")
+            ->selectRaw("SUM({$metric}) as scaled_sum")
+            ->selectRaw("MIN({$metric}) as scaled_min")
+            ->selectRaw("MAX({$metric}) as scaled_max");
+    }
+
+    /** @param Builder<resource> $query */
+    private function applyQueryScope(Builder $query, Resource $resource, ?string $scope): void
+    {
+        if ($scope === null) {
+            return;
+        }
+
+        $declaredScopes = $resource instanceof DeclaresReportingQueryScopes
+            ? $resource::reportingQueryScopes()
+            : [];
+
+        if (preg_match('/\A[a-zA-Z][a-zA-Z0-9_]*\z/', $scope) !== 1
+            || ! in_array($scope, $declaredScopes, true)
+            || ! method_exists($resource, 'scope'.Str::studly($scope))) {
+            throw new InvalidArgumentException('Reporting query scopes must be explicitly allowlisted no-argument Eloquent scopes.');
+        }
+
+        $query->{$scope}();
+    }
+
+    /** @param Builder<resource> $query */
+    private function applyRange(Builder $query, Resource $resource, ?DateRange $range): void
+    {
+        if ($range === null) {
+            return;
+        }
+
+        $query->where($resource->qualifyColumn('created_at'), '>=', $this->utc($range->start))
+            ->where($resource->qualifyColumn('created_at'), '<', $this->utc($range->end));
+    }
+
+    /** @return Builder<resource> */
+    private function authorizedQuery(Resource $resource): Builder
+    {
+        $query = $resource->newQuery();
+
+        if (method_exists($resource, 'indexQuery')) {
+            $query = $resource->indexQuery($query);
+        }
+
+        return $query;
+    }
+
+    private function average(string $sum, int $count): string
+    {
+        $scaled = $this->integer($sum);
+        $negative = $scaled < 0;
+        $absolute = abs($scaled);
+        $rounded = intdiv($absolute, $count);
+
+        if (($absolute % $count) * 2 >= $count) {
+            $rounded++;
+        }
+
+        return $this->decimal($negative ? -$rounded : $rounded);
+    }
+
+    /** @return list<array{0: string, 1: string, 2: string}> */
+    private function bucketBoundaries(DateRange $range, ?DateBucket $bucket, string $timezone): array
+    {
+        if ($bucket === null || ! in_array($timezone, timezone_identifiers_list(), true)) {
+            throw new InvalidArgumentException('Reporting buckets require an approved bucket and valid IANA timezone.');
+        }
+
+        $cursor = CarbonImmutable::instance($range->start)->setTimezone($timezone);
+        $end = CarbonImmutable::instance($range->end)->setTimezone($timezone);
+        $cursor = match ($bucket) {
+            DateBucket::Day => $cursor->startOfDay(),
+            DateBucket::Week => $cursor->startOfWeek(),
+            DateBucket::Month => $cursor->startOfMonth(),
+            DateBucket::Quarter => $cursor->firstOfQuarter(),
+            DateBucket::Year => $cursor->startOfYear(),
+        };
+        $boundaries = [];
+
+        while ($cursor < $end) {
+            $next = match ($bucket) {
+                DateBucket::Day => $cursor->addDay(),
+                DateBucket::Week => $cursor->addWeek(),
+                DateBucket::Month => $cursor->addMonthNoOverflow(),
+                DateBucket::Quarter => $cursor->addQuarter(),
+                DateBucket::Year => $cursor->addYear(),
+            };
+            $key = match ($bucket) {
+                DateBucket::Day => $cursor->format('Y-m-d'),
+                DateBucket::Week => $cursor->format('o-\\WW'),
+                DateBucket::Month => $cursor->format('Y-m'),
+                DateBucket::Quarter => $cursor->format('Y').'-Q'.$cursor->quarter,
+                DateBucket::Year => $cursor->format('Y'),
+            };
+            $boundaries[] = [$key, $cursor->utc()->toDateTimeString(), $next->utc()->toDateTimeString()];
+
+            if (count($boundaries) > self::MAX_BUCKETS) {
+                throw new InvalidArgumentException('Reporting bucket requests are limited to 400 points.');
+            }
+
+            $cursor = $next;
+        }
+
+        return $boundaries;
+    }
+
+    /**
+     * @param  Builder<resource>  $query
+     * @return list<AggregatePoint>
+     */
+    private function bucketed(Builder $query, Resource $resource, AggregateDefinition $definition, ?string $metric): array
+    {
+        if ($definition->range === null) {
+            throw new InvalidArgumentException('Reporting time buckets require a range.');
+        }
+
+        $boundaries = $this->bucketBoundaries($definition->range, $definition->bucket, $definition->timezone);
+        $grammar = $query->getQuery()->getGrammar();
+        $timestamp = $grammar->wrap($resource->qualifyColumn('created_at'));
+        $cases = [];
+        $bindings = [];
+
+        foreach ($boundaries as [$key, $start, $end]) {
+            $cases[] = "WHEN {$timestamp} >= ? AND {$timestamp} < ? THEN ?";
+            array_push($bindings, $start, $end, $key);
+        }
+
+        $expression = 'CASE '.implode(' ', $cases).' END';
+        $rows = $this->aggregateSelect($query, $definition->operation, $metric)
+            ->selectRaw("{$expression} as bucket_key", $bindings)
+            ->groupBy('bucket_key')
+            ->orderBy('bucket_key')
+            ->toBase()
+            ->get();
+
+        return $rows->map(fn (object $row): AggregatePoint => new AggregatePoint(
+            key: (string) $row->bucket_key,
+            label: (string) $row->bucket_key,
+            value: $this->aggregateFromRow($row, $definition->operation),
+            rowCount: (int) $row->row_count,
+        ))->all();
+    }
+
+    private function decimal(string|int $scaled): string
+    {
+        $value = is_int($scaled) ? $scaled : $this->integer($scaled);
+        $negative = $value < 0;
+        $absolute = abs($value);
+
+        return ($negative ? '-' : '').intdiv($absolute, 1_000_000).'.'.str_pad((string) ($absolute % 1_000_000), 6, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * @param  Builder<resource>  $query
+     * @return list<AggregatePoint>
+     */
+    private function grouped(Builder $query, Resource $resource, AggregateDefinition $definition, ?string $metric): array
+    {
+        $field = $this->groupField($resource, $definition->groupBy);
+        $fieldClass = $resource->fieldClassBySlug($definition->groupBy);
+        $qualified = $resource->qualifyColumn($definition->groupBy);
+        $wrapped = $query->getQuery()->getGrammar()->wrap($qualified);
+        $rows = $this->aggregateSelect($query, $definition->operation, $metric)
+            ->selectRaw("{$wrapped} as group_key")
+            ->groupBy($qualified)
+            ->orderByRaw("CASE WHEN {$wrapped} IS NULL THEN 1 ELSE 0 END")
+            ->orderBy($qualified)
+            ->limit(self::MAX_GROUPS + 1)
+            ->toBase()
+            ->get();
+
+        if ($rows->count() > self::MAX_GROUPS) {
+            throw new RuntimeException('Reporting groups exceed the 100 point limit.');
+        }
+
+        return $rows->map(function (object $row) use ($definition, $field, $fieldClass, $resource): AggregatePoint {
+            $raw = $row->group_key;
+            $key = $this->groupKey($raw, $fieldClass);
+            $label = $raw === null
+                ? 'Empty'
+                : $this->groupLabel($raw, $field, $fieldClass, $resource);
+
+            return new AggregatePoint($key, $label, $this->aggregateFromRow($row, $definition->operation), (int) $row->row_count);
+        })->sort(function (AggregatePoint $left, AggregatePoint $right) use ($fieldClass): int {
+            if ($left->key === null || $right->key === null) {
+                return $left->key === $right->key ? 0 : ($left->key === null ? 1 : -1);
+            }
+
+            $leftKey = $fieldClass instanceof Number ? ExactDecimal::sortableKey($left->key) : $left->key;
+            $rightKey = $fieldClass instanceof Number ? ExactDecimal::sortableKey($right->key) : $right->key;
+
+            return strcmp($leftKey, $rightKey);
+        })->values()->all();
+    }
+
+    /** @return array<string, mixed> */
+    private function groupField(Resource $resource, ?string $slug): array
+    {
+        if ($slug === null || ! $resource->isTableField($slug)) {
+            throw new InvalidArgumentException('Reporting groups must be declared physical scalar fields.');
+        }
+
+        $field = $resource->fieldBySlug($slug);
+        $class = $resource->fieldClassBySlug($slug);
+
+        if (! is_array($field) || ! ($class instanceof Boolean || $class instanceof Number || $class instanceof Select || $class instanceof Text)) {
+            throw new InvalidArgumentException('Reporting groups must be declared physical scalar fields.');
+        }
+
+        return $field;
+    }
+
+    private function groupKey(mixed $value, object $field): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($field instanceof Boolean) {
+            return (bool) $value ? '1' : '0';
+        }
+
+        if ($field instanceof Number) {
+            return $this->decimal((string) $this->scaledInteger($value));
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * Resolve a human group label without the FieldValueContract presentation stack.
+     * Prefer option catalogs (Select/Status/etc.), then field display(), then string cast.
+     */
+    private function groupLabel(mixed $raw, array $field, object $fieldClass, Resource $resource): string
+    {
+        if (method_exists($fieldClass, 'options')) {
+            $options = $fieldClass->options($resource, $field);
+
+            if ($options instanceof Collection) {
+                $options = $options->all();
+            }
+
+            if (is_array($options)) {
+                foreach ($options as $optionKey => $option) {
+                    if (is_array($option) && array_key_exists('key', $option)) {
+                        $key = $option['key'];
+                        $value = $option['value'] ?? $option['label'] ?? $key;
+                    } elseif (! is_int($optionKey)) {
+                        $key = $optionKey;
+                        $value = is_array($option) ? ($option['value'] ?? $option['label'] ?? $optionKey) : $option;
+                    } else {
+                        $key = $option;
+                        $value = is_array($option) ? ($option['value'] ?? $option['label'] ?? $option) : $option;
+                    }
+
+                    if ((string) $key === (string) $raw) {
+                        return (string) $value;
+                    }
+                }
+            }
+        }
+
+        if (method_exists($fieldClass, 'display')) {
+            $presented = $fieldClass->display($field, $raw, $resource);
+
+            if ($presented instanceof Htmlable) {
+                return html_entity_decode(strip_tags($presented->toHtml()), ENT_QUOTES, 'UTF-8');
+            }
+
+            if (is_scalar($presented) || $presented === null) {
+                return html_entity_decode(strip_tags((string) $presented), ENT_QUOTES, 'UTF-8');
+            }
+        }
+
+        return (string) $raw;
+    }
+
+    private function integer(string $value): int
+    {
+        if (preg_match('/^-?\d+$/', $value) !== 1) {
+            throw new RuntimeException('Reporting aggregate overflowed its exact signed integer contract.');
+        }
+
+        $negative = str_starts_with($value, '-');
+        $digits = ltrim($value, '-0');
+        $digits = $digits === '' ? '0' : $digits;
+        $maximum = $negative ? '9223372036854775808' : '9223372036854775807';
+
+        if (strlen($digits) > strlen($maximum) || (strlen($digits) === strlen($maximum) && strcmp($digits, $maximum) > 0)) {
+            throw new RuntimeException('Reporting aggregate overflowed its exact signed integer contract.');
+        }
+
+        return (int) $value;
+    }
+
+    /** @param Builder<resource> $query */
+    private function metricExpression(Builder $query, Resource $resource, AggregateDefinition $definition): ?string
+    {
+        if ($definition->operation === AggregateOperation::Count) {
+            return null;
+        }
+
+        if ($definition->metric === null) {
+            throw new InvalidArgumentException('Numeric reporting requires a declared metric field.');
+        }
+
+        $field = $resource->fieldBySlug($definition->metric);
+        $fieldClass = $resource->fieldClassBySlug($definition->metric);
+
+        if (! is_array($field) || ! $fieldClass instanceof Number) {
+            throw new InvalidArgumentException('Reporting metrics must be declared Number fields.');
+        }
+
+        $configuration = method_exists($fieldClass, 'exactQueryConfiguration')
+            ? $fieldClass->exactQueryConfiguration($field)
+            : ['mode' => 'legacy', 'precision' => null, 'scale' => 0];
+
+        // Null precision means integer/legacy Number without an explicit
+        // DECIMAL(p, s) contract. Those are reporting-safe at scale 0 and must
+        // not fall back to Number::DEFAULT_PRECISION (19), which is outside the
+        // portable reporting envelope (precision ≤ 18, scale ≤ 6).
+        $precision = $configuration['precision'] ?? 18;
+        $scale = $configuration['scale'] ?? 0;
+
+        if ($precision > 18 || $scale > 6) {
+            throw new InvalidArgumentException('Reporting metrics require precision at most 18 and scale at most 6.');
+        }
+
+        if ($resource->isTableField($definition->metric)) {
+            return $this->physicalScaledExpression($query, $resource->qualifyColumn($definition->metric));
+        }
+
+        // Meta projection dual-write/read is intentionally not ported. Widgets
+        // continue to use their legacy meta CAST path for non-physical metrics.
+        throw new InvalidArgumentException(
+            config('aura.reporting.projection.reads_enabled', false)
+                ? 'Meta-backed reporting metrics require the typed projection stack, which is not available in this build.'
+                : 'Meta-backed reporting metrics require enabled typed projection reads.'
+        );
+    }
+
+    private function physicalScaledExpression(Builder $query, string $qualifiedColumn): string
+    {
+        $connection = $query->getConnection();
+
+        if (! $connection instanceof Connection) {
+            throw new RuntimeException('Reporting requires a concrete database connection.');
+        }
+
+        $grammar = $query->getQuery()->getGrammar();
+        $column = $grammar->wrap($qualifiedColumn);
+
+        if ($connection->getDriverName() === 'sqlite') {
+            $this->registerSqliteScaler($connection);
+
+            return "aura_reporting_scaled({$column})";
+        }
+
+        return match ($connection->getDriverName()) {
+            'pgsql' => "CAST({$column} * 1000000 AS BIGINT)",
+            'mariadb', 'mysql' => "CAST({$column} * 1000000 AS SIGNED)",
+            default => throw new RuntimeException('Reporting has no approved numeric expression for this database driver.'),
+        };
+    }
+
+    private function registerSqliteScaler(Connection $connection): void
+    {
+        $connection->getPdo()->sqliteCreateFunction('aura_reporting_scaled', fn (mixed $value): ?int => $this->scaledInteger($value), 1, true);
+    }
+
+    private function resource(string $class): Resource
+    {
+        if (! is_a($class, Resource::class, true) || ! in_array($class, app(Aura::class)->getResources(), true)) {
+            throw new InvalidArgumentException('Reporting resources must be registered Aura Resource classes.');
+        }
+
+        return new $class;
+    }
+
+    private function scaledInteger(mixed $value): ?int
+    {
+        if (! is_int($value) && ! is_string($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        if (preg_match('/\A([+-]?)(\d+)(?:\.(\d{1,6}))?\z/', $value, $matches) !== 1) {
+            return null;
+        }
+
+        $integer = ltrim($matches[2], '0');
+        $integer = $integer === '' ? '0' : $integer;
+        $fraction = str_pad($matches[3] ?? '', 6, '0');
+        $digits = ltrim($integer.$fraction, '0');
+        $digits = $digits === '' ? '0' : $digits;
+        $negative = $matches[1] === '-' && $digits !== '0';
+        $maximum = $negative ? '9223372036854775808' : '9223372036854775807';
+
+        if (strlen($digits) > strlen($maximum) || (strlen($digits) === strlen($maximum) && strcmp($digits, $maximum) > 0)) {
+            return null;
+        }
+
+        return (int) ($negative ? '-'.$digits : $digits);
+    }
+
+    private function utc(DateTimeInterface $value): DateTimeImmutable
+    {
+        return DateTimeImmutable::createFromInterface($value)->setTimezone(new \DateTimeZone('UTC'));
+    }
+}

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -3,6 +3,7 @@
 namespace Aura\Base;
 
 use Aura\Base\Contracts\DefinesFields;
+use Aura\Base\Contracts\TableResource;
 use Aura\Base\Models\Scopes\ScopedScope;
 use Aura\Base\Models\Scopes\TeamScope;
 use Aura\Base\Models\Scopes\TypeScope;
@@ -39,7 +40,7 @@ use Illuminate\Support\Str;
  * @property-read Collection $fields  Computed input-field map (getFieldsAttribute()).
  * @property-read mixed $meta  The meta relation / normalized meta map (see getMeta()).
  */
-class Resource extends Model implements DefinesFields
+class Resource extends Model implements DefinesFields, TableResource
 {
     use AuraModelConfig;
     use HasFactory;

--- a/src/Resources/Attachment.php
+++ b/src/Resources/Attachment.php
@@ -8,6 +8,7 @@ use Aura\Base\Resource;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
@@ -36,6 +37,7 @@ class Attachment extends Resource
             'confirm-content' => 'Are you sure you want to delete this post?',
             'confirm-button' => 'Delete',
             'confirm-button-class' => 'ml-3 bg-red-600 hover:bg-red-700',
+            'ability' => 'delete',
         ],
     ];
 
@@ -43,6 +45,7 @@ class Attachment extends Resource
         'deleteSelected' => [
             'label' => 'Delete',
             'method' => 'collection',
+            'ability' => 'delete',
         ],
     ];
 
@@ -70,6 +73,8 @@ class Attachment extends Resource
 
     public function deleteAttachment()
     {
+        Gate::authorize('delete', $this);
+
         parent::delete();
 
         return redirect()->route('aura.attachment.index');
@@ -77,8 +82,12 @@ class Attachment extends Resource
 
     public function deleteSelected($ids)
     {
-        self::whereIn('id', $ids)->delete();
+        $ids = array_values(array_filter((array) $ids, fn ($id) => $id !== null && $id !== ''));
 
+        foreach (self::query()->whereKey($ids)->get() as $attachment) {
+            Gate::authorize('delete', $attachment);
+            $attachment->delete();
+        }
     }
 
     public function filePath($size = null)

--- a/src/Resources/Role.php
+++ b/src/Resources/Role.php
@@ -20,11 +20,15 @@ class Role extends Resource
             'label' => 'Delete',
             'icon' => '<svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>',
             'class' => 'hover:text-red-700 text-red-500 font-bold',
+            'ability' => 'delete',
         ],
     ];
 
     public array $bulkActions = [
-        'deleteSelected' => 'Delete',
+        'deleteSelected' => [
+            'label' => 'Delete',
+            'ability' => 'delete',
+        ],
     ];
 
     public static $customTable = true;
@@ -150,6 +154,12 @@ class Role extends Resource
     public static function currentTeamIdForResolution(): ?int
     {
         return optional(auth()->user())->current_team_id;
+    }
+
+    public function deleteSelected($ids = null)
+    {
+        Gate::authorize('delete', $this);
+        $this->delete();
     }
 
     /**

--- a/src/Support/ExactDecimal.php
+++ b/src/Support/ExactDecimal.php
@@ -1,0 +1,433 @@
+<?php
+
+namespace Aura\Base\Support;
+
+use Aura\Base\Fields\Number;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use InvalidArgumentException;
+
+final class ExactDecimal
+{
+    public const MAX_DIGITS = 65;
+
+    public static function applyComparison(
+        EloquentBuilder|QueryBuilder $query,
+        Connection $connection,
+        string $wrappedColumn,
+        string $operator,
+        mixed $value,
+        ?array $numberConfiguration = null,
+    ): void {
+        if (! in_array($operator, ['=', '!=', '>', '<', '>=', '<='], true)) {
+            throw new InvalidArgumentException("Unsupported exact-decimal operator [{$operator}].");
+        }
+
+        $configuration = $numberConfiguration === null
+            ? null
+            : self::validatedConfiguration($numberConfiguration);
+
+        if ($configuration !== null) {
+            $value = self::configuredNormalizedValue($value, $configuration);
+        }
+
+        $comparisonKey = self::sortableKey($value);
+
+        if ($value === null || str_starts_with($comparisonKey, '3')) {
+            throw new InvalidArgumentException('Exact-decimal comparisons require a valid plain base-10 value.');
+        }
+
+        $nativeNumber = self::nativeConfiguredNumber($connection, $wrappedColumn, $configuration);
+
+        if ($nativeNumber !== null) {
+            $query->whereRaw(
+                "{$nativeNumber['value']} IS NOT NULL AND {$nativeNumber['value']} {$operator} {$nativeNumber['target']}",
+                [(string) $value],
+            );
+
+            return;
+        }
+
+        $key = self::sqlSortableKey($connection, $wrappedColumn, $configuration);
+        $query->whereRaw("{$key} IS NOT NULL AND {$key} {$operator} ?", [$comparisonKey]);
+    }
+
+    public static function applySorting(
+        EloquentBuilder|QueryBuilder $query,
+        Connection $connection,
+        string $wrappedColumn,
+        string $direction,
+        ?array $numberConfiguration = null,
+    ): void {
+        $direction = strtolower($direction);
+
+        if (! in_array($direction, ['asc', 'desc'], true)) {
+            throw new InvalidArgumentException("Unsupported exact-decimal sort direction [{$direction}].");
+        }
+
+        $configuration = $numberConfiguration === null
+            ? null
+            : self::validatedConfiguration($numberConfiguration);
+        $nativeNumber = self::nativeConfiguredNumber($connection, $wrappedColumn, $configuration);
+
+        if ($nativeNumber !== null) {
+            $query->orderByRaw("CASE WHEN {$nativeNumber['value']} IS NULL THEN 1 ELSE 0 END")
+                ->orderByRaw("{$nativeNumber['value']} {$direction}");
+
+            return;
+        }
+
+        $key = self::sqlSortableKey($connection, $wrappedColumn, $configuration);
+        $query->orderByRaw("CASE WHEN {$key} IS NULL THEN 1 ELSE 0 END")
+            ->orderByRaw("{$key} {$direction}");
+    }
+
+    public static function registerSqliteFunction(Connection $connection): void
+    {
+        if ($connection->getDriverName() !== 'sqlite') {
+            return;
+        }
+
+        $connection->getPdo()->sqliteCreateFunction(
+            'aura_decimal_sort_key',
+            self::sortableKey(...),
+            1,
+            true,
+        );
+        $connection->getPdo()->sqliteCreateFunction(
+            'aura_number_sort_key',
+            self::configuredSortableKey(...),
+            4,
+            true,
+        );
+    }
+
+    public static function sortableKey(mixed $value): string
+    {
+        $value = trim((string) $value);
+
+        if (preg_match('/\A([+-]?)(\d+)(?:\.(\d+))?\z/', $value, $matches) !== 1) {
+            return '3'.$value;
+        }
+
+        $integer = ltrim($matches[2], '0');
+        $integer = $integer === '' ? '0' : $integer;
+        $fraction = $matches[3] ?? '';
+        $digitCount = ($integer === '0' ? 0 : strlen($integer)) + strlen($fraction);
+
+        if ($digitCount > self::MAX_DIGITS) {
+            return '3'.$value;
+        }
+
+        $fraction = rtrim($fraction, '0');
+        $fraction = str_pad($fraction, self::MAX_DIGITS, '0');
+        $negative = $matches[1] === '-' && ($integer !== '0' || trim($fraction, '0') !== '');
+
+        if (! $negative && $integer === '0' && trim($fraction, '0') === '') {
+            return '1';
+        }
+
+        if (! $negative) {
+            return '2'.sprintf('%03d', strlen($integer)).$integer.$fraction;
+        }
+
+        return '0'.sprintf('%03d', 999 - strlen($integer)).self::complement($integer.$fraction);
+    }
+
+    public static function supportsSql(Connection $connection): bool
+    {
+        return in_array($connection->getDriverName(), ['mysql', 'pgsql', 'sqlite'], true);
+    }
+
+    private static function complement(string $digits): string
+    {
+        return strtr($digits, '0123456789', '9876543210');
+    }
+
+    /**
+     * @param  array{mode: 'decimal'|'integer'|'legacy', precision: int|null, scale: int}  $configuration
+     */
+    private static function configuredNormalizedValue(mixed $value, array $configuration): int|string|null
+    {
+        $field = [];
+
+        if ($configuration['mode'] !== 'legacy') {
+            $field['number_type'] = $configuration['mode'];
+        }
+
+        if ($configuration['precision'] !== null) {
+            $field['precision'] = $configuration['precision'];
+        }
+
+        if ($configuration['mode'] === 'decimal') {
+            $field['scale'] = $configuration['scale'];
+        }
+
+        return (new Number)->normalizeForExactQuery($value, $field);
+    }
+
+    private static function configuredSortableKey(
+        mixed $value,
+        string $mode,
+        mixed $precision,
+        mixed $scale,
+    ): string {
+        $configuration = self::validatedConfiguration([
+            'mode' => $mode,
+            'precision' => $precision === null ? null : (int) $precision,
+            'scale' => (int) $scale,
+        ]);
+        $normalized = self::configuredNormalizedValue($value, $configuration);
+
+        return $normalized === null ? '3'.trim((string) $value) : self::sortableKey($normalized);
+    }
+
+    private static function mysqlComplement(string $expression): string
+    {
+        // Replace through non-digit placeholders so 0 -> 9 cannot be changed
+        // again by the later 9 -> 0 pass.
+        $temporary = range('A', 'J');
+
+        foreach (range(0, 9) as $digit) {
+            $expression = "REPLACE({$expression}, '{$digit}', '{$temporary[$digit]}')";
+        }
+
+        foreach (range(0, 9) as $digit) {
+            $expression = "REPLACE({$expression}, '{$temporary[$digit]}', '".(9 - $digit)."')";
+        }
+
+        return $expression;
+    }
+
+    /**
+     * @param  array{mode: 'decimal'|'integer'|'legacy', precision: int|null, scale: int}  $configuration
+     */
+    private static function mysqlConfiguredValue(string $column, array $configuration): string
+    {
+        $value = "TRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(CAST({$column} AS CHAR), CHAR(0), ' '), CHAR(9), ' '), CHAR(10), ' '), CHAR(11), ' '), CHAR(13), ' '))";
+        $unsigned = "(CASE WHEN LEFT({$value}, 1) IN ('+', '-') THEN SUBSTRING({$value}, 2) ELSE {$value} END)";
+        $integerRaw = "SUBSTRING_INDEX({$unsigned}, '.', 1)";
+        $fractionRaw = "(CASE WHEN LOCATE('.', {$unsigned}) > 0 THEN SUBSTRING({$unsigned}, LOCATE('.', {$unsigned}) + 1) ELSE '' END)";
+        $integer = "COALESCE(NULLIF(TRIM(LEADING '0' FROM {$integerRaw}), ''), '0')";
+        $integerDigits = "(CASE WHEN {$integer} = '0' THEN 0 ELSE CHAR_LENGTH({$integer}) END)";
+        $digitCount = "({$integerDigits} + CHAR_LENGTH({$fractionRaw}))";
+        $plain = "({$value} REGEXP '^[+-]?[0-9]+([.][0-9]+)?$' AND {$value} NOT REGEXP '[^-+0-9.]' AND {$digitCount} <= ".self::MAX_DIGITS.')';
+        $hasFraction = "(LOCATE('.', {$unsigned}) > 0)";
+
+        if ($configuration['mode'] === 'legacy') {
+            $precision = $configuration['precision'];
+            $valid = $precision === null
+                ? $plain
+                : "({$plain} AND ({$hasFraction} OR CHAR_LENGTH({$integer}) <= {$precision}))";
+
+            return "(CASE WHEN {$valid} THEN {$value} ELSE '' END)";
+        }
+
+        if ($configuration['mode'] === 'integer') {
+            $precision = $configuration['precision'];
+            $valid = "({$plain} AND NOT {$hasFraction}".
+                ($precision === null ? '' : " AND CHAR_LENGTH({$integer}) <= {$precision}").')';
+            $precision ??= self::MAX_DIGITS;
+
+            return "(CASE WHEN {$valid} THEN CAST({$value} AS DECIMAL({$precision}, 0)) ELSE NULL END)";
+        }
+
+        $precision = $configuration['precision'];
+        $scale = $configuration['scale'];
+        $integerCapacity = $precision - $scale;
+        $roundingDigit = "SUBSTRING(RPAD({$fractionRaw}, ".($scale + 1).", '0'), ".($scale + 1).', 1)';
+        $keptFraction = $scale === 0 ? "''" : "LEFT(RPAD({$fractionRaw}, {$scale}, '0'), {$scale})";
+        $maximumInteger = $integerCapacity === 0 ? '0' : str_repeat('9', $integerCapacity);
+        $maximumFraction = $scale === 0 ? '' : str_repeat('9', $scale);
+        $roundingOverflow = "({$roundingDigit} IN ('5', '6', '7', '8', '9') AND {$integer} = '{$maximumInteger}' AND {$keptFraction} = '{$maximumFraction}')";
+        $valid = "({$plain} AND {$integerDigits} <= {$integerCapacity} AND NOT {$roundingOverflow})";
+
+        return "(CASE WHEN {$valid} THEN CAST({$value} AS DECIMAL({$precision}, {$scale})) ELSE NULL END)";
+    }
+
+    private static function mysqlSortableKey(string $column): string
+    {
+        $value = "TRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(CAST({$column} AS CHAR), CHAR(0), ' '), CHAR(9), ' '), CHAR(10), ' '), CHAR(11), ' '), CHAR(13), ' '))";
+        $unsigned = "(CASE WHEN LEFT({$value}, 1) IN ('+', '-') THEN SUBSTRING({$value}, 2) ELSE {$value} END)";
+        $integerRaw = "SUBSTRING_INDEX({$unsigned}, '.', 1)";
+        $fractionRaw = "(CASE WHEN LOCATE('.', {$unsigned}) > 0 THEN SUBSTRING({$unsigned}, LOCATE('.', {$unsigned}) + 1) ELSE '' END)";
+        $integer = "COALESCE(NULLIF(TRIM(LEADING '0' FROM {$integerRaw}), ''), '0')";
+        $fraction = "TRIM(TRAILING '0' FROM {$fractionRaw})";
+        $paddedFraction = "RPAD({$fraction}, ".self::MAX_DIGITS.", '0')";
+        $magnitude = "CONCAT({$integer}, {$paddedFraction})";
+        $digitCount = "((CASE WHEN {$integer} = '0' THEN 0 ELSE CHAR_LENGTH({$integer}) END) + CHAR_LENGTH({$fractionRaw}))";
+        $zero = "({$integer} = '0' AND {$fraction} = '')";
+        $valid = "({$value} REGEXP '^[+-]?[0-9]+([.][0-9]+)?$' AND {$value} NOT REGEXP '[^-+0-9.]' AND {$digitCount} <= ".self::MAX_DIGITS.')';
+        $negative = "(LEFT({$value}, 1) = '-' AND NOT {$zero})";
+        $negativeKey = "CONCAT('0', LPAD(999 - CHAR_LENGTH({$integer}), 3, '0'), ".self::mysqlComplement($magnitude).')';
+        $positiveKey = "CONCAT('2', LPAD(CHAR_LENGTH({$integer}), 3, '0'), {$magnitude})";
+
+        return "(CASE WHEN {$valid} THEN CAST(CASE WHEN {$zero} THEN '1' WHEN {$negative} THEN {$negativeKey} ELSE {$positiveKey} END AS BINARY) ELSE NULL END)";
+    }
+
+    /**
+     * @param  array{mode: 'decimal'|'integer'|'legacy', precision: int|null, scale: int}|null  $configuration
+     * @return array{value: string, target: string}|null
+     */
+    private static function nativeConfiguredNumber(
+        Connection $connection,
+        string $wrappedColumn,
+        ?array $configuration,
+    ): ?array {
+        if ($configuration === null
+            || $configuration['mode'] === 'legacy'
+            || ! in_array($connection->getDriverName(), ['mysql', 'pgsql'], true)) {
+            return null;
+        }
+
+        $precision = $configuration['precision'] ?? self::MAX_DIGITS;
+        $scale = $configuration['scale'];
+
+        return match ($connection->getDriverName()) {
+            'mysql' => [
+                'value' => self::mysqlConfiguredValue($wrappedColumn, $configuration),
+                'target' => "CAST(? AS DECIMAL({$precision}, {$scale}))",
+            ],
+            'pgsql' => [
+                'value' => self::postgresConfiguredValue($wrappedColumn, $configuration),
+                'target' => "CAST(? AS NUMERIC({$precision}, {$scale}))",
+            ],
+        };
+    }
+
+    /**
+     * @param  array{mode: 'decimal'|'integer'|'legacy', precision: int|null, scale: int}  $configuration
+     */
+    private static function postgresConfiguredValue(string $column, array $configuration): string
+    {
+        $value = "BTRIM(REPLACE(REPLACE(REPLACE(REPLACE(CAST({$column} AS TEXT), CHR(9), ' '), CHR(10), ' '), CHR(11), ' '), CHR(13), ' '))";
+        $unsigned = "(CASE WHEN LEFT({$value}, 1) IN ('+', '-') THEN SUBSTRING({$value} FROM 2) ELSE {$value} END)";
+        $integerRaw = "SPLIT_PART({$unsigned}, '.', 1)";
+        $fractionRaw = "(CASE WHEN STRPOS({$unsigned}, '.') > 0 THEN SPLIT_PART({$unsigned}, '.', 2) ELSE '' END)";
+        $integer = "COALESCE(NULLIF(LTRIM({$integerRaw}, '0'), ''), '0')";
+        $integerDigits = "(CASE WHEN {$integer} = '0' THEN 0 ELSE LENGTH({$integer}) END)";
+        $digitCount = "({$integerDigits} + LENGTH({$fractionRaw}))";
+        $plain = "({$value} ~ '^[+-]?[0-9]+([.][0-9]+)?$' AND {$value} !~ '[^-+0-9.]' AND {$digitCount} <= ".self::MAX_DIGITS.')';
+        $hasFraction = "(STRPOS({$unsigned}, '.') > 0)";
+
+        if ($configuration['mode'] === 'legacy') {
+            $precision = $configuration['precision'];
+            $valid = $precision === null
+                ? $plain
+                : "({$plain} AND ({$hasFraction} OR LENGTH({$integer}) <= {$precision}))";
+
+            return "(CASE WHEN {$valid} THEN {$value} ELSE '' END)";
+        }
+
+        if ($configuration['mode'] === 'integer') {
+            $precision = $configuration['precision'];
+            $valid = "({$plain} AND NOT {$hasFraction}".
+                ($precision === null ? '' : " AND LENGTH({$integer}) <= {$precision}").')';
+            $precision ??= self::MAX_DIGITS;
+
+            return "(CASE WHEN {$valid} THEN CAST({$value} AS NUMERIC({$precision}, 0)) ELSE NULL END)";
+        }
+
+        $precision = $configuration['precision'];
+        $scale = $configuration['scale'];
+        $integerCapacity = $precision - $scale;
+        $roundingDigit = "SUBSTRING(RPAD({$fractionRaw}, ".($scale + 1).", '0') FROM ".($scale + 1).' FOR 1)';
+        $keptFraction = $scale === 0 ? "''" : "LEFT(RPAD({$fractionRaw}, {$scale}, '0'), {$scale})";
+        $maximumInteger = $integerCapacity === 0 ? '0' : str_repeat('9', $integerCapacity);
+        $maximumFraction = $scale === 0 ? '' : str_repeat('9', $scale);
+        $roundingOverflow = "({$roundingDigit} IN ('5', '6', '7', '8', '9') AND {$integer} = '{$maximumInteger}' AND {$keptFraction} = '{$maximumFraction}')";
+        $valid = "({$plain} AND {$integerDigits} <= {$integerCapacity} AND NOT {$roundingOverflow})";
+
+        return "(CASE WHEN {$valid} THEN CAST({$value} AS NUMERIC({$precision}, {$scale})) ELSE NULL END)";
+    }
+
+    private static function postgresSortableKey(string $column): string
+    {
+        $value = "BTRIM(REPLACE(REPLACE(REPLACE(REPLACE(CAST({$column} AS TEXT), CHR(9), ' '), CHR(10), ' '), CHR(11), ' '), CHR(13), ' '))";
+        $unsigned = "(CASE WHEN LEFT({$value}, 1) IN ('+', '-') THEN SUBSTRING({$value} FROM 2) ELSE {$value} END)";
+        $integerRaw = "SPLIT_PART({$unsigned}, '.', 1)";
+        $fractionRaw = "(CASE WHEN STRPOS({$unsigned}, '.') > 0 THEN SPLIT_PART({$unsigned}, '.', 2) ELSE '' END)";
+        $integer = "COALESCE(NULLIF(LTRIM({$integerRaw}, '0'), ''), '0')";
+        $fraction = "RTRIM({$fractionRaw}, '0')";
+        $paddedFraction = "RPAD({$fraction}, ".self::MAX_DIGITS.", '0')";
+        $magnitude = "({$integer} || {$paddedFraction})";
+        $digitCount = "((CASE WHEN {$integer} = '0' THEN 0 ELSE LENGTH({$integer}) END) + LENGTH({$fractionRaw}))";
+        $zero = "({$integer} = '0' AND {$fraction} = '')";
+        $valid = "({$value} ~ '^[+-]?[0-9]+([.][0-9]+)?$' AND {$value} !~ '[^-+0-9.]' AND {$digitCount} <= ".self::MAX_DIGITS.')';
+        $negative = "(LEFT({$value}, 1) = '-' AND NOT {$zero})";
+        $negativeKey = "('0' || LPAD((999 - LENGTH({$integer}))::TEXT, 3, '0') || TRANSLATE({$magnitude}, '0123456789', '9876543210'))";
+        $positiveKey = "('2' || LPAD(LENGTH({$integer})::TEXT, 3, '0') || {$magnitude})";
+
+        return "((CASE WHEN {$valid} THEN CASE WHEN {$zero} THEN '1' WHEN {$negative} THEN {$negativeKey} ELSE {$positiveKey} END ELSE NULL END) COLLATE \"C\")";
+    }
+
+    /**
+     * @param  array{mode: 'decimal'|'integer'|'legacy', precision: int|null, scale: int}|null  $configuration
+     */
+    private static function sqliteSortableKey(Connection $connection, string $column, ?array $configuration): string
+    {
+        self::registerSqliteFunction($connection);
+        $key = $configuration === null
+            ? "aura_decimal_sort_key({$column})"
+            : "aura_number_sort_key({$column}, '{$configuration['mode']}', ".($configuration['precision'] ?? 'NULL').", {$configuration['scale']})";
+
+        return "(CASE WHEN SUBSTR({$key}, 1, 1) IN ('0', '1', '2') THEN {$key} ELSE NULL END)";
+    }
+
+    /**
+     * Valid values become a binary-collated key: reversed negative magnitude,
+     * zero, then positive magnitude. Invalid values become NULL. String
+     * operations avoid all float and DECIMAL narrowing.
+     */
+    private static function sqlSortableKey(Connection $connection, string $wrappedColumn, ?array $numberConfiguration): string
+    {
+        $configuration = $numberConfiguration === null
+            ? null
+            : self::validatedConfiguration($numberConfiguration);
+
+        if ($configuration !== null
+            && $configuration['mode'] === 'legacy'
+            && $configuration['precision'] === null) {
+            $configuration = null;
+        }
+
+        return match ($connection->getDriverName()) {
+            'mysql' => self::mysqlSortableKey($configuration === null
+                ? $wrappedColumn
+                : self::mysqlConfiguredValue($wrappedColumn, $configuration)),
+            'pgsql' => self::postgresSortableKey($configuration === null
+                ? $wrappedColumn
+                : self::postgresConfiguredValue($wrappedColumn, $configuration)),
+            'sqlite' => self::sqliteSortableKey($connection, $wrappedColumn, $configuration),
+            default => throw new InvalidArgumentException("Exact-decimal queries are not supported for database driver [{$connection->getDriverName()}]."),
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $configuration
+     * @return array{mode: 'decimal'|'integer'|'legacy', precision: int|null, scale: int}
+     */
+    private static function validatedConfiguration(array $configuration): array
+    {
+        $mode = $configuration['mode'] ?? null;
+        $precision = $configuration['precision'] ?? null;
+        $scale = $configuration['scale'] ?? null;
+
+        if (! in_array($mode, ['decimal', 'integer', 'legacy'], true)
+            || ($precision !== null && (! is_int($precision) || $precision < 1 || $precision > self::MAX_DIGITS))
+            || ! is_int($scale)
+            || $scale < 0
+            || $scale > 30
+            || ($mode === 'decimal' && ($precision === null || $scale > $precision))
+            || ($mode !== 'decimal' && $scale !== 0)) {
+            throw new InvalidArgumentException('Invalid exact-number query configuration.');
+        }
+
+        return [
+            'mode' => $mode,
+            'precision' => $precision,
+            'scale' => $scale,
+        ];
+    }
+}

--- a/src/Support/KanbanConfiguration.php
+++ b/src/Support/KanbanConfiguration.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Aura\Base\Support;
+
+use Aura\Base\Contracts\TableResource;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+final class KanbanConfiguration
+{
+    /**
+     * @return array{
+     *     enabled: bool,
+     *     valid: bool,
+     *     group_field: string,
+     *     columns: array<string, array{value: string, color: string|null}>,
+     *     card_title: string,
+     *     card_subtitle: string|null,
+     *     order_by: array{field: string, direction: 'asc'|'desc'}|null,
+     *     show_empty_columns: bool
+     * }
+     */
+    public static function for(Model&TableResource $resource): array
+    {
+        $legacyView = method_exists($resource, 'tableKanbanView')
+            ? $resource->tableKanbanView()
+            : false;
+        $declared = method_exists($resource, 'kanbanSettings')
+            ? $resource->kanbanSettings()
+            : [];
+
+        if (! is_array($declared)) {
+            $declared = [];
+        }
+
+        $enabled = (bool) ($declared['enabled'] ?? (is_string($legacyView) && $legacyView !== ''));
+        $groupField = is_string($declared['group_field'] ?? null)
+            ? $declared['group_field']
+            : 'status';
+        $cardTitle = is_string($declared['card_title'] ?? null)
+            ? $declared['card_title']
+            : 'title';
+        $cardSubtitle = is_string($declared['card_subtitle'] ?? null)
+            ? $declared['card_subtitle']
+            : null;
+        $showEmptyColumns = $declared['show_empty_columns'] ?? true;
+
+        $field = $resource->fieldBySlug($groupField);
+        $fieldClass = $resource->fieldClassBySlug($groupField);
+        $columns = is_array($field) && is_object($fieldClass) && method_exists($fieldClass, 'options')
+            ? self::normalizeOptions($fieldClass->options($resource, $field))
+            : [];
+
+        $requestedColumns = $declared['columns'] ?? [];
+        if (! is_array($requestedColumns)) {
+            $requestedColumns = [];
+        }
+
+        if ($requestedColumns !== []) {
+            $requestedKeys = collect($requestedColumns)
+                ->filter(fn (mixed $key): bool => is_string($key) || is_int($key))
+                ->map(fn (string|int $key): string => (string) $key)
+                ->unique()
+                ->values();
+
+            if ($requestedKeys->count() !== count($requestedColumns) || $requestedKeys->contains(fn (string $key): bool => ! isset($columns[$key]))) {
+                $columns = [];
+            } else {
+                $columns = $requestedKeys->mapWithKeys(fn (string $key): array => [$key => $columns[$key]])->all();
+            }
+        }
+
+        $orderBy = self::normalizeOrder($resource, $declared['order_by'] ?? null);
+        $valid = $groupField !== ''
+            && $columns !== []
+            && self::isDisplayableField($resource, $cardTitle)
+            && ($cardSubtitle === null || self::isDisplayableField($resource, $cardSubtitle))
+            && is_bool($showEmptyColumns)
+            && (! array_key_exists('order_by', $declared) || $declared['order_by'] === null || $orderBy !== null);
+
+        return [
+            'enabled' => $enabled && $valid,
+            'valid' => $valid,
+            'group_field' => $groupField,
+            'columns' => $columns,
+            'card_title' => $cardTitle,
+            'card_subtitle' => $cardSubtitle,
+            'order_by' => $orderBy,
+            'show_empty_columns' => is_bool($showEmptyColumns) ? $showEmptyColumns : true,
+        ];
+    }
+
+    private static function isDisplayableField(Model&TableResource $resource, string $field): bool
+    {
+        return $field !== '' && ($field === $resource->getKeyName() || is_array($resource->fieldBySlug($field)));
+    }
+
+    /**
+     * @return array<string, array{value: string, color: string|null}>
+     */
+    private static function normalizeOptions(mixed $options): array
+    {
+        if ($options instanceof Collection) {
+            $options = $options->all();
+        }
+
+        if (! is_array($options)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($options as $optionKey => $option) {
+            if (is_array($option) && array_key_exists('key', $option)) {
+                $key = $option['key'];
+                $value = $option['value'] ?? $option['label'] ?? $key;
+                $color = $option['color'] ?? null;
+            } elseif (! is_int($optionKey)) {
+                $key = $optionKey;
+                $value = is_array($option) ? ($option['value'] ?? $option['label'] ?? $optionKey) : $option;
+                $color = is_array($option) ? ($option['color'] ?? null) : null;
+            } else {
+                $key = $option;
+                $value = $option;
+                $color = null;
+            }
+
+            if ((! is_string($key) && ! is_int($key)) || (! is_string($value) && ! is_int($value))) {
+                continue;
+            }
+
+            $normalized[(string) $key] = [
+                'value' => (string) $value,
+                'color' => is_string($color) ? $color : null,
+            ];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array{field: string, direction: 'asc'|'desc'}|null
+     */
+    private static function normalizeOrder(Model&TableResource $resource, mixed $orderBy): ?array
+    {
+        if ($orderBy === null) {
+            return null;
+        }
+
+        if (! is_array($orderBy)) {
+            return null;
+        }
+
+        $field = $orderBy['field'] ?? null;
+        $direction = $orderBy['direction'] ?? null;
+
+        if (
+            ! is_string($field)
+            || ! self::isDisplayableField($resource, $field)
+            || ! is_string($direction)
+            || ! in_array(strtolower($direction), ['asc', 'desc'], true)
+        ) {
+            return null;
+        }
+
+        return [
+            'field' => $field,
+            'direction' => strtolower($direction),
+        ];
+    }
+}

--- a/src/ThemeTokens.php
+++ b/src/ThemeTokens.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Aura\Base;
+
+final class ThemeTokens
+{
+    /** @var list<string> */
+    private const COLOR_NAMES = [
+        'primary',
+        'background',
+        'panel',
+        'border',
+        'text',
+        'muted',
+        'success',
+        'warning',
+        'danger',
+    ];
+
+    /** @var list<string> */
+    private const GENERIC_FONT_FAMILIES = [
+        'serif',
+        'sans-serif',
+        'monospace',
+        'cursive',
+        'fantasy',
+        'system-ui',
+        'ui-serif',
+        'ui-sans-serif',
+        'ui-monospace',
+        'ui-rounded',
+        'math',
+        'emoji',
+        'fangsong',
+    ];
+
+    /** @var array<string, mixed>|null */
+    private static ?array $packageTheme = null;
+
+    /**
+     * @param  array<string, mixed>  $theme
+     * @return array<string, string>
+     */
+    public static function colors(array $theme, string $mode): array
+    {
+        $mode = $mode === 'dark' ? 'dark' : 'light';
+        $packageColors = self::packageTheme()['colors'][$mode];
+        $configuredColors = $theme['colors'][$mode] ?? [];
+
+        if (! is_array($configuredColors)) {
+            $configuredColors = [];
+        }
+
+        $colors = [];
+
+        foreach (self::COLOR_NAMES as $name) {
+            $configuredValue = $configuredColors[$name] ?? null;
+            $colors[$name] = self::isColorValue($configuredValue)
+                ? trim($configuredValue)
+                : $packageColors[$name];
+        }
+
+        return $colors;
+    }
+
+    /**
+     * @param  array<string, mixed>  $theme
+     */
+    public static function fontFamily(array $theme): string
+    {
+        $families = $theme['font']['family'] ?? [];
+
+        if (is_string($families)) {
+            $families = preg_split('/\s*,\s*/', $families) ?: [];
+        }
+
+        if (! is_array($families)) {
+            $families = [];
+        }
+
+        $families = array_values(array_filter(array_map(
+            self::formatFontFamily(...),
+            $families,
+        )));
+
+        if ($families === []) {
+            return self::fontFamily(self::packageTheme());
+        }
+
+        return implode(', ', $families);
+    }
+
+    /**
+     * Return a host-local public asset path, rejecting external and executable URLs.
+     *
+     * @param  array<string, mixed>  $theme
+     */
+    public static function fontStylesheet(array $theme): ?string
+    {
+        $stylesheet = $theme['font']['stylesheet'] ?? null;
+
+        if (! is_string($stylesheet)) {
+            return null;
+        }
+
+        $stylesheet = trim($stylesheet);
+
+        if (
+            $stylesheet === ''
+            || str_starts_with($stylesheet, '//')
+            || str_contains($stylesheet, '\\')
+            || preg_match('/^[a-z][a-z0-9+.-]*:/i', $stylesheet) === 1
+            || preg_match('/(?:^|\/)\.\.(?:\/|$)/', $stylesheet) === 1
+            || preg_match('/[\x00-\x1F\x7F]/', $stylesheet) === 1
+        ) {
+            return null;
+        }
+
+        return ltrim($stylesheet, '/');
+    }
+
+    /**
+     * Resolve package defaults, host config, and persisted settings in that order.
+     *
+     * @param  array<string, mixed>  $storedSettings
+     * @return array<string, mixed>
+     */
+    public static function resolve(array $storedSettings = []): array
+    {
+        $packageTheme = self::packageTheme();
+        $configuredTheme = config('aura.theme', []);
+
+        if (! is_array($configuredTheme)) {
+            $configuredTheme = [];
+        }
+
+        return self::merge(
+            self::merge($packageTheme, $configuredTheme),
+            $storedSettings,
+        );
+    }
+
+    private static function formatFontFamily(mixed $family): ?string
+    {
+        if (! is_string($family)) {
+            return null;
+        }
+
+        $family = trim($family);
+        $openingQuote = $family[0] ?? '';
+
+        if (
+            strlen($family) >= 2
+            && in_array($openingQuote, ['"', "'"], true)
+            && str_ends_with($family, $openingQuote)
+        ) {
+            $family = substr($family, 1, -1);
+        }
+
+        if (
+            $family === ''
+            || preg_match('/[\x00-\x1F\x7F<>]/', $family) === 1
+        ) {
+            return null;
+        }
+
+        if (in_array(strtolower($family), self::GENERIC_FONT_FAMILIES, true)) {
+            return strtolower($family);
+        }
+
+        return '"'.str_replace(['\\', '"'], ['\\\\', '\\"'], $family).'"';
+    }
+
+    private static function isColorValue(mixed $value): bool
+    {
+        if (! is_string($value)) {
+            return false;
+        }
+
+        $value = trim($value);
+
+        if (preg_match('/^var\(--[a-zA-Z0-9_-]+\)$/', $value) === 1) {
+            return true;
+        }
+
+        if (preg_match('/^(\d{1,3})\s+(\d{1,3})\s+(\d{1,3})$/', $value, $matches) !== 1) {
+            return false;
+        }
+
+        foreach (array_slice($matches, 1) as $channel) {
+            if ((int) $channel > 255) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Recursively merge associative maps while replacing ordered lists.
+     *
+     * @param  array<string, mixed>  $base
+     * @param  array<string, mixed>  $override
+     * @return array<string, mixed>
+     */
+    private static function merge(array $base, array $override): array
+    {
+        foreach ($override as $key => $value) {
+            if (
+                isset($base[$key])
+                && is_array($base[$key])
+                && is_array($value)
+                && ! array_is_list($base[$key])
+                && ! array_is_list($value)
+            ) {
+                $base[$key] = self::merge($base[$key], $value);
+
+                continue;
+            }
+
+            $base[$key] = $value;
+        }
+
+        return $base;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function packageTheme(): array
+    {
+        if (self::$packageTheme !== null) {
+            return self::$packageTheme;
+        }
+
+        /** @var array<string, mixed> $configuration */
+        $configuration = require dirname(__DIR__).'/config/aura.php';
+
+        /** @var array<string, mixed> $theme */
+        $theme = $configuration['theme'];
+
+        return self::$packageTheme = $theme;
+    }
+}

--- a/src/Traits/InteractsWithTable.php
+++ b/src/Traits/InteractsWithTable.php
@@ -29,6 +29,27 @@ trait InteractsWithTable
         return false;
     }
 
+    /**
+     * Configure the resource's Kanban capability.
+     *
+     * Returning a Kanban view from tableKanbanView() continues to enable the
+     * legacy status-based board. New resources should override this method.
+     *
+     * @return array<string, mixed>
+     */
+    public function kanbanSettings(): array
+    {
+        return [
+            'enabled' => is_string($this->tableKanbanView()) && $this->tableKanbanView() !== '',
+            'group_field' => 'status',
+            'columns' => [],
+            'card_title' => 'title',
+            'card_subtitle' => null,
+            'order_by' => null,
+            'show_empty_columns' => true,
+        ];
+    }
+
     public function showTableSettings()
     {
         return true;

--- a/src/Widgets/Donut.php
+++ b/src/Widgets/Donut.php
@@ -2,6 +2,13 @@
 
 namespace Aura\Base\Widgets;
 
+use Aura\Base\Aura;
+use Aura\Base\Fields\Number;
+use Aura\Base\Reporting\AggregateDefinition;
+use Aura\Base\Reporting\AggregateEngine;
+use Aura\Base\Reporting\AggregateOperation;
+use Aura\Base\Reporting\DateRange;
+use Aura\Base\Resource;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Locked;
@@ -22,43 +29,37 @@ class Donut extends Widget
     public function getValue($start, $end)
     {
         $column = optional($this->widget)['column'];
-        $table = $this->model->getTable();
 
         // Never let an unknown/tampered column reach the raw-SQL identifier path.
         if ($column && ! $this->isSafeColumn($column)) {
             $column = null;
         }
 
-        $posts = $this->model->query()
-            ->where($table.'.created_at', '>=', $start)
-            ->where($table.'.created_at', '<', $end);
+        if ($this->canUseAggregateEngine($column)) {
+            $operation = $this->aggregateOperation();
 
-        if (! $column) {
-            return ['Total' => $posts->count()];
+            if (! $column) {
+                return ['Total' => $this->scalarFromAggregate(app(AggregateEngine::class)->run(new AggregateDefinition(
+                    resource: $this->model::class,
+                    operation: AggregateOperation::Count,
+                    range: new DateRange($start, $end),
+                    queryScope: is_string($this->widget['queryScope'] ?? null) ? $this->widget['queryScope'] : null,
+                ))->value)];
+            }
+
+            return collect(app(AggregateEngine::class)->run(new AggregateDefinition(
+                resource: $this->model::class,
+                operation: $operation,
+                metric: $operation === AggregateOperation::Count ? null : $column,
+                groupBy: $column,
+                range: new DateRange($start, $end),
+                queryScope: is_string($this->widget['queryScope'] ?? null) ? $this->widget['queryScope'] : null,
+            ))->points)
+                ->mapWithKeys(fn ($point): array => [$point->label => $this->scalarFromAggregate($point->value)])
+                ->toArray();
         }
 
-        if ($column && $this->model->isMetaField($column)) {
-            $posts->leftJoin('meta', function ($join) use ($column) {
-                $join->on($this->model->getQualifiedKeyName(), '=', 'meta.metable_id')
-                    ->where('meta.key', '=', $column)
-                    ->where('meta.metable_type', '=', $this->model->getMorphClass());
-            });
-
-            $aggregateExpression = 'CAST(meta.value as SIGNED)';
-            $labelExpression = 'meta.value';
-        } else {
-            $aggregateExpression = $table.'.'.$column;
-            $labelExpression = $table.'.'.$column;
-        }
-
-        $method = in_array($this->method, ['avg', 'sum', 'min', 'max'], true) ? strtoupper($this->method) : 'COUNT';
-        $aggregateSelect = $method === 'COUNT' ? 'COUNT(*)' : $method.'('.$aggregateExpression.')';
-
-        return $posts->selectRaw($labelExpression.' as label, '.$aggregateSelect.' as aggregate')
-            ->groupBy(DB::raw($labelExpression))
-            ->pluck('aggregate', 'label')
-            ->mapWithKeys(fn ($value, $label) => [(string) ($label ?: 'Empty') => $value])
-            ->toArray();
+        return $this->legacyValue($start, $end, $column);
     }
 
     public function getValuesProperty()
@@ -104,5 +105,96 @@ class Donut extends Widget
     {
         $this->start = $start;
         $this->end = $end;
+    }
+
+    protected function aggregateOperation(): AggregateOperation
+    {
+        return match ($this->method) {
+            'avg' => AggregateOperation::Average,
+            'sum' => AggregateOperation::Sum,
+            'min' => AggregateOperation::Minimum,
+            'max' => AggregateOperation::Maximum,
+            default => AggregateOperation::Count,
+        };
+    }
+
+    /**
+     * Physical group-by (or plain count) through AggregateEngine when the resource is registered.
+     * Meta/group-by-metric columns keep the legacy CAST path.
+     */
+    protected function canUseAggregateEngine(?string $column): bool
+    {
+        if (! $this->model instanceof Resource) {
+            return false;
+        }
+
+        if (! in_array($this->model::class, app(Aura::class)->getResources(), true)) {
+            return false;
+        }
+
+        if ($column === null) {
+            return true;
+        }
+
+        if (! $this->model->isTableField($column)) {
+            return false;
+        }
+
+        $operation = $this->aggregateOperation();
+
+        if ($operation === AggregateOperation::Count) {
+            return true;
+        }
+
+        return $this->model->fieldClassBySlug($column) instanceof Number;
+    }
+
+    protected function legacyValue($start, $end, ?string $column)
+    {
+        $table = $this->model->getTable();
+
+        $posts = $this->model->query()
+            ->where($table.'.created_at', '>=', $start)
+            ->where($table.'.created_at', '<', $end);
+
+        if (! $column) {
+            return ['Total' => $posts->count()];
+        }
+
+        if ($column && $this->model->isMetaField($column)) {
+            $posts->leftJoin('meta', function ($join) use ($column) {
+                $join->on($this->model->getQualifiedKeyName(), '=', 'meta.metable_id')
+                    ->where('meta.key', '=', $column)
+                    ->where('meta.metable_type', '=', $this->model->getMorphClass());
+            });
+
+            $aggregateExpression = 'CAST(meta.value as SIGNED)';
+            $labelExpression = 'meta.value';
+        } else {
+            $aggregateExpression = $table.'.'.$column;
+            $labelExpression = $table.'.'.$column;
+        }
+
+        $method = in_array($this->method, ['avg', 'sum', 'min', 'max'], true) ? strtoupper($this->method) : 'COUNT';
+        $aggregateSelect = $method === 'COUNT' ? 'COUNT(*)' : $method.'('.$aggregateExpression.')';
+
+        return $posts->selectRaw($labelExpression.' as label, '.$aggregateSelect.' as aggregate')
+            ->groupBy(DB::raw($labelExpression))
+            ->pluck('aggregate', 'label')
+            ->mapWithKeys(fn ($value, $label) => [(string) ($label ?: 'Empty') => $value])
+            ->toArray();
+    }
+
+    protected function scalarFromAggregate(int|string|null $value): int|float|null
+    {
+        if ($value === null || is_int($value)) {
+            return $value;
+        }
+
+        if (preg_match('/^-?\d+\.0+$/', $value) === 1) {
+            return (int) $value;
+        }
+
+        return (float) $value;
     }
 }

--- a/src/Widgets/Pie.php
+++ b/src/Widgets/Pie.php
@@ -2,6 +2,13 @@
 
 namespace Aura\Base\Widgets;
 
+use Aura\Base\Aura;
+use Aura\Base\Fields\Number;
+use Aura\Base\Reporting\AggregateDefinition;
+use Aura\Base\Reporting\AggregateEngine;
+use Aura\Base\Reporting\AggregateOperation;
+use Aura\Base\Reporting\DateRange;
+use Aura\Base\Resource;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Locked;
@@ -22,43 +29,37 @@ class Pie extends Widget
     public function getValue($start, $end)
     {
         $column = optional($this->widget)['column'];
-        $table = $this->model->getTable();
 
         // Never let an unknown/tampered column reach the raw-SQL identifier path.
         if ($column && ! $this->isSafeColumn($column)) {
             $column = null;
         }
 
-        $posts = $this->model->query()
-            ->where($table.'.created_at', '>=', $start)
-            ->where($table.'.created_at', '<', $end);
+        if ($this->canUseAggregateEngine($column)) {
+            $operation = $this->aggregateOperation();
 
-        if (! $column) {
-            return ['Total' => $posts->count()];
+            if (! $column) {
+                return ['Total' => $this->scalarFromAggregate(app(AggregateEngine::class)->run(new AggregateDefinition(
+                    resource: $this->model::class,
+                    operation: AggregateOperation::Count,
+                    range: new DateRange($start, $end),
+                    queryScope: is_string($this->widget['queryScope'] ?? null) ? $this->widget['queryScope'] : null,
+                ))->value)];
+            }
+
+            return collect(app(AggregateEngine::class)->run(new AggregateDefinition(
+                resource: $this->model::class,
+                operation: $operation,
+                metric: $operation === AggregateOperation::Count ? null : $column,
+                groupBy: $column,
+                range: new DateRange($start, $end),
+                queryScope: is_string($this->widget['queryScope'] ?? null) ? $this->widget['queryScope'] : null,
+            ))->points)
+                ->mapWithKeys(fn ($point): array => [$point->label => $this->scalarFromAggregate($point->value)])
+                ->toArray();
         }
 
-        if ($column && $this->model->isMetaField($column)) {
-            $posts->leftJoin('meta', function ($join) use ($column) {
-                $join->on($this->model->getQualifiedKeyName(), '=', 'meta.metable_id')
-                    ->where('meta.key', '=', $column)
-                    ->where('meta.metable_type', '=', $this->model->getMorphClass());
-            });
-
-            $aggregateExpression = 'CAST(meta.value as SIGNED)';
-            $labelExpression = 'meta.value';
-        } else {
-            $aggregateExpression = $table.'.'.$column;
-            $labelExpression = $table.'.'.$column;
-        }
-
-        $method = in_array($this->method, ['avg', 'sum', 'min', 'max'], true) ? strtoupper($this->method) : 'COUNT';
-        $aggregateSelect = $method === 'COUNT' ? 'COUNT(*)' : $method.'('.$aggregateExpression.')';
-
-        return $posts->selectRaw($labelExpression.' as label, '.$aggregateSelect.' as aggregate')
-            ->groupBy(DB::raw($labelExpression))
-            ->pluck('aggregate', 'label')
-            ->mapWithKeys(fn ($value, $label) => [(string) ($label ?: 'Empty') => $value])
-            ->toArray();
+        return $this->legacyValue($start, $end, $column);
     }
 
     public function getValuesProperty()
@@ -104,5 +105,97 @@ class Pie extends Widget
     {
         $this->start = $start;
         $this->end = $end;
+    }
+
+    protected function aggregateOperation(): AggregateOperation
+    {
+        return match ($this->method) {
+            'avg' => AggregateOperation::Average,
+            'sum' => AggregateOperation::Sum,
+            'min' => AggregateOperation::Minimum,
+            'max' => AggregateOperation::Maximum,
+            default => AggregateOperation::Count,
+        };
+    }
+
+    /**
+     * Physical group-by (or plain count) through AggregateEngine when the resource is registered.
+     * Meta/group-by-metric columns keep the legacy CAST path.
+     */
+    protected function canUseAggregateEngine(?string $column): bool
+    {
+        if (! $this->model instanceof Resource) {
+            return false;
+        }
+
+        if (! in_array($this->model::class, app(Aura::class)->getResources(), true)) {
+            return false;
+        }
+
+        if ($column === null) {
+            return true;
+        }
+
+        // Group-by path only supports physical scalar group fields with count (or physical Number metrics).
+        if (! $this->model->isTableField($column)) {
+            return false;
+        }
+
+        $operation = $this->aggregateOperation();
+
+        if ($operation === AggregateOperation::Count) {
+            return true;
+        }
+
+        return $this->model->fieldClassBySlug($column) instanceof Number;
+    }
+
+    protected function legacyValue($start, $end, ?string $column)
+    {
+        $table = $this->model->getTable();
+
+        $posts = $this->model->query()
+            ->where($table.'.created_at', '>=', $start)
+            ->where($table.'.created_at', '<', $end);
+
+        if (! $column) {
+            return ['Total' => $posts->count()];
+        }
+
+        if ($column && $this->model->isMetaField($column)) {
+            $posts->leftJoin('meta', function ($join) use ($column) {
+                $join->on($this->model->getQualifiedKeyName(), '=', 'meta.metable_id')
+                    ->where('meta.key', '=', $column)
+                    ->where('meta.metable_type', '=', $this->model->getMorphClass());
+            });
+
+            $aggregateExpression = 'CAST(meta.value as SIGNED)';
+            $labelExpression = 'meta.value';
+        } else {
+            $aggregateExpression = $table.'.'.$column;
+            $labelExpression = $table.'.'.$column;
+        }
+
+        $method = in_array($this->method, ['avg', 'sum', 'min', 'max'], true) ? strtoupper($this->method) : 'COUNT';
+        $aggregateSelect = $method === 'COUNT' ? 'COUNT(*)' : $method.'('.$aggregateExpression.')';
+
+        return $posts->selectRaw($labelExpression.' as label, '.$aggregateSelect.' as aggregate')
+            ->groupBy(DB::raw($labelExpression))
+            ->pluck('aggregate', 'label')
+            ->mapWithKeys(fn ($value, $label) => [(string) ($label ?: 'Empty') => $value])
+            ->toArray();
+    }
+
+    protected function scalarFromAggregate(int|string|null $value): int|float|null
+    {
+        if ($value === null || is_int($value)) {
+            return $value;
+        }
+
+        if (preg_match('/^-?\d+\.0+$/', $value) === 1) {
+            return (int) $value;
+        }
+
+        return (float) $value;
     }
 }

--- a/src/Widgets/Sparkline.php
+++ b/src/Widgets/Sparkline.php
@@ -2,6 +2,14 @@
 
 namespace Aura\Base\Widgets;
 
+use Aura\Base\Aura;
+use Aura\Base\Fields\Number;
+use Aura\Base\Reporting\AggregateDefinition;
+use Aura\Base\Reporting\AggregateEngine;
+use Aura\Base\Reporting\AggregateOperation;
+use Aura\Base\Reporting\DateBucket;
+use Aura\Base\Reporting\DateRange;
+use Aura\Base\Resource;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Locked;
@@ -27,12 +35,111 @@ class Sparkline extends Widget
     public function getValue($start, $end)
     {
         $column = optional($this->widget)['column'];
-        $createdAtColumn = $this->model->getTable().'.created_at';
 
         // Never let an unknown/tampered column reach the meta-join / raw-SQL path.
         if ($column && ! $this->isSafeColumn($column)) {
             $column = null;
         }
+
+        if ($this->canUseAggregateEngine($column)) {
+            $operation = $this->aggregateOperation();
+            $result = app(AggregateEngine::class)->run(new AggregateDefinition(
+                resource: $this->model::class,
+                operation: $operation,
+                metric: $operation === AggregateOperation::Count ? null : $column,
+                range: new DateRange($start, $end),
+                bucket: DateBucket::Day,
+                timezone: is_string($this->widget['timezone'] ?? null) ? $this->widget['timezone'] : config('app.timezone', 'UTC'),
+                queryScope: is_string($this->widget['queryScope'] ?? null) ? $this->widget['queryScope'] : null,
+            ));
+            $postsByDate = collect($result->points)
+                ->mapWithKeys(fn ($point): array => [$point->key => $this->scalarFromAggregate($point->value) ?? 0])
+                ->all();
+
+            $dateRange = [];
+            for ($date = Carbon::parse($start); $date->lte($end); $date->addDay()) {
+                $dateRange[$date->format('Y-m-d')] = 0;
+            }
+
+            return collect($dateRange)->merge($postsByDate);
+        }
+
+        return $this->legacyValue($start, $end, $column);
+    }
+
+    public function getValuesProperty()
+    {
+        $currentStart = $this->getCarbonDate($this->start ?? now()->subDays(30)->startOfDay())->copy()->addDay();
+        $currentEnd = $this->getCarbonDate($this->end ?? now()->endOfDay());
+        $diff = round($currentStart->diffInDays($currentEnd));
+
+        $previousStart = $currentStart->copy()->subDays($diff + 1);
+        $previousEnd = $currentStart->copy()->subDay();
+
+        // Keep uncached evaluation for sparkline tests and dashboards that
+        // omit widget slugs; ValueWidget may still use the cache key path.
+        return [
+            'current' => $this->getValue($currentStart, $currentEnd)->toArray(),
+            'previous' => $this->getValue($previousStart, $previousEnd)->toArray(),
+        ];
+    }
+
+    public function mount()
+    {
+        if (optional($this->widget)['method']) {
+            $this->method = $this->widget['method'];
+        }
+    }
+
+    public function render()
+    {
+        return view('aura::components.widgets.sparkline-area');
+    }
+
+    #[On('dateFilterUpdated')]
+    public function updateDateRange($start, $end)
+    {
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    protected function aggregateOperation(): AggregateOperation
+    {
+        // Sparkline historically used method for chart style (area/bar), not
+        // aggregate verb. Only honor explicit numeric verbs; default to count.
+        return match ($this->method) {
+            'avg' => AggregateOperation::Average,
+            'sum' => AggregateOperation::Sum,
+            'min' => AggregateOperation::Minimum,
+            'max' => AggregateOperation::Maximum,
+            default => AggregateOperation::Count,
+        };
+    }
+
+    protected function canUseAggregateEngine(?string $column): bool
+    {
+        if (! $this->model instanceof Resource) {
+            return false;
+        }
+
+        if (! in_array($this->model::class, app(Aura::class)->getResources(), true)) {
+            return false;
+        }
+
+        $operation = $this->aggregateOperation();
+
+        if ($operation === AggregateOperation::Count) {
+            return true;
+        }
+
+        return $column !== null
+            && $this->model->isTableField($column)
+            && $this->model->fieldClassBySlug($column) instanceof Number;
+    }
+
+    protected function legacyValue($start, $end, ?string $column)
+    {
+        $createdAtColumn = $this->model->getTable().'.created_at';
         $method = $this->method;
 
         $query = $this->model->query()
@@ -69,37 +176,16 @@ class Sparkline extends Widget
         return collect($dateRange)->merge($postsByDate);
     }
 
-    public function getValuesProperty()
+    protected function scalarFromAggregate(int|string|null $value): int|float|null
     {
-        $currentStart = $this->getCarbonDate($this->start)->addDay();
-        $currentEnd = $this->getCarbonDate($this->end);
-        $diff = round($currentStart->diffInDays($currentEnd));
-
-        $previousStart = $currentStart->copy()->subDays($diff + 1);
-        $previousEnd = $currentStart->copy()->subDay();
-
-        return [
-            'current' => $this->getValue($currentStart, $currentEnd)->toArray(),
-            'previous' => $this->getValue($previousStart, $previousEnd)->toArray(),
-        ];
-    }
-
-    public function mount()
-    {
-        if (optional($this->widget)['method']) {
-            $this->method = $this->widget['method'];
+        if ($value === null || is_int($value)) {
+            return $value;
         }
-    }
 
-    public function render()
-    {
-        return view('aura::components.widgets.sparkline-area');
-    }
+        if (preg_match('/^-?\d+\.0+$/', $value) === 1) {
+            return (int) $value;
+        }
 
-    #[On('dateFilterUpdated')]
-    public function updateDateRange($start, $end)
-    {
-        $this->start = $start;
-        $this->end = $end;
+        return (float) $value;
     }
 }

--- a/src/Widgets/ValueWidget.php
+++ b/src/Widgets/ValueWidget.php
@@ -2,6 +2,13 @@
 
 namespace Aura\Base\Widgets;
 
+use Aura\Base\Aura;
+use Aura\Base\Fields\Number;
+use Aura\Base\Reporting\AggregateDefinition;
+use Aura\Base\Reporting\AggregateEngine;
+use Aura\Base\Reporting\AggregateOperation;
+use Aura\Base\Reporting\DateRange;
+use Aura\Base\Resource;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Locked;
@@ -28,34 +35,19 @@ class ValueWidget extends Widget
             $column = null;
         }
 
-        $isMetaColumn = $column && $this->model->isMetaField($column);
+        if ($this->canUseAggregateEngine($column)) {
+            $operation = $this->aggregateOperation();
 
-        $posts = $this->model->query()
-            ->where('created_at', '>=', $start)
-            ->where('created_at', '<', $end);
-
-        // Apply the query scope only if it maps to a real Eloquent scope on the model.
-        $queryScope = optional($this->widget)['queryScope'];
-        if ($queryScope && method_exists($this->model, 'scope'.ucfirst($queryScope))) {
-            $posts->{$queryScope}();
+            return $this->scalarFromAggregate(app(AggregateEngine::class)->run(new AggregateDefinition(
+                resource: $this->model::class,
+                operation: $operation,
+                metric: $operation === AggregateOperation::Count ? null : $column,
+                range: new DateRange($start, $end),
+                queryScope: is_string($this->widget['queryScope'] ?? null) ? $this->widget['queryScope'] : null,
+            ))->value);
         }
 
-        if ($isMetaColumn) {
-            $posts->select($this->model->getTable().'.*', DB::raw("CAST(meta.value as SIGNED) as $column"))
-                ->leftJoin('meta', function ($join) use ($column) {
-                    $join->on($this->model->getQualifiedKeyName(), '=', 'meta.metable_id')
-                        ->where('meta.key', '=', $column)
-                        ->where('meta.metable_type', '=', $this->model->getMorphClass());
-                });
-        }
-
-        return match ($this->method) {
-            'avg' => $posts->avg($isMetaColumn ? DB::raw('CAST(meta.value as SIGNED)') : $column),
-            'sum' => $posts->sum($isMetaColumn ? DB::raw('CAST(meta.value as SIGNED)') : $column),
-            'min' => $posts->min($isMetaColumn ? DB::raw('CAST(meta.value as SIGNED)') : $column),
-            'max' => $posts->max($isMetaColumn ? DB::raw('CAST(meta.value as SIGNED)') : $column),
-            default => $posts->count(),
-        };
+        return $this->legacyValue($start, $end, $column);
     }
 
     public function getValuesProperty()
@@ -86,7 +78,7 @@ class ValueWidget extends Widget
 
     public function mount()
     {
-        if ($this->widget['method']) {
+        if (optional($this->widget)['method']) {
             $this->method = $this->widget['method'];
         }
     }
@@ -101,5 +93,83 @@ class ValueWidget extends Widget
     {
         $this->start = $start;
         $this->end = $end;
+    }
+
+    protected function aggregateOperation(): AggregateOperation
+    {
+        return match ($this->method) {
+            'avg' => AggregateOperation::Average,
+            'sum' => AggregateOperation::Sum,
+            'min' => AggregateOperation::Minimum,
+            'max' => AggregateOperation::Maximum,
+            default => AggregateOperation::Count,
+        };
+    }
+
+    /**
+     * AggregateEngine requires a registered Resource and physical metrics (or count).
+     * Meta-backed metrics keep the legacy CAST path until projection reads exist.
+     */
+    protected function canUseAggregateEngine(?string $column): bool
+    {
+        if (! $this->model instanceof Resource) {
+            return false;
+        }
+
+        if (! in_array($this->model::class, app(Aura::class)->getResources(), true)) {
+            return false;
+        }
+
+        if ($column === null) {
+            return true;
+        }
+
+        return $this->model->isTableField($column)
+            && $this->model->fieldClassBySlug($column) instanceof Number;
+    }
+
+    protected function legacyValue($start, $end, ?string $column)
+    {
+        $isMetaColumn = $column && $this->model->isMetaField($column);
+
+        $posts = $this->model->query()
+            ->where('created_at', '>=', $start)
+            ->where('created_at', '<', $end);
+
+        // Apply the query scope only if it maps to a real Eloquent scope on the model.
+        $queryScope = optional($this->widget)['queryScope'];
+        if ($queryScope && method_exists($this->model, 'scope'.ucfirst($queryScope))) {
+            $posts->{$queryScope}();
+        }
+
+        if ($isMetaColumn) {
+            $posts->select($this->model->getTable().'.*', DB::raw("CAST(meta.value as SIGNED) as $column"))
+                ->leftJoin('meta', function ($join) use ($column) {
+                    $join->on($this->model->getQualifiedKeyName(), '=', 'meta.metable_id')
+                        ->where('meta.key', '=', $column)
+                        ->where('meta.metable_type', '=', $this->model->getMorphClass());
+                });
+        }
+
+        return match ($this->method) {
+            'avg' => $posts->avg($isMetaColumn ? DB::raw('CAST(meta.value as SIGNED)') : $column),
+            'sum' => $posts->sum($isMetaColumn ? DB::raw('CAST(meta.value as SIGNED)') : $column),
+            'min' => $posts->min($isMetaColumn ? DB::raw('CAST(meta.value as SIGNED)') : $column),
+            'max' => $posts->max($isMetaColumn ? DB::raw('CAST(meta.value as SIGNED)') : $column),
+            default => $posts->count(),
+        };
+    }
+
+    protected function scalarFromAggregate(int|string|null $value): int|float|null
+    {
+        if ($value === null || is_int($value)) {
+            return $value;
+        }
+
+        if (preg_match('/^-?\d+\.0+$/', $value) === 1) {
+            return (int) $value;
+        }
+
+        return (float) $value;
     }
 }

--- a/stubs/scaffold/views/components/layout/app.blade.php
+++ b/stubs/scaffold/views/components/layout/app.blade.php
@@ -20,7 +20,6 @@
 
   <style>[x-cloak] { display: none !important; }</style>
 
-  <link rel="stylesheet" href="/vendor/aura/public/inter.css">
   @vite(['resources/css/app.css'], 'vendor/aura')
   @vite('resources/css/app.css')
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,6 +43,17 @@ module.exports = {
                 countdown: 'countdown 3s linear 1',
             },
             colors: {
+                aura: {
+                    primary: withOpacityValue('--aura-color-primary'),
+                    background: withOpacityValue('--aura-color-background'),
+                    panel: withOpacityValue('--aura-color-panel'),
+                    border: withOpacityValue('--aura-color-border'),
+                    text: withOpacityValue('--aura-color-text'),
+                    muted: withOpacityValue('--aura-color-muted'),
+                    success: withOpacityValue('--aura-color-success'),
+                    warning: withOpacityValue('--aura-color-warning'),
+                    danger: withOpacityValue('--aura-color-danger'),
+                },
                 sidebar: {
                     'bg' : withOpacityValue('--sidebar-bg'),
                     'bg-hover' : withOpacityValue('--sidebar-bg-hover'),
@@ -80,7 +91,7 @@ module.exports = {
                 }
             },
             fontFamily: {
-                sans: ['Inter', ...defaultTheme.fontFamily.sans],
+                sans: ['var(--aura-font-sans)', ...defaultTheme.fontFamily.sans],
             },
             fontSize: {
                 '2xs': '0.67rem',

--- a/tests/Feature/Media/MediaAuthorizationTest.php
+++ b/tests/Feature/Media/MediaAuthorizationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use Aura\Base\Livewire\Media\InvalidMediaOwnerContext;
+use Aura\Base\Livewire\Media\MediaAuthorization;
+use Aura\Base\Resources\Attachment;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Illuminate\Auth\Access\AuthorizationException;
+
+beforeEach(function () {
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+function mediaAuthAttachment(string $name = 'photo.jpg'): Attachment
+{
+    return Attachment::create([
+        'url' => 'media/'.$name,
+        'name' => $name,
+        'title' => $name,
+        'size' => 1024,
+        'mime_type' => 'image/jpeg',
+    ]);
+}
+
+test('authorizeAttachments returns visible attachments for the actor', function () {
+    $attachment = mediaAuthAttachment();
+
+    $authorized = app(MediaAuthorization::class)
+        ->authorizeAttachments([(string) $attachment->id], $this->user);
+
+    expect($authorized)->toHaveCount(1)
+        ->and($authorized->first()->getKey())->toBe($attachment->id);
+});
+
+test('authorizeAttachments rejects foreign team attachment ids', function () {
+    $otherTeam = Team::factory()->createQuietly(['user_id' => $this->user->id]);
+
+    $foreign = Attachment::withoutGlobalScopes()->create([
+        'url' => 'media/foreign.jpg',
+        'name' => 'foreign.jpg',
+        'title' => 'foreign.jpg',
+        'size' => 1024,
+        'mime_type' => 'image/jpeg',
+        'team_id' => $otherTeam->id,
+        'user_id' => $this->user->id,
+        'type' => Attachment::$type,
+    ]);
+
+    expect(Attachment::whereKey($foreign->id)->exists())->toBeFalse();
+
+    expect(fn () => app(MediaAuthorization::class)
+        ->authorizeAttachments([(string) $foreign->id], $this->user))
+        ->toThrow(InvalidMediaOwnerContext::class);
+});
+
+test('authorizeAttachments rejects unviewable attachment ids', function () {
+    $user = createAdmin();
+    $role = Role::where('slug', 'editor')->firstOrFail();
+    $permissions = $role->permissions;
+    $permissions['view-attachment'] = false;
+    $permissions['viewAny-attachment'] = true;
+    $role->update(['permissions' => $permissions]);
+
+    $this->actingAs($user->refresh());
+
+    $attachment = mediaAuthAttachment('private.jpg');
+
+    expect(fn () => app(MediaAuthorization::class)
+        ->authorizeAttachments([(string) $attachment->id], $user->refresh()))
+        ->toThrow(AuthorizationException::class);
+});
+
+test('authorizeAttachments empty list requires viewAny', function () {
+    $user = createAdmin();
+    $role = Role::where('slug', 'editor')->firstOrFail();
+    $permissions = $role->permissions;
+    $permissions['viewAny-attachment'] = false;
+    $permissions['view-attachment'] = false;
+    $role->update(['permissions' => $permissions]);
+
+    $this->actingAs($user->refresh());
+
+    expect(fn () => app(MediaAuthorization::class)
+        ->authorizeAttachments([], $user->refresh()))
+        ->toThrow(AuthorizationException::class);
+});
+
+test('authorizeAttachments empty list succeeds with viewAny', function () {
+    $user = createAdmin();
+
+    $this->actingAs($user);
+
+    $authorized = app(MediaAuthorization::class)->authorizeAttachments([], $user);
+
+    expect($authorized)->toHaveCount(0);
+});
+
+test('deleteSelected requires delete permission', function () {
+    $user = createAdmin();
+    $role = Role::where('slug', 'editor')->firstOrFail();
+    $permissions = $role->permissions;
+    $permissions['delete-attachment'] = false;
+    $role->update(['permissions' => $permissions]);
+
+    $this->actingAs($user->refresh());
+
+    $attachment = mediaAuthAttachment('keep-me.jpg');
+
+    expect(fn () => (new Attachment)->deleteSelected([$attachment->id]))
+        ->toThrow(AuthorizationException::class);
+
+    expect(Attachment::whereKey($attachment->id)->exists())->toBeTrue();
+});
+
+test('deleteSelected deletes when the actor may delete', function () {
+    $attachment1 = mediaAuthAttachment('one.jpg');
+    $attachment2 = mediaAuthAttachment('two.jpg');
+
+    (new Attachment)->deleteSelected([$attachment1->id, $attachment2->id]);
+
+    expect(Attachment::whereKey($attachment1->id)->exists())->toBeFalse()
+        ->and(Attachment::whereKey($attachment2->id)->exists())->toBeFalse();
+});

--- a/tests/Feature/Media/MediaManagerAuthorizationTest.php
+++ b/tests/Feature/Media/MediaManagerAuthorizationTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use Aura\Base\Livewire\Media\InvalidMediaOwnerContext;
+use Aura\Base\Livewire\MediaManager;
+use Aura\Base\Resources\Attachment;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\Cache;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+function managerAttachment(string $name = 'photo.jpg'): Attachment
+{
+    return Attachment::create([
+        'url' => 'media/'.$name,
+        'name' => $name,
+        'title' => $name,
+        'size' => 2048,
+        'mime_type' => 'image/jpeg',
+    ]);
+}
+
+function denyAttachmentViewForAdmin(): User
+{
+    $user = createAdmin();
+    $role = Role::where('slug', 'editor')
+        ->where('team_id', $user->current_team_id)
+        ->firstOrFail();
+    $permissions = $role->permissions;
+    $permissions['view-attachment'] = false;
+    $permissions['viewAny-attachment'] = true;
+    $role->update(['permissions' => $permissions]);
+    Cache::flush();
+
+    return $user->refresh();
+}
+
+test('mount does not leak all attachment ids via rowIds', function () {
+    managerAttachment('a.jpg');
+    managerAttachment('b.jpg');
+    managerAttachment('c.jpg');
+
+    livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [],
+        'modalAttributes' => null,
+    ])
+        ->assertSet('rowIds', [])
+        ->assertOk();
+});
+
+test('mount authorizes selected attachment ids', function () {
+    $attachment = managerAttachment('selected.jpg');
+
+    livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [(string) $attachment->id],
+        'modalAttributes' => null,
+    ])
+        ->assertSet('selected', [(string) $attachment->id])
+        ->assertOk();
+});
+
+test('mount rejects unauthorized selected ids', function () {
+    $user = denyAttachmentViewForAdmin();
+    $this->actingAs($user);
+
+    $attachment = managerAttachment('hidden.jpg');
+
+    // Livewire converts AuthorizationException on mount into a forbidden response.
+    livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [(string) $attachment->id],
+        'modalAttributes' => null,
+    ])->assertForbidden();
+});
+
+test('select rejects unauthorized attachment ids', function () {
+    $user = denyAttachmentViewForAdmin();
+    $this->actingAs($user);
+
+    $attachment = managerAttachment('not-mine.jpg');
+
+    // Mount with empty selection (requires viewAny only).
+    livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [],
+        'modalAttributes' => null,
+    ])
+        ->call('select', [(string) $attachment->id])
+        ->assertForbidden();
+});
+
+test('select rejects foreign team attachment ids', function () {
+    $otherTeam = Team::factory()->createQuietly(['user_id' => $this->user->id]);
+
+    $foreign = Attachment::withoutGlobalScopes()->create([
+        'url' => 'media/foreign.jpg',
+        'name' => 'foreign.jpg',
+        'title' => 'foreign.jpg',
+        'size' => 1024,
+        'mime_type' => 'image/jpeg',
+        'team_id' => $otherTeam->id,
+        'user_id' => $this->user->id,
+        'type' => Attachment::$type,
+    ]);
+
+    expect(fn () => livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [],
+        'modalAttributes' => null,
+    ])->call('select', [(string) $foreign->id]))->toThrow(InvalidMediaOwnerContext::class);
+});
+
+test('select accepts authorized attachment ids', function () {
+    $attachment = managerAttachment('ok.jpg');
+
+    livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [],
+        'modalAttributes' => null,
+    ])
+        ->call('select', [(string) $attachment->id])
+        ->assertDispatched('updateField');
+});

--- a/tests/Feature/Reporting/ResourceAggregateEngineTest.php
+++ b/tests/Feature/Reporting/ResourceAggregateEngineTest.php
@@ -1,0 +1,262 @@
+<?php
+
+use Aura\Base\Aura;
+use Aura\Base\Contracts\DeclaresReportingQueryScopes;
+use Aura\Base\Fields\Boolean;
+use Aura\Base\Fields\Number;
+use Aura\Base\Fields\Select;
+use Aura\Base\Fields\Text;
+use Aura\Base\Reporting\AggregateDefinition;
+use Aura\Base\Reporting\AggregateOperation;
+use Aura\Base\Reporting\DateBucket;
+use Aura\Base\Reporting\DateRange;
+use Aura\Base\Reporting\ResourceAggregateEngine;
+use Aura\Base\Resource;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Schema;
+
+final class Core29AggregateResource extends Resource implements DeclaresReportingQueryScopes
+{
+    public static $customTable = true;
+
+    public static ?string $slug = 'core29-aggregate-resource';
+
+    public static string $type = 'Core29AggregateResource';
+
+    public static bool $usesMeta = false;
+
+    protected $fillable = ['amount', 'stage', 'visible', 'user_id', 'team_id'];
+
+    protected $table = 'core29_aggregate_resources';
+
+    public static function getFields(): array
+    {
+        return [
+            ['name' => 'Amount', 'slug' => 'amount', 'type' => Number::class, 'number_type' => 'decimal', 'precision' => 18, 'scale' => 6],
+            ['name' => 'Stage', 'slug' => 'stage', 'type' => Select::class, 'options' => [['key' => 'open', 'value' => 'Open'], ['key' => 'won', 'value' => 'Won']]],
+            ['name' => 'Visible', 'slug' => 'visible', 'type' => Boolean::class],
+            ['name' => 'Ignored', 'slug' => 'ignored', 'type' => Text::class],
+        ];
+    }
+
+    /** @param Builder<Core29AggregateResource> $query */
+    public function indexQuery(Builder $query): Builder
+    {
+        return $query->where($this->qualifyColumn('visible'), true);
+    }
+
+    public static function reportingQueryScopes(): array
+    {
+        return ['openStage'];
+    }
+
+    /** @param Builder<Core29AggregateResource> $query */
+    public function scopeOpenStage(Builder $query): Builder
+    {
+        return $query->where($this->qualifyColumn('stage'), 'open');
+    }
+}
+
+beforeEach(function (): void {
+    Schema::create('core29_aggregate_resources', function (Blueprint $table): void {
+        $table->id();
+        $table->text('amount')->nullable();
+        $table->string('stage')->nullable();
+        $table->boolean('visible');
+        $table->unsignedBigInteger('user_id')->nullable();
+        $table->unsignedBigInteger('team_id')->nullable();
+        $table->timestamps();
+    });
+    $this->actingAs($this->user = createSuperAdmin());
+    app(Aura::class)->registerResources([Core29AggregateResource::class]);
+    Gate::before(static fn (): bool => true);
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('core29_aggregate_resources');
+});
+
+test('aggregates exact physical values through the authorized resource query', function (): void {
+    $team = ['user_id' => $this->user->id, 'team_id' => $this->user->current_team_id];
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '1.250000', 'stage' => 'open', 'visible' => true, ...$team]);
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '2.500000', 'stage' => 'won', 'visible' => true, ...$team]);
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '99.000000', 'stage' => 'won', 'visible' => false, ...$team]);
+
+    expect(Core29AggregateResource::withoutGlobalScopes()->count())->toBe(3);
+
+    $result = (new ResourceAggregateEngine)->run(new AggregateDefinition(
+        Core29AggregateResource::class,
+        AggregateOperation::Average,
+        'amount',
+    ));
+
+    expect($result->value)->toBe('1.875000');
+});
+
+test('returns immutable null-last formatted group points and rejects unregistered resources', function (): void {
+    $team = ['user_id' => $this->user->id, 'team_id' => $this->user->current_team_id];
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '2.000000', 'stage' => 'won', 'visible' => true, ...$team]);
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '1.000000', 'stage' => null, 'visible' => true, ...$team]);
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '1.000000', 'stage' => 'open', 'visible' => true, ...$team]);
+
+    $result = (new ResourceAggregateEngine)->run(new AggregateDefinition(
+        Core29AggregateResource::class,
+        AggregateOperation::Sum,
+        'amount',
+        'stage',
+    ));
+
+    expect($result->points)->toHaveCount(3)
+        ->and($result->points[0]->key)->toBe('open')
+        ->and($result->points[0]->label)->toBe('Open')
+        ->and($result->points[2]->key)->toBeNull()
+        ->and($result->points[2]->label)->toBe('Empty')
+        ->and(fn () => $result->points[0]->label = 'nope')->toThrow(Error::class);
+});
+
+test('uses half-open ranges', function (): void {
+    DB::table('core29_aggregate_resources')->insert([
+        ['amount' => '1.000000', 'stage' => 'open', 'visible' => true, 'user_id' => $this->user->id, 'team_id' => $this->user->current_team_id, 'created_at' => '2026-01-01 00:00:00', 'updated_at' => '2026-01-01 00:00:00'],
+        ['amount' => '2.000000', 'stage' => 'open', 'visible' => true, 'user_id' => $this->user->id, 'team_id' => $this->user->current_team_id, 'created_at' => '2026-01-02 00:00:00', 'updated_at' => '2026-01-02 00:00:00'],
+    ]);
+
+    expect(Core29AggregateResource::withoutGlobalScopes()->count())->toBe(2)
+        ->and(Core29AggregateResource::withoutGlobalScopes()
+            ->where('created_at', '>=', '2026-01-01 00:00:00')
+            ->where('created_at', '<', '2026-01-02 00:00:00')
+            ->count())->toBe(1);
+
+    $result = (new ResourceAggregateEngine)->run(new AggregateDefinition(
+        Core29AggregateResource::class,
+        AggregateOperation::Count,
+        range: new DateRange(new DateTimeImmutable('2026-01-01 00:00:00 UTC'), new DateTimeImmutable('2026-01-02 00:00:00 UTC')),
+    ));
+
+    expect($result->value)->toBe(1);
+});
+
+test('only explicitly allowlisted reporting query scopes can run', function (): void {
+    $team = ['user_id' => $this->user->id, 'team_id' => $this->user->current_team_id];
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '1.000000', 'stage' => 'open', 'visible' => true, ...$team]);
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '2.000000', 'stage' => 'won', 'visible' => true, ...$team]);
+    $engine = new ResourceAggregateEngine;
+
+    expect($engine->run(new AggregateDefinition(
+        Core29AggregateResource::class,
+        AggregateOperation::Count,
+        queryScope: 'openStage',
+    ))->value)->toBe(1)
+        ->and(fn () => $engine->run(new AggregateDefinition(
+            Core29AggregateResource::class,
+            AggregateOperation::Count,
+            queryScope: 'indexQuery',
+        )))->toThrow(InvalidArgumentException::class, 'explicitly allowlisted');
+});
+
+test('rounds exact averages half away from zero and returns null for all-null values', function (): void {
+    $team = ['user_id' => $this->user->id, 'team_id' => $this->user->current_team_id];
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '0.000001', 'stage' => 'open', 'visible' => true, ...$team]);
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '0.000002', 'stage' => 'open', 'visible' => true, ...$team]);
+    $engine = new ResourceAggregateEngine;
+
+    expect($engine->run(new AggregateDefinition(Core29AggregateResource::class, AggregateOperation::Average, 'amount'))->value)
+        ->toBe('0.000002');
+
+    DB::table('core29_aggregate_resources')->delete();
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '-0.000001', 'stage' => 'open', 'visible' => true, ...$team]);
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => '-0.000002', 'stage' => 'open', 'visible' => true, ...$team]);
+
+    expect($engine->run(new AggregateDefinition(Core29AggregateResource::class, AggregateOperation::Average, 'amount'))->value)
+        ->toBe('-0.000002');
+
+    DB::table('core29_aggregate_resources')->delete();
+    Core29AggregateResource::withoutGlobalScopes()->create(['amount' => null, 'stage' => 'open', 'visible' => true, ...$team]);
+
+    expect($engine->run(new AggregateDefinition(Core29AggregateResource::class, AggregateOperation::Sum, 'amount'))->value)->toBeNull();
+});
+
+test('uses portable local calendar keys for every bucket and both Zurich DST transitions', function (): void {
+    $attributes = ['visible' => true, 'user_id' => $this->user->id, 'team_id' => $this->user->current_team_id];
+    DB::table('core29_aggregate_resources')->insert([
+        [...$attributes, 'amount' => '1.000000', 'stage' => 'open', 'created_at' => '2024-02-29 12:00:00', 'updated_at' => '2024-02-29 12:00:00'],
+        [...$attributes, 'amount' => '1.000000', 'stage' => 'open', 'created_at' => '2024-03-31 00:30:00', 'updated_at' => '2024-03-31 00:30:00'],
+        [...$attributes, 'amount' => '1.000000', 'stage' => 'open', 'created_at' => '2024-03-31 01:30:00', 'updated_at' => '2024-03-31 01:30:00'],
+        [...$attributes, 'amount' => '1.000000', 'stage' => 'open', 'created_at' => '2024-10-27 00:30:00', 'updated_at' => '2024-10-27 00:30:00'],
+        [...$attributes, 'amount' => '1.000000', 'stage' => 'open', 'created_at' => '2024-10-27 01:30:00', 'updated_at' => '2024-10-27 01:30:00'],
+    ]);
+    $engine = new ResourceAggregateEngine;
+    $bucket = static function (DateBucket $bucket, string $start, string $end) use ($engine): array {
+        $result = $engine->run(new AggregateDefinition(
+            Core29AggregateResource::class,
+            AggregateOperation::Count,
+            range: new DateRange(new DateTimeImmutable($start, new DateTimeZone('Europe/Zurich')), new DateTimeImmutable($end, new DateTimeZone('Europe/Zurich'))),
+            bucket: $bucket,
+            timezone: 'Europe/Zurich',
+        ));
+
+        return array_column($result->points, 'value', 'key');
+    };
+
+    expect($bucket(DateBucket::Day, '2024-03-30', '2024-04-02'))->toBe(['2024-03-31' => 2])
+        ->and($bucket(DateBucket::Day, '2024-10-26', '2024-10-29'))->toBe(['2024-10-27' => 2])
+        ->and($bucket(DateBucket::Week, '2024-03-25', '2024-04-01'))->toBe(['2024-W13' => 2])
+        ->and($bucket(DateBucket::Month, '2024-02-01', '2024-04-01'))->toBe(['2024-02' => 1, '2024-03' => 2])
+        ->and($bucket(DateBucket::Quarter, '2024-01-01', '2025-01-01'))->toBe(['2024-Q1' => 3, '2024-Q4' => 2])
+        ->and($bucket(DateBucket::Year, '2024-01-01', '2025-01-01'))->toBe(['2024' => 5]);
+});
+
+test('rejects invalid timezones and more than four hundred bucket points', function (): void {
+    $engine = new ResourceAggregateEngine;
+
+    expect(fn () => $engine->run(new AggregateDefinition(
+        Core29AggregateResource::class,
+        AggregateOperation::Count,
+        range: new DateRange(new DateTimeImmutable('2024-01-01'), new DateTimeImmutable('2024-01-02')),
+        bucket: DateBucket::Day,
+        timezone: 'Invalid/Timezone',
+    )))->toThrow(InvalidArgumentException::class, 'valid IANA timezone')
+        ->and(fn () => $engine->run(new AggregateDefinition(
+            Core29AggregateResource::class,
+            AggregateOperation::Count,
+            range: new DateRange(new DateTimeImmutable('2024-01-01'), new DateTimeImmutable('2025-03-01')),
+            bucket: DateBucket::Day,
+        )))->toThrow(InvalidArgumentException::class, 'limited to 400 points');
+});
+
+test('rejects meta-backed metrics without projection reads', function (): void {
+    $engine = new ResourceAggregateEngine;
+
+    // Create a temporary resource class is heavy; use a custom-table resource that marks amount as meta.
+    $metaResource = new class extends Resource
+    {
+        public static $customTable = true;
+
+        public static ?string $slug = 'core29-meta-metric';
+
+        public static string $type = 'Core29MetaMetric';
+
+        public static bool $usesMeta = true;
+
+        protected $fillable = ['user_id', 'team_id'];
+
+        protected $table = 'core29_aggregate_resources';
+
+        public static function getFields(): array
+        {
+            return [
+                ['name' => 'Amount', 'slug' => 'amount', 'type' => Number::class],
+            ];
+        }
+    };
+
+    app(Aura::class)->registerResources([$metaResource::class]);
+
+    expect(fn () => $engine->run(new AggregateDefinition(
+        $metaResource::class,
+        AggregateOperation::Sum,
+        'amount',
+    )))->toThrow(InvalidArgumentException::class, 'Meta-backed reporting metrics');
+});

--- a/tests/Feature/Resource/RecordLayoutTest.php
+++ b/tests/Feature/Resource/RecordLayoutTest.php
@@ -1,0 +1,381 @@
+<?php
+
+use Aura\Base\Facades\Aura;
+use Aura\Base\Livewire\ComponentSlots\ComponentSlotCollision;
+use Aura\Base\Livewire\ComponentSlots\LivewireCollisionInspector;
+use Aura\Base\Livewire\Resource\View;
+use Aura\Base\Preferences\PreferenceContext;
+use Aura\Base\Preferences\PreferenceDefinition;
+use Aura\Base\Preferences\PreferenceManager;
+use Aura\Base\Preferences\PreferenceRegistry;
+use Aura\Base\Preferences\PreferenceScope;
+use Aura\Base\Preferences\PreferenceValueType;
+use Aura\Base\RecordLayout\DefinesRecordLayoutPanels;
+use Aura\Base\RecordLayout\InvalidRecordLayoutPanel;
+use Aura\Base\RecordLayout\RecordLayoutPanel;
+use Aura\Base\RecordLayout\RecordLayoutPanelValidator;
+use Aura\Base\RecordLayout\RecordLayoutRegion;
+use Aura\Base\RecordLayout\RecordLayoutRegistry;
+use Aura\Base\RecordLayout\RecordLayoutResolver;
+use Aura\Base\RecordLayout\RegisteredRecordLayoutPanel;
+use Aura\Base\Resource;
+use Aura\Base\Resources\User;
+use Aura\Base\Tests\Fixtures\RecordLayout\SecondPanel;
+use Aura\Base\Tests\Fixtures\RecordLayout\TestPanel;
+use Aura\Base\Tests\Fixtures\RecordLayout\ThirdPanel;
+use Aura\Base\Tests\Resources\Post;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+use Livewire\Livewire;
+
+class Core25InvalidInputPanel extends Component
+{
+    public string $inModal = '';
+
+    public string $model = '';
+}
+
+class Core25ConflictingMountPanel extends Component
+{
+    public bool $inModal = false;
+
+    public Resource $model;
+
+    public function mount(string $model, int $inModal): void {}
+}
+
+class Core25DuplicatePanelResource extends Resource implements DefinesRecordLayoutPanels
+{
+    public static string $type = 'Core25DuplicatePanelResource';
+
+    public static function recordLayoutPanels(): array
+    {
+        return [
+            new RecordLayoutPanel('duplicate', RecordLayoutRegion::MainContent, TestPanel::class),
+            new RecordLayoutPanel('duplicate', RecordLayoutRegion::RightSidebar, TestPanel::class),
+        ];
+    }
+}
+
+function core25Registry(): RecordLayoutRegistry
+{
+    $registry = new RecordLayoutRegistry(
+        app(LivewireCollisionInspector::class),
+        app(PreferenceRegistry::class),
+        app(RecordLayoutPanelValidator::class),
+    );
+    app()->instance(RecordLayoutRegistry::class, $registry);
+    app()->forgetInstance(RecordLayoutResolver::class);
+
+    return $registry;
+}
+
+function core25Post(): Post
+{
+    $post = Post::create([
+        'title' => 'Composable record',
+        'content' => 'Core 25',
+        'type' => Post::getType(),
+        'status' => 'publish',
+    ]);
+
+    Aura::fake();
+    Aura::setModel(new Post);
+
+    return $post;
+}
+
+function core25PreferenceContext(?User $user = null): PreferenceContext
+{
+    $user ??= auth()->user();
+
+    return new PreferenceContext(
+        (string) config('app.name'),
+        $user,
+        config('aura.teams') ? $user?->currentTeam : null,
+        Post::getType(),
+    );
+}
+
+beforeEach(function () {
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+test('the default record view remains unchanged when no panels are registered', function () {
+    core25Registry();
+    $post = core25Post();
+
+    Livewire::test(View::class, ['slug' => 'post', 'id' => $post->id])
+        ->assertSee('Composable record')
+        ->assertSeeHtml('space-x-2')
+        ->assertDontSeeHtml('flex-wrap gap-4')
+        ->assertDontSeeHtml('data-record-layout="page"');
+});
+
+test('multiple plugin panels render in deterministic order across stable regions', function () {
+    $registry = core25Registry();
+    $registry->register('zeta/activity', [
+        new RecordLayoutPanel('third', RecordLayoutRegion::MainContent, ThirdPanel::class, order: 20),
+    ]);
+    $registry->register('alpha/summary', [
+        new RecordLayoutPanel('second', RecordLayoutRegion::MainContent, SecondPanel::class, order: 10),
+        new RecordLayoutPanel('first', RecordLayoutRegion::LeftSummary, TestPanel::class),
+    ]);
+    $registry->captureBaselineState();
+    $post = core25Post();
+
+    $html = Livewire::test(View::class, ['slug' => 'post', 'id' => $post->id])->html();
+
+    expect($html)->toContain('data-record-layout="page"')
+        ->and($html)->toContain('data-record-layout-region="left-summary"')
+        ->and(strpos($html, SecondPanel::class))->toBeLessThan(strpos($html, ThirdPanel::class));
+});
+
+test('hidden unauthorized and preference-disabled panels fail closed', function () {
+    app(PreferenceRegistry::class)->register(new PreferenceDefinition(
+        key: 'record-layout.test-panel',
+        type: PreferenceValueType::Boolean,
+        default: true,
+        scopes: [PreferenceScope::User, PreferenceScope::Team],
+        resourceAware: true,
+    ));
+
+    $registry = core25Registry();
+    $registry->register('acme/panels', [
+        new RecordLayoutPanel('hidden', RecordLayoutRegion::MainContent, TestPanel::class, visible: false),
+        new RecordLayoutPanel('denied', RecordLayoutRegion::MainContent, SecondPanel::class, ability: 'core25-denied'),
+        new RecordLayoutPanel(
+            'preferred',
+            RecordLayoutRegion::MainContent,
+            ThirdPanel::class,
+            preferenceKey: 'record-layout.test-panel',
+        ),
+    ]);
+    Gate::define('core25-denied', fn (): bool => false);
+
+    app(PreferenceManager::class)->set(
+        'record-layout.test-panel',
+        false,
+        PreferenceScope::User,
+        core25PreferenceContext($this->user),
+        $this->user,
+    );
+
+    $registry->captureBaselineState();
+    $post = core25Post();
+
+    Livewire::test(View::class, ['slug' => 'post', 'id' => $post->id])
+        ->assertDontSee(TestPanel::class)
+        ->assertDontSee(SecondPanel::class)
+        ->assertDontSee(ThirdPanel::class)
+        ->assertDontSeeHtml('data-record-layout="page"');
+});
+
+test('invalid or missing panel components are rejected atomically', function () {
+    $registry = core25Registry();
+
+    expect(fn () => $registry->register('acme/panels', [
+        new RecordLayoutPanel('valid', RecordLayoutRegion::MainContent, TestPanel::class),
+        new RecordLayoutPanel('missing', RecordLayoutRegion::MainContent, 'Acme\\MissingPanel'),
+    ]))->toThrow(InvalidRecordLayoutPanel::class);
+
+    expect($registry->panelsFor(new Post))->toBe([]);
+
+    expect(fn () => $registry->register('acme/panels', [
+        new RecordLayoutPanel('bad-inputs', RecordLayoutRegion::MainContent, Core25InvalidInputPanel::class),
+    ]))->toThrow(InvalidRecordLayoutPanel::class);
+
+    expect(fn () => $registry->register('acme/panels', [
+        new RecordLayoutPanel('conflicting-mount', RecordLayoutRegion::MainContent, Core25ConflictingMountPanel::class),
+    ]))->toThrow(InvalidRecordLayoutPanel::class);
+});
+
+test('resource declarations use the same duplicate and preference invariants', function () {
+    $duplicates = core25Registry();
+
+    expect(fn () => $duplicates->captureBaselineState([Core25DuplicatePanelResource::class]))
+        ->toThrow(InvalidArgumentException::class);
+    expect($duplicates->panelsFor(new Core25DuplicatePanelResource))->toBe([]);
+
+    $preferences = core25Registry();
+    $preferences->register('acme/panels', [
+        new RecordLayoutPanel(
+            'missing-preference',
+            RecordLayoutRegion::MainContent,
+            TestPanel::class,
+            preferenceKey: 'record-layout.missing',
+        ),
+    ]);
+
+    expect(fn () => $preferences->captureBaselineState())
+        ->toThrow(InvalidRecordLayoutPanel::class, 'preference [record-layout.missing] is not registered');
+});
+
+test('panel registration is idempotent before boot finalization and closed afterwards', function () {
+    $registry = core25Registry();
+    $panel = new RecordLayoutPanel('stable', RecordLayoutRegion::MainContent, TestPanel::class);
+
+    $registry->register('acme/panels', [$panel]);
+    $registry->register('acme/panels', [$panel]);
+
+    expect($registry->panelsFor(new Post))->toHaveCount(1);
+
+    $registry->captureBaselineState();
+
+    expect(fn () => $registry->register('other/panels', [$panel]))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('panel transports reject even same-class claims through the core collision preflight', function () {
+    $registry = core25Registry();
+    $panel = new RecordLayoutPanel('claimed', RecordLayoutRegion::MainContent, TestPanel::class);
+    $registered = new RegisteredRecordLayoutPanel('acme/panels', $panel);
+    Livewire::component($registered->transport(), TestPanel::class);
+
+    $registry->register('acme/panels', [$panel]);
+
+    expect(fn () => $registry->captureBaselineState())
+        ->toThrow(ComponentSlotCollision::class);
+    expect($registry->panelsFor(new Post))->toBe([]);
+});
+
+test('record layout transport ownership survives a fresh registry without trusting replacements', function () {
+    $panel = new RecordLayoutPanel('worker-owned', RecordLayoutRegion::MainContent, TestPanel::class);
+    $registered = new RegisteredRecordLayoutPanel('acme/panels', $panel);
+
+    $firstRegistry = core25Registry();
+    $firstRegistry->register('acme/panels', [$panel]);
+    $firstRegistry->captureBaselineState();
+
+    $freshRegistry = core25Registry();
+    $freshRegistry->register('acme/panels', [$panel]);
+    expect(fn () => $freshRegistry->captureBaselineState())->not->toThrow(ComponentSlotCollision::class);
+
+    Livewire::component($registered->transport(), SecondPanel::class);
+
+    $replacedRegistry = core25Registry();
+    $replacedRegistry->register('acme/panels', [$panel]);
+    expect(fn () => $replacedRegistry->captureBaselineState())
+        ->toThrow(ComponentSlotCollision::class, SecondPanel::class);
+});
+
+test('a failed batch preflight does not claim earlier livewire transports', function () {
+    $registry = core25Registry();
+    $first = new RegisteredRecordLayoutPanel(
+        'acme/panels',
+        new RecordLayoutPanel('first', RecordLayoutRegion::MainContent, TestPanel::class),
+    );
+    $claimed = new RegisteredRecordLayoutPanel(
+        'acme/panels',
+        new RecordLayoutPanel('claimed', RecordLayoutRegion::MainContent, SecondPanel::class),
+    );
+    Livewire::component($claimed->transport(), SecondPanel::class);
+
+    $registry->register('acme/panels', [$first->panel, $claimed->panel]);
+
+    expect(fn () => $registry->captureBaselineState())
+        ->toThrow(ComponentSlotCollision::class);
+    expect(fn () => app(LivewireCollisionInspector::class)->assertReservable(
+        $first->transport(),
+        TestPanel::class,
+        static fn (?string $name): ?string => null,
+    ))->not->toThrow(ComponentSlotCollision::class);
+});
+
+test('shared eager loads and preference reads stay bounded as panels increase', function () {
+    $registry = core25Registry();
+    $panels = [];
+
+    foreach (range(1, 10) as $index) {
+        $panels[] = new RecordLayoutPanel(
+            'panel-'.$index,
+            RecordLayoutRegion::MainContent,
+            TestPanel::class,
+            eagerLoad: ['user'],
+        );
+    }
+
+    $registry->register('acme/panels', $panels);
+    $registry->captureBaselineState();
+    $post = core25Post()->fresh();
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    $layout = app(RecordLayoutResolver::class)->resolve($post);
+    $queries = DB::getQueryLog();
+    DB::disableQueryLog();
+
+    expect($layout->panels(RecordLayoutRegion::MainContent))->toHaveCount(10)
+        ->and($post->relationLoaded('user'))->toBeTrue()
+        ->and(count($queries))->toBeLessThanOrEqual(7);
+});
+
+test('a shared preference is resolved once for multiple panels', function () {
+    app(PreferenceRegistry::class)->register(new PreferenceDefinition(
+        key: 'record-layout.shared-preference',
+        type: PreferenceValueType::Boolean,
+        default: true,
+        scopes: [PreferenceScope::User, PreferenceScope::Team],
+        resourceAware: true,
+    ));
+    $registry = core25Registry();
+    $panels = [];
+
+    foreach (range(1, 10) as $index) {
+        $panels[] = new RecordLayoutPanel(
+            'preferred-'.$index,
+            RecordLayoutRegion::MainContent,
+            TestPanel::class,
+            preferenceKey: 'record-layout.shared-preference',
+        );
+    }
+
+    $registry->register('acme/panels', $panels);
+    $registry->captureBaselineState();
+    $post = core25Post()->fresh();
+    DB::flushQueryLog();
+    DB::enableQueryLog();
+
+    $layout = app(RecordLayoutResolver::class)->resolve($post);
+    $queries = DB::getQueryLog();
+    DB::disableQueryLog();
+
+    expect($layout->panels(RecordLayoutRegion::MainContent))->toHaveCount(10)
+        ->and(count($queries))->toBeLessThanOrEqual(35);
+});
+
+test('modal record views pass their context to panels', function () {
+    $registry = core25Registry();
+    $registry->register('acme/panels', [
+        new RecordLayoutPanel('modal', RecordLayoutRegion::RightSidebar, TestPanel::class),
+    ]);
+    $registry->captureBaselineState();
+    $post = core25Post();
+
+    Livewire::test(View::class, ['slug' => 'post', 'id' => $post->id, 'inModal' => true])
+        ->assertSeeHtml('data-record-layout="modal"')
+        ->assertSeeHtml('data-modal="true"');
+});
+
+test('custom-table records resolve the same declarative panel contract', function () {
+    $registry = core25Registry();
+    $registry->register('acme/panels', [
+        new RecordLayoutPanel(
+            'custom-table',
+            RecordLayoutRegion::MainContent,
+            TestPanel::class,
+            resources: [User::class],
+        ),
+    ]);
+    $registry->captureBaselineState();
+
+    Aura::fake();
+    Aura::setModel(new User);
+
+    expect($this->user->usesCustomTable())->toBeTrue();
+
+    Livewire::test(View::class, ['slug' => 'user', 'id' => $this->user->getKey()])
+        ->assertSee(TestPanel::class)
+        ->assertSeeHtml('data-record-layout="page"');
+});

--- a/tests/Feature/Security/BulkActionsAuthorizationTest.php
+++ b/tests/Feature/Security/BulkActionsAuthorizationTest.php
@@ -110,3 +110,20 @@ test('bulkAction runs a declared action for an authorized user', function () {
 
     expect(SecurityBulkModel::count())->toBe(0);
 });
+
+test('bulkAction fails closed when a forged id is mixed into an otherwise valid selection', function () {
+    $this->actingAs(createSuperAdmin());
+
+    $keep = SecurityBulkModel::create(['title' => 'Keep me']);
+    $delete = SecurityBulkModel::create(['title' => 'Delete me']);
+
+    $model = SecurityBulkModel::first();
+
+    livewire(Table::class, ['query' => null, 'model' => $model])
+        ->set('selected', [(string) $delete->id, '999999999'])
+        ->call('bulkAction', 'deleteSelected')
+        ->assertHasErrors(['selected']);
+
+    expect(SecurityBulkModel::find($keep->id))->not->toBeNull()
+        ->and(SecurityBulkModel::find($delete->id))->not->toBeNull();
+});

--- a/tests/Feature/Security/FailClosedQueryFiltersAndTeamScopeTest.php
+++ b/tests/Feature/Security/FailClosedQueryFiltersAndTeamScopeTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use Aura\Base\Livewire\Table\Traits\QueryFilters;
+use Aura\Base\Models\Scopes\TeamScope;
+use Aura\Base\Policies\ResourcePolicy;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\User;
+use Aura\Base\Tests\Resources\Post;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function () {
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+it('fails closed for tenant models when the user has no current team', function () {
+    $teamId = $this->user->current_team_id;
+
+    Post::withoutGlobalScope(TeamScope::class)->create([
+        'title' => 'Tenant Post',
+        'type' => 'Post',
+        'status' => 'publish',
+        'team_id' => $teamId,
+    ]);
+
+    // Clear team context without logging out.
+    DB::table('users')->where('id', $this->user->id)->update(['current_team_id' => null]);
+    Cache::forget(User::currentTeamCacheKey($this->user->id));
+    $this->user->refresh();
+
+    expect(Post::query()->count())->toBe(0)
+        ->and(Post::query()->toSql())->toContain('1 = 0');
+});
+
+it('restricts non-global-admin user queries to self when no current team is set', function () {
+    $other = User::factory()->create();
+
+    DB::table('users')->where('id', $this->user->id)->update(['current_team_id' => null]);
+    Cache::forget(User::currentTeamCacheKey($this->user->id));
+    $this->user->refresh();
+
+    $ids = User::query()->pluck('id')->all();
+
+    expect($ids)->toBe([$this->user->id])
+        ->and($ids)->not->toContain($other->id);
+});
+
+it('fails closed for Role queries when the user has no current team', function () {
+    // Ensure the catalog has at least one global role from bootstrap/seeding.
+    expect(Role::withoutGlobalScope(TeamScope::class)->count())->toBeGreaterThan(0);
+
+    DB::table('users')->where('id', $this->user->id)->update(['current_team_id' => null]);
+    Cache::forget(User::currentTeamCacheKey($this->user->id));
+    $this->user->refresh();
+
+    expect(Role::query()->count())->toBe(0)
+        ->and(Role::query()->toSql())->toContain('1 = 0');
+});
+
+it('rejects table filters with an unknown operator via fail-closed default', function () {
+    $harness = new class
+    {
+        use QueryFilters;
+
+        public $filters = ['custom' => []];
+
+        public $model;
+
+        public function runOperator(Builder $query, array $filter): void
+        {
+            $this->applyOperatorCondition($query, $filter);
+        }
+
+        public function runTable(Builder $query, array $filter): Builder
+        {
+            return $this->applyTableFieldFilter($query, $filter);
+        }
+
+        public function valid(array $filter): bool
+        {
+            return $this->isValidFilter($filter);
+        }
+    };
+
+    $query = Post::query();
+    $harness->runOperator($query, [
+        'name' => 'title',
+        'operator' => 'drop_table',
+        'value' => 'x',
+    ]);
+
+    expect($query->toSql())->toContain('1 = 0');
+
+    $tableQuery = Post::query();
+    $harness->runTable($tableQuery, [
+        'name' => 'title',
+        'operator' => 'not_a_real_operator',
+        'value' => 'x',
+    ]);
+
+    expect($tableQuery->toSql())->toContain('1 = 0');
+
+    expect($harness->valid(['name' => 'title', 'value' => 'x']))->toBeFalse()
+        ->and($harness->valid(['name' => 'title', 'operator' => '', 'value' => 'x']))->toBeFalse()
+        ->and($harness->valid(['name' => 'title', 'operator' => 'contains', 'value' => 'x']))->toBeTrue();
+});
+
+it('fails closed for malformed custom filter payloads', function () {
+    $harness = new class
+    {
+        use QueryFilters;
+
+        public $filters = ['custom' => ['not-a-group' => true]];
+
+        public $model;
+
+        public function run(Builder $query): Builder
+        {
+            return $this->applyCustomFilter($query);
+        }
+    };
+
+    $query = Post::query();
+    $harness->run($query);
+
+    expect($query->toSql())->toContain('1 = 0');
+});
+
+it('denies policy abilities when actor and resource use different connections', function () {
+    $policy = new ResourcePolicy;
+
+    // Same connection should still authorize for a super admin.
+    expect($policy->view($this->user, new Post))->toBeTrue();
+
+    // Pin the resource to a connection name that cannot match the actor.
+    $resource = new Post;
+    $resource->setConnection('foreign_security_connection');
+
+    expect($this->user->getConnectionName())->not->toBe($resource->getConnectionName())
+        ->and($policy->view($this->user, $resource))->toBeFalse()
+        ->and($policy->update($this->user, $resource))->toBeFalse()
+        ->and($policy->delete($this->user, $resource))->toBeFalse()
+        ->and($policy->create($this->user, $resource))->toBeFalse()
+        ->and($policy->viewAny($this->user, $resource))->toBeFalse()
+        ->and($policy->restore($this->user, $resource))->toBeFalse()
+        ->and($policy->forceDelete($this->user, $resource))->toBeFalse();
+});

--- a/tests/Feature/Security/GlobalSearchAuthorizationTest.php
+++ b/tests/Feature/Security/GlobalSearchAuthorizationTest.php
@@ -3,6 +3,7 @@
 use Aura\Base\Facades\Aura;
 use Aura\Base\Livewire\GlobalSearch;
 use Aura\Base\Resource;
+use Aura\Base\Resources\Role;
 use Aura\Base\Resources\User;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Livewire;
@@ -71,7 +72,12 @@ test('global search hides users when the current user cannot view users', functi
     // Build a role with viewAny-user explicitly denied, then search by email.
     $this->actingAs($admin = createAdmin());
 
-    $admin->roles->first()->update([
+    $role = $admin->roles()->first()
+        ?? Role::where('slug', 'editor')
+            ->where('team_id', $admin->current_team_id)
+            ->firstOrFail();
+
+    $role->update([
         'permissions' => ['view-user' => false, 'viewAny-user' => false],
     ]);
 

--- a/tests/Feature/Security/TableRowActionAuthorizationTest.php
+++ b/tests/Feature/Security/TableRowActionAuthorizationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use Aura\Base\Facades\Aura;
+use Aura\Base\Livewire\Table\Table;
+use Aura\Base\Resource;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Cache;
+
+use function Pest\Livewire\livewire;
+
+/**
+ * Test resource that declares a single legitimate row action.
+ */
+class SecurityRowActionModel extends Resource
+{
+    public array $actions = [
+        'delete' => [
+            'label' => 'Delete',
+            'ability' => 'delete',
+        ],
+    ];
+
+    public static $singularName = 'SecurityRow';
+
+    public static ?string $slug = 'securityrow';
+
+    public static string $type = 'SecurityRow';
+
+    public static function getFields()
+    {
+        return [
+            [
+                'name' => 'Title',
+                'type' => 'Aura\\Base\\Fields\\Text',
+                'validation' => 'required',
+                'searchable' => true,
+                'slug' => 'title',
+            ],
+        ];
+    }
+}
+
+beforeEach(function () {
+    Aura::fake();
+    Aura::registerResources([SecurityRowActionModel::class]);
+    Aura::setModel(new SecurityRowActionModel);
+    Cache::clear();
+});
+
+test('table row action rejects a forged undeclared action name', function () {
+    $this->actingAs(createSuperAdmin());
+
+    $record = SecurityRowActionModel::create(['title' => 'Stay put']);
+
+    livewire(Table::class, ['query' => null, 'model' => $record])
+        ->call('action', ['action' => 'forceDelete', 'id' => $record->id])
+        ->assertStatus(403);
+
+    expect(SecurityRowActionModel::whereKey($record->id)->exists())->toBeTrue();
+});
+
+test('table row action blocks delete when the user is not authorized', function () {
+    // Limited admin (Editor role) has no delete permission for this resource.
+    $this->actingAs(createAdmin());
+
+    $record = SecurityRowActionModel::create(['title' => 'Protected']);
+
+    livewire(Table::class, ['query' => null, 'model' => $record])
+        ->call('action', ['action' => 'delete', 'id' => $record->id])
+        ->assertStatus(403);
+
+    expect(SecurityRowActionModel::whereKey($record->id)->exists())->toBeTrue();
+});
+
+test('table row action resolves the record only inside the current table scope', function () {
+    // Cross-team record must not be reachable via bare model find — the table
+    // scope (TeamScope + type) has to own the lookup.
+    $this->actingAs(createSuperAdmin());
+
+    $own = SecurityRowActionModel::create(['title' => 'Own team row']);
+
+    $otherTeam = foreignTeam();
+
+    $foreign = SecurityRowActionModel::withoutGlobalScopes()->create([
+        'title' => 'Foreign team row',
+        'team_id' => $otherTeam->id,
+        'type' => SecurityRowActionModel::$type,
+    ]);
+
+    expect(SecurityRowActionModel::whereKey($own->id)->exists())->toBeTrue();
+    // Foreign row is invisible under the acting team's TeamScope.
+    expect(SecurityRowActionModel::whereKey($foreign->id)->exists())->toBeFalse();
+
+    // Custom row action: exact selection inside scope fails closed.
+    livewire(Table::class, ['query' => null, 'model' => $own])
+        ->call('action', ['action' => 'delete', 'id' => $foreign->id])
+        ->assertHasErrors(['selected']);
+
+    expect(SecurityRowActionModel::withoutGlobalScopes()->whereKey($foreign->id)->exists())->toBeTrue();
+    expect(SecurityRowActionModel::whereKey($own->id)->exists())->toBeTrue();
+})->skip(fn () => ! config('aura.teams'), 'Cross-team scoped find requires teams.');
+
+test('table view action uses scoped find and never bare model find', function () {
+    $this->actingAs(createSuperAdmin());
+
+    $own = SecurityRowActionModel::create(['title' => 'Visible']);
+
+    $otherTeam = foreignTeam();
+
+    $foreign = SecurityRowActionModel::withoutGlobalScopes()->create([
+        'title' => 'Hidden',
+        'team_id' => $otherTeam->id,
+        'type' => SecurityRowActionModel::$type,
+    ]);
+
+    // Out-of-scope id must 404 via firstOrFail on the scoped query.
+    expect(fn () => livewire(Table::class, ['query' => null, 'model' => $own])
+        ->call('action', ['action' => 'view', 'id' => $foreign->id]))
+        ->toThrow(ModelNotFoundException::class);
+
+    // In-scope id is authorized and redirects.
+    livewire(Table::class, ['query' => null, 'model' => $own])
+        ->call('action', ['action' => 'view', 'id' => $own->id])
+        ->assertRedirect(route('aura.securityrow.view', ['id' => $own->id]));
+})->skip(fn () => ! config('aura.teams'), 'Cross-team scoped find requires teams.');
+
+test('table row action runs a declared delete for an authorized user', function () {
+    $this->actingAs(createSuperAdmin());
+
+    $record = SecurityRowActionModel::create(['title' => 'Delete me']);
+
+    livewire(Table::class, ['query' => null, 'model' => $record])
+        ->call('action', ['action' => 'delete', 'id' => $record->id])
+        ->assertHasNoErrors();
+
+    expect(SecurityRowActionModel::whereKey($record->id)->exists())->toBeFalse();
+});

--- a/tests/Feature/Table/KanbanContractTest.php
+++ b/tests/Feature/Table/KanbanContractTest.php
@@ -1,0 +1,346 @@
+<?php
+
+use Aura\Base\Fields\Select;
+use Aura\Base\Fields\Status;
+use Aura\Base\Fields\Text;
+use Aura\Base\Livewire\Table\Table;
+use Aura\Base\Resource;
+use Aura\Base\Resources\User;
+use Aura\Base\Support\KanbanConfiguration;
+use Illuminate\Support\Facades\Gate;
+
+use function Pest\Livewire\livewire;
+
+class Core07StatusBoardResource extends Resource
+{
+    public static ?string $slug = 'core07-status-board';
+
+    public static string $type = 'Core07StatusBoard';
+
+    public static function getFields(): array
+    {
+        return [
+            [
+                'name' => 'Title',
+                'slug' => 'title',
+                'type' => Text::class,
+            ],
+            [
+                'name' => 'Summary',
+                'slug' => 'content',
+                'type' => Text::class,
+            ],
+            [
+                'name' => 'Status',
+                'slug' => 'status',
+                'type' => Status::class,
+                'options' => [
+                    ['key' => 'draft', 'value' => 'Draft', 'color' => 'gray'],
+                    ['key' => 'reviewed', 'value' => 'Reviewed', 'color' => 'green'],
+                    ['key' => 'published', 'value' => 'Published', 'color' => 'blue'],
+                ],
+            ],
+        ];
+    }
+
+    public function kanbanSettings(): array
+    {
+        return [
+            'enabled' => true,
+            'group_field' => 'status',
+            'columns' => ['reviewed', 'draft', 'published'],
+            'card_title' => 'title',
+            'card_subtitle' => 'content',
+            'order_by' => ['field' => 'title', 'direction' => 'asc'],
+            'show_empty_columns' => true,
+        ];
+    }
+}
+
+class Core07StageBoardResource extends Resource
+{
+    public static ?string $slug = 'core07-stage-board';
+
+    public static string $type = 'Core07StageBoard';
+
+    public static function getFields(): array
+    {
+        return [
+            [
+                'name' => 'Title',
+                'slug' => 'title',
+                'type' => Text::class,
+            ],
+            [
+                'name' => 'Stage',
+                'slug' => 'content',
+                'type' => Select::class,
+                'options' => [
+                    'lead' => 'Lead',
+                    'won' => 'Won',
+                    'lost' => 'Lost',
+                ],
+            ],
+        ];
+    }
+
+    public function kanbanSettings(): array
+    {
+        return [
+            'enabled' => true,
+            'group_field' => 'content',
+            'columns' => ['lead', 'won'],
+            'card_title' => 'title',
+            'card_subtitle' => null,
+            'show_empty_columns' => true,
+        ];
+    }
+}
+
+class Core07ListOnlyResource extends Resource
+{
+    public static ?string $slug = 'core07-list-only';
+
+    public static string $type = 'Core07ListOnly';
+
+    public static function getFields(): array
+    {
+        return [
+            [
+                'name' => 'Title',
+                'slug' => 'title',
+                'type' => Text::class,
+            ],
+        ];
+    }
+}
+
+class Core07InvalidBoardResource extends Core07StatusBoardResource
+{
+    public static ?string $slug = 'core07-invalid-board';
+
+    public static string $type = 'Core07InvalidBoard';
+
+    public function kanbanSettings(): array
+    {
+        return array_replace(parent::kanbanSettings(), [
+            'columns' => ['draft', 'forged'],
+        ]);
+    }
+}
+
+class Core07DisabledBoardResource extends Core07StatusBoardResource
+{
+    public static ?string $slug = 'core07-disabled-board';
+
+    public static string $type = 'Core07DisabledBoard';
+
+    public function kanbanSettings(): array
+    {
+        return array_replace(parent::kanbanSettings(), [
+            'enabled' => false,
+        ]);
+    }
+}
+
+class Core07DenyUpdatePolicy
+{
+    public function update(User $user, Core07StageBoardResource $resource): bool
+    {
+        return false;
+    }
+}
+
+beforeEach(function () {
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+test('KanbanConfiguration resolves declared columns and disables invalid contracts', function () {
+    $valid = KanbanConfiguration::for(new Core07StatusBoardResource);
+    expect($valid['enabled'])->toBeTrue()
+        ->and($valid['valid'])->toBeTrue()
+        ->and(array_keys($valid['columns']))->toBe(['reviewed', 'draft', 'published'])
+        ->and($valid['group_field'])->toBe('status')
+        ->and($valid['card_title'])->toBe('title')
+        ->and($valid['card_subtitle'])->toBe('content')
+        ->and($valid['order_by'])->toBe(['field' => 'title', 'direction' => 'asc']);
+
+    $stage = KanbanConfiguration::for(new Core07StageBoardResource);
+    expect($stage['enabled'])->toBeTrue()
+        ->and(array_keys($stage['columns']))->toBe(['lead', 'won'])
+        ->and($stage['group_field'])->toBe('content');
+
+    $invalid = KanbanConfiguration::for(new Core07InvalidBoardResource);
+    expect($invalid['enabled'])->toBeFalse()
+        ->and($invalid['valid'])->toBeFalse()
+        ->and($invalid['columns'])->toBe([]);
+
+    $disabled = KanbanConfiguration::for(new Core07DisabledBoardResource);
+    expect($disabled['enabled'])->toBeFalse()
+        ->and($disabled['valid'])->toBeTrue();
+
+    $listOnly = KanbanConfiguration::for(new Core07ListOnlyResource);
+    expect($listOnly['enabled'])->toBeFalse();
+});
+
+test('Kanban renders declared columns and real resource card fields', function () {
+    Core07StatusBoardResource::create([
+        'title' => 'Zulu deal',
+        'content' => 'Created first',
+        'status' => 'draft',
+    ]);
+
+    Core07StatusBoardResource::create([
+        'title' => 'Alpha deal',
+        'content' => 'A real customer opportunity',
+        'status' => 'draft',
+    ]);
+
+    Core07StatusBoardResource::create([
+        'title' => 'Beta deal',
+        'content' => 'Already reviewed',
+        'status' => 'reviewed',
+    ]);
+
+    $component = livewire(Table::class, [
+        'model' => new Core07StatusBoardResource,
+        'settings' => ['default_view' => 'kanban'],
+    ]);
+
+    $component
+        ->assertSet('currentView', 'kanban')
+        ->assertSeeInOrder(['Reviewed', 'Draft', 'Published'])
+        ->assertSee('Alpha deal')
+        ->assertSee('A real customer opportunity')
+        ->assertSee('Beta deal')
+        ->assertSeeHtml('wire:key="kanban-card-');
+});
+
+test('Kanban uses the resource configured group field for rendering and mutation', function () {
+    $card = Core07StageBoardResource::create([
+        'title' => 'Qualified lead',
+        'content' => 'lead',
+        'status' => 'draft',
+    ]);
+
+    livewire(Table::class, [
+        'model' => new Core07StageBoardResource,
+        'settings' => ['default_view' => 'kanban'],
+    ])
+        ->assertSee('Qualified lead')
+        ->assertSeeInOrder(['Lead', 'Won'])
+        ->call('updateCardStatus', $card->getKey(), 'won')
+        ->assertHasNoErrors();
+
+    expect($card->fresh()->content)->toBe('won')
+        ->and($card->fresh()->status)->toBe('draft');
+});
+
+test('view switching persists only supported views and invalid preferences fall back safely', function () {
+    $resource = new Core07StatusBoardResource;
+
+    livewire(Table::class, ['model' => $resource])
+        ->call('switchView', 'kanban')
+        ->assertSet('currentView', 'kanban')
+        ->assertSeeHtml('aura-table-kanban-view');
+
+    expect($this->user->getOption('table_view.'.$resource->getType()))->toBe('kanban');
+
+    $this->user->updateOption('table_view.'.$resource->getType(), 'forged-view');
+
+    livewire(Table::class, ['model' => $resource])
+        ->assertSet('currentView', 'list')
+        ->assertSeeHtml('aura-table-list-view');
+
+    $listOnly = new Core07ListOnlyResource;
+    $this->user->updateOption('table_view.'.$listOnly->getType(), 'kanban');
+
+    livewire(Table::class, ['model' => $listOnly])
+        ->assertSet('currentView', 'list')
+        ->call('switchView', 'kanban')
+        ->assertSet('currentView', 'list');
+});
+
+test('saved Kanban preferences can only reorder and hide declared columns', function () {
+    $resource = new Core07StatusBoardResource;
+    $this->user->updateOption('kanban_statuses.'.$resource->getType(), [
+        'forged' => ['value' => 'Forged', 'visible' => true],
+        'draft' => ['value' => 'Forged Draft Label', 'visible' => false],
+        'reviewed' => ['visible' => true],
+    ]);
+
+    $component = livewire(Table::class, [
+        'model' => $resource,
+        'settings' => ['default_view' => 'kanban'],
+    ])->assertSet('kanbanStatuses', [
+        'draft' => ['value' => 'Draft', 'color' => 'gray', 'visible' => false],
+        'reviewed' => ['value' => 'Reviewed', 'color' => 'green', 'visible' => true],
+        'published' => ['value' => 'Published', 'color' => 'blue', 'visible' => true],
+    ]);
+
+    $component
+        ->call('reorderKanbanStatuses', 'published', 0)
+        ->assertSet('kanbanStatuses', [
+            'published' => ['value' => 'Published', 'color' => 'blue', 'visible' => true],
+            'draft' => ['value' => 'Draft', 'color' => 'gray', 'visible' => false],
+            'reviewed' => ['value' => 'Reviewed', 'color' => 'green', 'visible' => true],
+        ])
+        ->call('reorderKanbanStatuses', 'forged', 0)
+        ->assertStatus(422);
+});
+
+test('configured Kanban group mutation still enforces the resource policy', function () {
+    Gate::policy(Core07StageBoardResource::class, Core07DenyUpdatePolicy::class);
+    $card = Core07StageBoardResource::create([
+        'title' => 'Protected lead',
+        'content' => 'lead',
+        'status' => 'draft',
+    ]);
+
+    livewire(Table::class, [
+        'model' => new Core07StageBoardResource,
+        'settings' => ['default_view' => 'kanban'],
+    ])
+        ->call('updateCardStatus', $card->getKey(), 'won')
+        ->assertForbidden();
+
+    expect($card->fresh()->content)->toBe('lead');
+});
+
+test('Kanban mutations reject destinations excluded from the board contract', function () {
+    $card = Core07StageBoardResource::create([
+        'title' => 'Qualified lead',
+        'content' => 'lead',
+    ]);
+
+    livewire(Table::class, [
+        'model' => new Core07StageBoardResource,
+        'settings' => ['default_view' => 'kanban'],
+    ])
+        ->call('updateCardStatus', $card->getKey(), 'lost')
+        ->assertStatus(422);
+
+    expect($card->fresh()->content)->toBe('lead');
+});
+
+test('Kanban mutations reject disabled and invalid board contracts', function () {
+    $disabledCard = Core07DisabledBoardResource::create([
+        'title' => 'Disabled board card',
+        'status' => 'draft',
+    ]);
+    $invalidCard = Core07InvalidBoardResource::create([
+        'title' => 'Invalid board card',
+        'status' => 'draft',
+    ]);
+
+    livewire(Table::class, ['model' => new Core07DisabledBoardResource])
+        ->call('updateCardStatus', $disabledCard->getKey(), 'reviewed')
+        ->assertStatus(422);
+
+    livewire(Table::class, ['model' => new Core07InvalidBoardResource])
+        ->call('updateCardStatus', $invalidCard->getKey(), 'reviewed')
+        ->assertStatus(422);
+
+    expect($disabledCard->fresh()->status)->toBe('draft')
+        ->and($invalidCard->fresh()->status)->toBe('draft');
+});

--- a/tests/Feature/ThemeTokensTest.php
+++ b/tests/Feature/ThemeTokensTest.php
@@ -1,0 +1,258 @@
+<?php
+
+use Aura\Base\ThemeTokens;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Filesystem\Filesystem;
+
+test('theme token defaults expose the stable light and dark contract', function () {
+    expect(config('aura.theme.font'))->toBe([
+        'family' => [
+            'ui-sans-serif',
+            'system-ui',
+            'sans-serif',
+            'Apple Color Emoji',
+            'Segoe UI Emoji',
+            'Segoe UI Symbol',
+            'Noto Color Emoji',
+        ],
+        'stylesheet' => false,
+    ])->and(config('aura.theme.colors.light'))->toBe([
+        'primary' => 'var(--primary-600)',
+        'background' => '255 255 255',
+        'panel' => '250 250 250',
+        'border' => '228 228 231',
+        'text' => '24 24 27',
+        'muted' => '82 82 91',
+        'success' => '22 163 74',
+        'warning' => '217 119 6',
+        'danger' => '220 38 38',
+    ])->and(config('aura.theme.colors.dark'))->toBe([
+        'primary' => 'var(--primary-600)',
+        'background' => '9 9 11',
+        'panel' => '24 24 27',
+        'border' => '63 63 70',
+        'text' => '244 244 245',
+        'muted' => '161 161 170',
+        'success' => '22 163 74',
+        'warning' => '217 119 6',
+        'danger' => '220 38 38',
+    ]);
+});
+
+test('renderer emits the semantic variables for both color schemes', function () {
+    $html = view('aura::components.layout.colors', [
+        'settings' => ThemeTokens::resolve(),
+    ])->render();
+
+    expect($html)
+        ->toContain('--aura-font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";')
+        ->toContain('--aura-color-primary: var(--primary-600);')
+        ->toContain('--aura-color-background: 255 255 255;')
+        ->toContain('--aura-color-panel: 250 250 250;')
+        ->toContain('--aura-color-border: 228 228 231;')
+        ->toContain('--aura-color-text: 24 24 27;')
+        ->toContain('--aura-color-muted: 82 82 91;')
+        ->toContain('--aura-color-success: 22 163 74;')
+        ->toContain('--aura-color-warning: 217 119 6;')
+        ->toContain('--aura-color-danger: 220 38 38;')
+        ->toContain('.dark {')
+        ->toContain('--aura-color-background: 9 9 11;')
+        ->toContain('--aura-color-panel: 24 24 27;')
+        ->toContain('--aura-color-border: 63 63 70;')
+        ->toContain('--aura-color-text: 244 244 245;')
+        ->toContain('--aura-color-muted: 161 161 170;');
+});
+
+test('font family serializer removes only matching outer quote pairs', function (array|string $families, string $expected) {
+    expect(ThemeTokens::fontFamily([
+        'font' => ['family' => $families],
+    ]))->toBe($expected);
+})->with([
+    'matching double quote pair and surrounding whitespace' => [
+        ['  "Acme Sans"  ', ' system-ui '],
+        '"Acme Sans", system-ui',
+    ],
+    'matching single quote pair' => [
+        ["'Source Serif 4'", 'serif'],
+        '"Source Serif 4", serif',
+    ],
+    'embedded quotes' => [
+        ['Brand "Quoted"', 'sans-serif'],
+        '"Brand \"Quoted\"", sans-serif',
+    ],
+    'backslashes' => [
+        ['C:\\Fonts\\Acme', 'monospace'],
+        '"C:\\\\Fonts\\\\Acme", monospace',
+    ],
+    'unmatched opening quote' => [
+        ['"Brand Quoted', 'sans-serif'],
+        '"\"Brand Quoted", sans-serif',
+    ],
+    'unmatched closing quote' => [
+        ['Brand Quoted"', 'sans-serif'],
+        '"Brand Quoted\"", sans-serif',
+    ],
+    'mixed outer quotes' => [
+        ['"Brand Quoted\'', 'sans-serif'],
+        '"\"Brand Quoted\'", sans-serif',
+    ],
+    'exactly one matching outer pair' => [
+        ['""Acme Sans""', 'sans-serif'],
+        '"\"Acme Sans\"", sans-serif',
+    ],
+    'comma separated fallback list' => [
+        '  "Acme Sans"  ,  system-ui , sans-serif  ',
+        '"Acme Sans", system-ui, sans-serif',
+    ],
+]);
+
+test('renderer preserves quoted custom font names in the font CSS variable', function () {
+    $html = view('aura::components.layout.colors', [
+        'settings' => [
+            'font' => [
+                'family' => ['Brand "Quoted"', 'C:\\Fonts\\Acme', 'sans-serif'],
+            ],
+        ],
+    ])->render();
+
+    expect($html)->toContain(
+        '--aura-font-sans: "Brand \"Quoted\"", "C:\\\\Fonts\\\\Acme", sans-serif;',
+    );
+});
+
+test('host and stored settings override tokens without losing package defaults', function () {
+    config()->set('aura.theme', [
+        'color-palette' => 'emerald',
+        'font' => [
+            'family' => ['Atkinson Hyperlegible', 'sans-serif'],
+        ],
+        'colors' => [
+            'light' => [
+                'primary' => '1 2 3',
+            ],
+        ],
+    ]);
+
+    $theme = ThemeTokens::resolve([
+        'colors' => [
+            'dark' => [
+                'panel' => '4 5 6',
+            ],
+        ],
+    ]);
+
+    expect($theme['color-palette'])->toBe('emerald')
+        ->and(ThemeTokens::fontFamily($theme))->toBe('"Atkinson Hyperlegible", sans-serif')
+        ->and(ThemeTokens::colors($theme, 'light')['primary'])->toBe('1 2 3')
+        ->and(ThemeTokens::colors($theme, 'light')['background'])->toBe('255 255 255')
+        ->and(ThemeTokens::colors($theme, 'dark')['panel'])->toBe('4 5 6')
+        ->and(ThemeTokens::colors($theme, 'dark')['danger'])->toBe('220 38 38');
+});
+
+test('font stylesheet is absent by default and accepts only a local asset path', function () {
+    $defaultHtml = view('aura::components.layout.styles', ['settings' => []])->render();
+    $localHtml = view('aura::components.layout.styles', [
+        'settings' => [
+            'font' => [
+                'family' => ['Acme Sans', 'sans-serif'],
+                'stylesheet' => 'fonts/acme-sans.css',
+            ],
+        ],
+    ])->render();
+
+    expect($defaultHtml)
+        ->not->toContain('inter.css')
+        ->not->toContain('fonts.googleapis.com')
+        ->not->toContain('fonts.gstatic.com')
+        ->and($localHtml)
+        ->toContain('href="http://localhost/fonts/acme-sans.css"')
+        ->toContain('--aura-font-sans: "Acme Sans", sans-serif;');
+
+    foreach (['https://fonts.example.com/theme.css', '//fonts.example.com/theme.css', 'data:text/css,body{}'] as $remoteStylesheet) {
+        $html = view('aura::components.layout.styles', [
+            'settings' => [
+                'font' => [
+                    'stylesheet' => $remoteStylesheet,
+                ],
+            ],
+        ])->render();
+
+        expect($html)->not->toContain($remoteStylesheet);
+    }
+});
+
+test('active views and host scaffold have no fixed Inter dependency', function () {
+    $packagePath = dirname(__DIR__, 2);
+    $files = [
+        $packagePath.'/resources/views/components/layout/styles.blade.php',
+        $packagePath.'/resources/views/components/widgets/bar.blade.php',
+        $packagePath.'/resources/views/livewire/styleguide.blade.php',
+        $packagePath.'/stubs/scaffold/views/components/layout/app.blade.php',
+    ];
+
+    foreach ($files as $file) {
+        expect(file_get_contents($file))
+            ->not->toContain("'Inter'")
+            ->not->toContain('/inter.css')
+            ->not->toContain('Font family: Inter');
+    }
+});
+
+test('renderer rejects malformed token values', function () {
+    $theme = ThemeTokens::resolve([
+        'font' => [
+            'family' => ['</style><script>alert(1)</script>'],
+        ],
+        'colors' => [
+            'light' => [
+                'text' => '999 0 0',
+                'danger' => 'red; background: url(https://example.com)',
+            ],
+        ],
+    ]);
+
+    expect(ThemeTokens::fontFamily($theme))->toBe(
+        'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+    )->and(ThemeTokens::colors($theme, 'light')['text'])->toBe('24 24 27')
+        ->and(ThemeTokens::colors($theme, 'light')['danger'])->toBe('220 38 38');
+});
+
+test('theme token configuration can be cached', function () {
+    $filesystem = new Filesystem;
+    $basePath = sys_get_temp_dir().'/aura-theme-config-cache-'.bin2hex(random_bytes(8));
+    $filesystem->makeDirectory($basePath.'/bootstrap/cache', 0755, true);
+    $filesystem->makeDirectory($basePath.'/storage/framework/cache/data', 0755, true);
+    $filesystem->makeDirectory($basePath.'/storage/framework/sessions', 0755, true);
+    $filesystem->makeDirectory($basePath.'/storage/framework/views', 0755, true);
+    $filesystem->makeDirectory($basePath.'/storage/logs', 0755, true);
+    $filesystem->put($basePath.'/bootstrap/app.php', <<<'PHP'
+<?php
+
+use Aura\Base\AuraServiceProvider;
+use Illuminate\Foundation\Application;
+use Livewire\LivewireServiceProvider;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withProviders([
+        LivewireServiceProvider::class,
+        AuraServiceProvider::class,
+    ])
+    ->create();
+PHP);
+
+    try {
+        $application = require $basePath.'/bootstrap/app.php';
+        $exitCode = $application->make(Kernel::class)->call('config:cache', [
+            '--no-interaction' => true,
+        ]);
+        $cachedConfiguration = require $application->getCachedConfigPath();
+
+        expect($exitCode)->toBe(0)
+            ->and($cachedConfiguration['aura']['theme']['colors']['light']['primary'])
+            ->toBe('var(--primary-600)')
+            ->and($cachedConfiguration['aura']['theme']['font']['stylesheet'])
+            ->toBeFalse();
+    } finally {
+        $filesystem->deleteDirectory($basePath);
+    }
+});

--- a/tests/Fixtures/RecordLayout/SecondPanel.php
+++ b/tests/Fixtures/RecordLayout/SecondPanel.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Aura\Base\Tests\Fixtures\RecordLayout;
+
+class SecondPanel extends TestPanel {}

--- a/tests/Fixtures/RecordLayout/TestPanel.php
+++ b/tests/Fixtures/RecordLayout/TestPanel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Aura\Base\Tests\Fixtures\RecordLayout;
+
+use Aura\Base\Resource;
+use Livewire\Component;
+
+class TestPanel extends Component
+{
+    public bool $inModal = false;
+
+    public Resource $model;
+
+    public function render(): string
+    {
+        return '<section data-test-record-panel="'.e(static::class).'" data-modal="'.($this->inModal ? 'true' : 'false').'">'
+            .e($this->model->title()).'</section>';
+    }
+}

--- a/tests/Fixtures/RecordLayout/ThirdPanel.php
+++ b/tests/Fixtures/RecordLayout/ThirdPanel.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Aura\Base\Tests\Fixtures\RecordLayout;
+
+class ThirdPanel extends TestPanel {}


### PR DESCRIPTION
## Summary

Follow-up to [#75](https://github.com/eminiarts/aura-cms/pull/75): land the **high-value security contracts** from the mega-branch inventory without the multi-kLOC fortress.

**~+300 / −100** in core wiring (plus small new classes/tests), not a 2.7k dispatcher + MediaSecurityStore port.

### Media
- `MediaAuthorization` — `applyAttachmentVisibility`, `authorizeAttachments`, create auth
- `ResourcePolicy::scopeMediaVisibility` (+ `ScopesMediaVisibility` contract)
- `MediaManager` — no more `Attachment::pluck('id')` leak; authorize selection
- `MediaUploader` — authorize **create on upload** (not mount, so forms with image fields still open for users without create-attachment)
- `Attachment` delete paths require `Gate`

### Table mutations
- New `TableMutationAuthorizer` (~200 LOC): **declare → ability → exact keys in table scope → per-record Gate**
- Bulk + row `action()` + bulk modal use it
- Fail closed when a forged ID is mixed into a valid selection
- Explicit `ability` on Attachment/Role actions

### Explicitly excluded (still from #74 mega-branch)
- `MediaSecurityStore` / reflection cache fortress
- Selection request/ack brokers
- Process-isolated global search
- Full `TableMutationDispatcher` query AST sealing / locks

## Test plan

- [x] `vendor/bin/pest --no-coverage tests/Feature/Media/ tests/Feature/Security/`
- [x] **176 passed** (450 assertions)
- [ ] CI green

## Base

Stacks on `agent/cherry-pick-pr74-goods` (PR #75). Can retarget to `main` after #75 merges.