### PR TITLE
Add explicit queued Team execution context

### DIFF
--- a/src/Models/Scopes/TeamScope.php
+++ b/src/Models/Scopes/TeamScope.php
@@ -4,6 +4,7 @@ namespace Aura\Base\Models\Scopes;
 
 use Aura\Base\Resources\Role;
 use Aura\Base\Resources\User;
+use Aura\Base\Support\TeamExecutionContext;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
@@ -116,6 +117,7 @@ class TeamScope implements Scope
     public static function flushState(): void
     {
         self::$applying = false;
+        TeamExecutionContext::clear();
     }
 
     /**
@@ -125,6 +127,10 @@ class TeamScope implements Scope
      */
     private function getCurrentTeamId()
     {
+        if (TeamExecutionContext::active()) {
+            return TeamExecutionContext::currentTeamId();
+        }
+
         if (! Auth::check()) {
             return;
         }

--- a/src/Support/TeamExecutionContext.php
+++ b/src/Support/TeamExecutionContext.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Aura\Base\Support;
+
+use Aura\Base\Resources\User;
+use Closure;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use InvalidArgumentException;
+
+/**
+ * Installs an explicit Team and actor for a request or queued unit of work.
+ *
+ * The context never changes the user's persisted current_team_id. It is a
+ * stack so nested operations restore their caller, and every mutation is
+ * unwound in finally to remain safe in queue workers and long-lived runtimes.
+ */
+class TeamExecutionContext
+{
+    /** @var array<int, array{team_id: int, actor: mixed}> */
+    private static array $stack = [];
+
+    public static function active(): bool
+    {
+        return self::$stack !== [];
+    }
+
+    public static function actor(): mixed
+    {
+        return data_get(self::$stack, array_key_last(self::$stack).'.actor');
+    }
+
+    public static function clear(): void
+    {
+        self::$stack = [];
+    }
+
+    public static function currentTeamId(): ?int
+    {
+        $teamId = data_get(self::$stack, array_key_last(self::$stack).'.team_id');
+
+        return is_numeric($teamId) ? (int) $teamId : null;
+    }
+
+    public function run(int|string|null $teamId, mixed $actor, Closure $callback): mixed
+    {
+        if (! config('aura.teams')) {
+            return $callback();
+        }
+
+        if (! is_numeric($teamId) || (int) $teamId < 1) {
+            throw new InvalidArgumentException('A valid Team is required for explicit Team execution.');
+        }
+
+        if (! $actor instanceof Model || ! $actor instanceof Authenticatable) {
+            throw new AuthorizationException('A persisted Aura actor is required for explicit Team execution.');
+        }
+
+        $teamId = (int) $teamId;
+        $actorId = $actor->getAuthIdentifier();
+
+        if (! $actorId || ! DB::table('teams')->where('id', $teamId)->exists()) {
+            throw new AuthorizationException('The Team execution context is unavailable.');
+        }
+
+        $globalAdmin = Gate::forUser($actor)->allows(User::GLOBAL_ADMIN_GATE);
+        $member = DB::table('user_role')
+            ->where('team_id', $teamId)
+            ->where('user_id', $actorId)
+            ->exists();
+
+        if (! $globalAdmin && ! $member) {
+            throw new AuthorizationException('The actor is no longer a member of this Team.');
+        }
+
+        $guard = Auth::guard();
+        $previousActor = $guard->user();
+        $previousTeamId = $actor->getAttribute('current_team_id');
+        $hadCurrentTeamRelation = method_exists($actor, 'relationLoaded') && $actor->relationLoaded('currentTeam');
+        $previousCurrentTeam = $hadCurrentTeamRelation ? $actor->getRelation('currentTeam') : null;
+
+        self::$stack[] = ['team_id' => $teamId, 'actor' => $actor];
+        $actor->setAttribute('current_team_id', $teamId);
+
+        if (method_exists($actor, 'unsetRelation')) {
+            $actor->unsetRelation('currentTeam');
+        }
+
+        $guard->setUser($actor);
+
+        try {
+            return $callback();
+        } finally {
+            array_pop(self::$stack);
+            $actor->setAttribute('current_team_id', $previousTeamId);
+
+            if ($hadCurrentTeamRelation && method_exists($actor, 'setRelation')) {
+                $actor->setRelation('currentTeam', $previousCurrentTeam);
+            } elseif (method_exists($actor, 'unsetRelation')) {
+                $actor->unsetRelation('currentTeam');
+            }
+
+            if ($previousActor) {
+                $guard->setUser($previousActor);
+            } else {
+                $guard->forgetUser();
+            }
+        }
+    }
+}

--- a/src/Traits/InitialPostFields.php
+++ b/src/Traits/InitialPostFields.php
@@ -3,6 +3,7 @@
 namespace Aura\Base\Traits;
 
 use Aura\Base\Resources\User;
+use Aura\Base\Support\TeamExecutionContext;
 use Illuminate\Support\Str;
 
 trait InitialPostFields
@@ -34,7 +35,9 @@ trait InitialPostFields
         }
 
         if (config('aura.teams') && ! isset($post->team_id) && auth()->user()) {
-            $post->team_id = auth()->user()->current_team_id;
+            $post->team_id = TeamExecutionContext::active()
+                ? TeamExecutionContext::currentTeamId()
+                : auth()->user()->current_team_id;
         }
 
         if (! $post->type && ! $post::usesCustomTable()) {

--- a/tests/Feature/TeamExecutionContextTest.php
+++ b/tests/Feature/TeamExecutionContextTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Aura\Base\Support\TeamExecutionContext;
+use Aura\Base\Tests\Resources\Post;
+use Illuminate\Auth\Access\AuthorizationException;
+
+beforeEach(function () {
+    if (! config('aura.teams')) {
+        $this->markTestSkipped('Explicit Team execution is a Teams-on seam.');
+    }
+});
+
+test('explicit execution scopes queries and restores actor and Team after exceptions', function () {
+    $requestActor = createSuperAdmin();
+    $teamA = $requestActor->currentTeam;
+    $teamB = Team::factory()->createQuietly(['user_id' => $requestActor->id]);
+    $queuedActor = User::factory()->create();
+    $role = Role::firstOrCreateGlobalAdmin();
+    $queuedActor->roles()->attach($role->id, ['team_id' => $teamA->id]);
+    $queuedActor->roles()->attach($role->id, ['team_id' => $teamB->id]);
+    $queuedActor->forceFill(['current_team_id' => $teamB->id])->saveQuietly();
+
+    Post::withoutEvents(function () use ($requestActor, $teamA, $teamB): void {
+        Post::create(['title' => 'Team A', 'type' => Post::$type, 'user_id' => $requestActor->id, 'team_id' => $teamA->id]);
+        Post::create(['title' => 'Team B', 'type' => Post::$type, 'user_id' => $requestActor->id, 'team_id' => $teamB->id]);
+    });
+
+    expect(fn () => app(TeamExecutionContext::class)->run($teamA->id, $queuedActor, function () use ($queuedActor, $teamA): void {
+        expect(auth()->id())->toBe($queuedActor->id)
+            ->and(TeamExecutionContext::active())->toBeTrue()
+            ->and(TeamExecutionContext::currentTeamId())->toBe($teamA->id)
+            ->and($queuedActor->current_team_id)->toBe($teamA->id)
+            ->and(Post::query()->pluck('title')->all())->toBe(['Team A']);
+
+        throw new RuntimeException('queue failure');
+    }))->toThrow(RuntimeException::class, 'queue failure');
+
+    expect(auth()->id())->toBe($requestActor->id)
+        ->and(TeamExecutionContext::active())->toBeFalse()
+        ->and(TeamExecutionContext::currentTeamId())->toBeNull()
+        ->and($queuedActor->current_team_id)->toBe($teamB->id)
+        ->and(User::withoutGlobalScopes()->findOrFail($queuedActor->id)->current_team_id)->toBe($teamB->id);
+});
+
+test('explicit execution rechecks membership before invoking queued work', function () {
+    $owner = createSuperAdmin();
+    $team = $owner->currentTeam;
+    $recipient = soleMemberOf($team);
+    $recipient->roles()->detach();
+    $invoked = false;
+
+    expect(fn () => app(TeamExecutionContext::class)->run($team->id, $recipient, function () use (&$invoked): void {
+        $invoked = true;
+    }))->toThrow(AuthorizationException::class);
+
+    expect($invoked)->toBeFalse()
+        ->and(TeamExecutionContext::active())->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- add an explicit Team and actor execution context for requests and queued jobs
- make TeamScope and initial post fields honor the explicit context
- recheck Team existence and actor membership while preserving global-admin behavior
- restore actor, Team state, and loaded relations even after exceptions

## Why
Aura Reports schedules recipient-specific report execution. Queue workers cannot safely rely on mutable current_team_id state, so the plugin needs a narrow core seam that installs an explicit Team context without persisting it.

## Verification
- Pint: passed
- PHPStan (changed source): no errors
- Pest: 2 tests, 15 assertions passed
- Tested with Laravel 13.25 / Testbench 11 in a clean worktree

Related Teamwork task: https://eminiartsgmbh.eu.teamwork.com/app/tasks/17800632