### PR TITLE
Slim media IDOR + table mutation auth (follow-up to #75)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -616,12 +616,6 @@ parameters:
 			path: src/Livewire/Table/Table.php
 
 		-
-			message: '#^Access to an undefined property Aura\\Base\\Livewire\\Table\\Table\:\:\$selectedRowsQuery\.$#'
-			identifier: property.notFound
-			count: 5
-			path: src/Livewire/Table/Table.php
-
-		-
 			message: '#^Access to an undefined property Aura\\Base\\Livewire\\Table\\Table\:\:\$userFilters\.$#'
 			identifier: property.notFound
 			count: 2

--- a/src/AuraServiceProvider.php
+++ b/src/AuraServiceProvider.php
@@ -32,6 +32,7 @@ use Aura\Base\Livewire\CreateResource;
 use Aura\Base\Livewire\EditResourceField;
 use Aura\Base\Livewire\GlobalSearch;
 use Aura\Base\Livewire\InviteUser;
+use Aura\Base\Livewire\Media\MediaAuthorization;
 use Aura\Base\Livewire\MediaManager;
 use Aura\Base\Livewire\MediaUploader;
 use Aura\Base\Livewire\Modals;
@@ -418,6 +419,7 @@ class AuraServiceProvider extends PackageServiceProvider
         $this->app->singleton(LivewireCollisionInspector::class, ArrayLivewireCollisionInspector::class);
         $this->app->singleton(RecordLayoutRegistry::class);
         $this->app->singleton(RecordLayoutResolver::class);
+        $this->app->singleton(MediaAuthorization::class);
 
         $this->app->scoped('aura', function (): Aura {
             return app(Aura::class);

--- a/src/Contracts/ScopesMediaVisibility.php
+++ b/src/Contracts/ScopesMediaVisibility.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Aura\Base\Contracts;
+
+use Aura\Base\Resource;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Builder;
+
+interface ScopesMediaVisibility
+{
+    public function scopeMediaVisibility(
+        Builder $query,
+        Authenticatable $actor,
+        Resource $resource,
+    ): Builder;
+}

--- a/src/Livewire/Media/InvalidMediaOwnerContext.php
+++ b/src/Livewire/Media/InvalidMediaOwnerContext.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Aura\Base\Livewire\Media;
+
+use RuntimeException;
+
+class InvalidMediaOwnerContext extends RuntimeException {}

--- a/src/Livewire/Media/MediaAuthorization.php
+++ b/src/Livewire/Media/MediaAuthorization.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Aura\Base\Livewire\Media;
+
+use Aura\Base\Contracts\ScopesMediaVisibility;
+use Aura\Base\Resource;
+use Aura\Base\Resources\Attachment;
+use Illuminate\Contracts\Auth\Access\Gate;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use InvalidArgumentException;
+use ReflectionClass;
+
+/**
+ * Lightweight media authorization for attachment visibility and selection.
+ *
+ * Intentionally excludes owner-token brokers, selection state machines, and
+ * cache/PDO identity fortresses from the experimental mega-branch.
+ */
+class MediaAuthorization
+{
+    public function __construct(
+        private readonly Gate $gate,
+        private readonly Guard $guard,
+    ) {}
+
+    public function applyAttachmentVisibility(Builder $query, Authenticatable $actor): Builder
+    {
+        $this->assertCurrentActor($actor);
+        $prototype = $this->attachmentPrototype();
+        $actorGate = $this->gate->forUser($actor);
+        $actorGate->authorize('viewAny', $prototype);
+        $policy = $this->gate->getPolicyFor($prototype);
+
+        if (! $policy instanceof ScopesMediaVisibility) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $policy->scopeMediaVisibility($query, $actor, $prototype);
+    }
+
+    public function authorizeAttachmentCreate(Authenticatable $actor): Resource
+    {
+        $this->assertCurrentActor($actor);
+        $attachment = $this->attachmentPrototype();
+        $this->gate->forUser($actor)->authorize('create', $attachment);
+
+        return $attachment;
+    }
+
+    /**
+     * @param  list<int|string>  $ids
+     * @return Collection<int, resource>
+     */
+    public function authorizeAttachments(array $ids, Authenticatable $actor): Collection
+    {
+        $this->assertCurrentActor($actor);
+        $normalized = $this->normalizeIds($ids);
+        $prototype = $this->attachmentPrototype();
+        $actorGate = $this->gate->forUser($actor);
+
+        if ($normalized === []) {
+            $actorGate->authorize('viewAny', $prototype);
+
+            return new Collection;
+        }
+
+        $attachmentClass = $prototype::class;
+        $query = $this->applyAttachmentVisibility($attachmentClass::query(), $actor);
+        $found = $query->whereKey($normalized)->get()
+            ->keyBy(fn (Resource $attachment): string => (string) $attachment->getKey());
+
+        if ($found->count() !== count($normalized)) {
+            throw new InvalidMediaOwnerContext('One or more media attachments are unavailable.');
+        }
+
+        $ordered = new Collection;
+
+        foreach ($normalized as $id) {
+            $attachment = $found->get($id);
+
+            if (! $attachment instanceof Resource) {
+                throw new InvalidMediaOwnerContext('One or more media attachments are unavailable.');
+            }
+
+            $actorGate->authorize('view', $attachment);
+            $ordered->push($attachment);
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * @param  Collection<int, resource>  $attachments
+     * @return Collection<int, resource>
+     */
+    public function visibleAttachments(Collection $attachments, Authenticatable $actor): Collection
+    {
+        $this->assertCurrentActor($actor);
+        $prototype = $this->attachmentPrototype();
+        $actorGate = $this->gate->forUser($actor);
+        $actorGate->authorize('viewAny', $prototype);
+
+        return $attachments
+            ->filter(function ($attachment) use ($actorGate, $prototype): bool {
+                if (! $attachment instanceof Resource || $attachment::class !== $prototype::class) {
+                    throw new InvalidMediaOwnerContext('The media attachment listing is invalid.');
+                }
+
+                return $actorGate->allows('view', $attachment);
+            })
+            ->values();
+    }
+
+    private function assertCurrentActor(Authenticatable $actor): void
+    {
+        $current = $this->guard->user();
+
+        if (! $current instanceof Authenticatable
+            || (string) $current->getAuthIdentifier() !== (string) $actor->getAuthIdentifier()) {
+            throw new InvalidMediaOwnerContext('The authenticated media actor changed.');
+        }
+    }
+
+    private function attachmentPrototype(): Resource
+    {
+        $attachmentClass = config('aura.resources.attachment', Attachment::class);
+
+        if (! is_string($attachmentClass) || ! class_exists($attachmentClass)
+            || ! is_subclass_of($attachmentClass, Resource::class)
+            || (new ReflectionClass($attachmentClass))->getName() !== ltrim($attachmentClass, '\\')) {
+            throw new InvalidMediaOwnerContext('The configured attachment resource is invalid.');
+        }
+
+        $attachment = app($attachmentClass);
+
+        if (! $attachment instanceof Resource) {
+            throw new InvalidMediaOwnerContext('The configured attachment resource is unavailable.');
+        }
+
+        return $attachment;
+    }
+
+    /**
+     * @param  list<int|string>  $ids
+     * @return list<string>
+     */
+    private function normalizeIds(array $ids): array
+    {
+        if (! array_is_list($ids)) {
+            throw new InvalidArgumentException('Media attachment IDs must be a list.');
+        }
+
+        $normalized = [];
+
+        foreach ($ids as $id) {
+            if ((! is_int($id) && ! is_string($id)) || (string) $id === '') {
+                throw new InvalidArgumentException('Media attachment IDs must contain non-empty integer or string values.');
+            }
+
+            $normalized[] = (string) $id;
+        }
+
+        if (count($normalized) !== count(array_unique($normalized, SORT_STRING))) {
+            throw new InvalidArgumentException('Media attachment IDs must not contain duplicates.');
+        }
+
+        return $normalized;
+    }
+}

--- a/src/Livewire/MediaManager.php
+++ b/src/Livewire/MediaManager.php
@@ -2,7 +2,8 @@
 
 namespace Aura\Base\Livewire;
 
-use Aura\Base\Resources\Attachment;
+use Aura\Base\Livewire\Media\MediaAuthorization;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
@@ -18,7 +19,7 @@ class MediaManager extends Component
 
     public $model;
 
-    public $rowIds = []; // Add this line
+    public $rowIds = [];
 
     public $selected = [];
 
@@ -27,47 +28,55 @@ class MediaManager extends Component
         return 'max-w-7xl';
     }
 
-    public function mount($slug, $selected, $modalAttributes)
+    public function mount($slug, $selected, $modalAttributes = null)
     {
-        $this->selected = $selected;
+        $user = Auth::user();
+
+        if (! $user) {
+            abort(403);
+        }
+
+        $this->selected = collect($selected ?? [])
+            ->map(fn ($id) => (string) $id)
+            ->values()
+            ->toArray();
         $this->fieldSlug = $slug;
         $this->modalAttributes = $modalAttributes;
         $this->field = app($this->model)->fieldBySlug($this->fieldSlug);
-        $this->rowIds = Attachment::pluck('id')->toArray(); // Add this line to populate rowIds
+        $this->rowIds = [];
+
+        app(MediaAuthorization::class)->authorizeAttachments($this->selected, $user);
     }
 
     public function render()
     {
-        return view('aura::livewire.media-manager', [
-            'rows' => Attachment::paginate(25), // Adjust the number as needed
-        ]);
+        return view('aura::livewire.media-manager');
     }
 
     public function select($selectedValues = null)
     {
-        // Use passed values from Alpine if available (more reliable than entangle sync)
-        // Ensure we have an array of strings for consistency
+        $user = Auth::user();
+
+        if (! $user) {
+            abort(403);
+        }
+
         $selected = collect($selectedValues ?? $this->selected)
             ->map(fn ($id) => (string) $id)
             ->values()
             ->toArray();
 
-        // Dispatch the updateField event globally to ALL Livewire components
-        // Use named parameter 'data' to match the listener's signature: updateField($data)
+        app(MediaAuthorization::class)->authorizeAttachments($selected, $user);
+
         $this->dispatch('updateField', data: [
             'slug' => $this->fieldSlug,
             'value' => $selected,
         ]);
-
-        // NOTE: Do NOT dispatch closeModal here!
-        // The modal must be closed from Alpine AFTER this Livewire call completes
-        // Otherwise the component is destroyed while events are still being processed
     }
 
     #[On('selectedRows')]
     public function selectAttachment($ids)
     {
-        // Only sync initial selection, not ongoing changes to prevent circular updates
         if (! $this->initialSelectionDone) {
             $this->selected = collect($ids)->map(fn ($id) => (string) $id)->values()->toArray();
             $this->initialSelectionDone = true;
@@ -77,23 +86,17 @@ class MediaManager extends Component
     #[On('tableMounted')]
     public function tableMounted()
     {
-        // Sync initial selection to the table when it mounts
         if ($this->selected && ! $this->initialSelectionDone) {
             $this->dispatch('selectedRows', collect($this->selected)->map(fn ($id) => (string) $id)->values()->toArray());
             $this->initialSelectionDone = true;
         }
     }
 
-    // Removed updated() method to prevent circular updates
-    // The entangle directive handles syncing automatically
-
     #[On('updateField')]
     public function updateField($data)
     {
-        // Only update if this is our field
         if ($data['slug'] == $this->fieldSlug) {
             $this->selected = collect($data['value'])->map(fn ($id) => (string) $id)->values()->toArray();
-            // Don't dispatch selectedRows here to prevent circular updates
         }
     }
 }

--- a/src/Livewire/MediaUploader.php
+++ b/src/Livewire/MediaUploader.php
@@ -2,7 +2,9 @@
 
 namespace Aura\Base\Livewire;
 
+use Aura\Base\Livewire\Media\MediaAuthorization;
 use Aura\Base\Resources\Attachment;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
 use Livewire\Attributes\On;
@@ -50,6 +52,18 @@ class MediaUploader extends Component
     public function mount(): void
     {
         $this->model = app($this->namespace);
+
+        $user = Auth::user();
+
+        // Only re-check existing selected IDs on mount. Create is authorized at
+        // upload time so forms that embed the uploader without create rights
+        // (e.g. user edit with an image field) can still open.
+        if ($user && is_array($this->selected) && $this->selected !== []) {
+            app(MediaAuthorization::class)->authorizeAttachments(
+                array_values($this->selected),
+                $user,
+            );
+        }
     }
 
     public function render(): View
@@ -75,6 +89,14 @@ class MediaUploader extends Component
             'message' => '',
             'ids' => [],
         ];
+
+        $user = Auth::user();
+
+        if (! $user) {
+            abort(403);
+        }
+
+        app(MediaAuthorization::class)->authorizeAttachmentCreate($user);
 
         try {
             $this->validate([

--- a/src/Livewire/Table/Table.php
+++ b/src/Livewire/Table/Table.php
@@ -140,18 +140,37 @@ class Table extends Component
 
     public function action($data)
     {
-        // return redirect to post view
-        if ($data['action'] == 'view') {
-            return redirect()->route('aura.'.$this->model()->getSlug().'.view', ['id' => $data['id']]);
-        }
-        // edit
-        if ($data['action'] == 'edit') {
-            return redirect()->route('aura.'.$this->model()->getSlug().'.edit', ['id' => $data['id']]);
+        $action = $data['action'] ?? null;
+        $id = $data['id'] ?? null;
+
+        if (! is_string($action) || $action === '' || $id === null || $id === '') {
+            abort(422, 'Invalid table action.');
         }
 
-        if (method_exists($this->model, $data['action'])) {
-            return $this->model()->find($data['id'])->{$data['action']}();
+        if ($action === 'view' || $action === 'edit') {
+            $record = (clone $this->query())->whereKey($id)->firstOrFail();
+            Gate::authorize(
+                $action === 'view' ? 'view' : 'update',
+                $record,
+            );
+
+            $route = $action === 'view' ? 'view' : 'edit';
+
+            return redirect()->route('aura.'.$this->model()->getSlug().'.'.$route, ['id' => $record->getKey()]);
         }
+
+        $record = app(TableMutationAuthorizer::class)->authorizeRow(
+            scope: clone $this->query(),
+            id: $id,
+            action: $action,
+            declared: $this->normalizedRowActions(),
+        );
+
+        if (! method_exists($record, $action)) {
+            abort(403, 'This action is not allowed.');
+        }
+
+        return $record->{$action}();
     }
 
     public function allTableRows()
@@ -328,9 +347,17 @@ class Table extends Component
 
     public function openBulkActionModal($action, $data)
     {
+        $records = app(TableMutationAuthorizer::class)->authorizeBulk(
+            scope: clone $this->query(),
+            action: $action,
+            declared: (array) $this->getBulkActionsProperty(),
+            selected: $this->selected,
+            selectAll: (bool) $this->selectAll,
+        );
+
         $this->dispatch('openModal', $data['modal'], [
             'action' => $action,
-            'selected' => $this->selectedRowsQuery->pluck('id'),
+            'selected' => $records->map(fn ($record) => $record->getKey())->values()->all(),
             'model' => get_class($this->model),
         ]);
     }
@@ -544,6 +571,34 @@ class Table extends Component
         } else {
             $this->dispatch('selectedRows', $this->selected);
         }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function normalizedRowActions(): array
+    {
+        $actions = $this->model->getActions();
+
+        if (! is_array($actions)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($actions as $key => $definition) {
+            if (is_int($key) && is_string($definition)) {
+                $normalized[$definition] = ['ability' => $definition];
+
+                continue;
+            }
+
+            if (is_string($key)) {
+                $normalized[$key] = $definition;
+            }
+        }
+
+        return $normalized;
     }
 
     /**

--- a/src/Livewire/Table/TableMutationAuthorizer.php
+++ b/src/Livewire/Table/TableMutationAuthorizer.php
@@ -35,7 +35,7 @@ final class TableMutationAuthorizer
     ) {}
 
     /**
-     * @param  array<string, mixed>  $declared
+     * @param  array<string, mixed>|string  $definition
      */
     public function abilityFor(string $action, mixed $definition): string
     {

--- a/src/Livewire/Table/TableMutationAuthorizer.php
+++ b/src/Livewire/Table/TableMutationAuthorizer.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Aura\Base\Livewire\Table;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use InvalidArgumentException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Small auth contract for table row/bulk mutations.
+ *
+ * declare → ability → exact keys in table scope → per-record Gate
+ *
+ * Does not include query AST sealing, lock retries, or signed downloads.
+ */
+final class TableMutationAuthorizer
+{
+    private const DEFAULT_ABILITIES = [
+        'delete' => 'delete',
+        'deleteAttachment' => 'delete',
+        'deleteSelected' => 'delete',
+        'forceDelete' => 'forceDelete',
+        'restore' => 'restore',
+        'update' => 'update',
+        'view' => 'view',
+        'edit' => 'update',
+    ];
+
+    public function __construct(
+        private readonly int $maxSelection = 500,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $declared
+     */
+    public function abilityFor(string $action, mixed $definition): string
+    {
+        if (is_array($definition) && array_key_exists('ability', $definition)) {
+            $ability = $definition['ability'];
+
+            if (! is_string($ability) || $ability === '') {
+                throw ValidationException::withMessages([
+                    'action' => 'Bulk action ability must be a non-empty string.',
+                ]);
+            }
+
+            return $ability;
+        }
+
+        if (isset(self::DEFAULT_ABILITIES[$action])) {
+            return self::DEFAULT_ABILITIES[$action];
+        }
+
+        // Fail closed: custom actions must declare an ability explicitly.
+        throw ValidationException::withMessages([
+            'action' => "Action [{$action}] must declare an ability.",
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $declared
+     * @return array<string, mixed>|string
+     */
+    public function assertDeclared(string $action, array $declared): mixed
+    {
+        if (! array_key_exists($action, $declared)) {
+            throw new HttpException(403, 'This action is not allowed.');
+        }
+
+        return $declared[$action];
+    }
+
+    /**
+     * @param  array<string, mixed>  $declared
+     * @param  list<int|string>|null  $selected
+     * @return Collection<int, Model>
+     */
+    public function authorizeBulk(
+        Builder $scope,
+        string $action,
+        array $declared,
+        ?array $selected,
+        bool $selectAll = false,
+    ): Collection {
+        $definition = $this->assertDeclared($action, $declared);
+        $ability = $this->abilityFor($action, $definition);
+        $records = $this->resolveExactSelection($scope, $selected, $selectAll);
+        $this->authorizeEach($records, $ability);
+
+        return $records;
+    }
+
+    /**
+     * @param  Collection<int, Model>  $records
+     */
+    public function authorizeEach(Collection $records, string $ability): void
+    {
+        foreach ($records as $record) {
+            Gate::authorize($ability, $record);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $declared
+     */
+    public function authorizeRow(
+        Builder $scope,
+        int|string $id,
+        string $action,
+        array $declared,
+    ): Model {
+        $definition = $this->assertDeclared($action, $declared);
+        $ability = $this->abilityFor($action, $definition);
+        $records = $this->resolveExactSelection($scope, [$id], selectAll: false);
+        $record = $records->first();
+
+        if (! $record instanceof Model) {
+            throw ValidationException::withMessages([
+                'id' => 'The selected row is unavailable.',
+            ]);
+        }
+
+        Gate::authorize($ability, $record);
+
+        return $record;
+    }
+
+    /**
+     * @param  list<int|string>|null  $selected
+     * @return Collection<int, Model>
+     */
+    public function resolveExactSelection(Builder $scope, ?array $selected, bool $selectAll): Collection
+    {
+        if ($selectAll) {
+            $records = (clone $scope)->limit($this->maxSelection + 1)->get();
+
+            if ($records->count() > $this->maxSelection) {
+                throw ValidationException::withMessages([
+                    'selected' => "Selection exceeds the maximum of {$this->maxSelection} rows.",
+                ]);
+            }
+
+            if ($records->isEmpty()) {
+                throw ValidationException::withMessages([
+                    'selected' => 'No rows are selected.',
+                ]);
+            }
+
+            return $records;
+        }
+
+        $keys = $this->normalizeKeys($selected ?? []);
+
+        if ($keys === []) {
+            throw ValidationException::withMessages([
+                'selected' => 'No rows are selected.',
+            ]);
+        }
+
+        if (count($keys) > $this->maxSelection) {
+            throw ValidationException::withMessages([
+                'selected' => "Selection exceeds the maximum of {$this->maxSelection} rows.",
+            ]);
+        }
+
+        $records = (clone $scope)->whereKey($keys)->get()
+            ->keyBy(fn (Model $model): string => (string) $model->getKey());
+
+        if ($records->count() !== count($keys)) {
+            throw ValidationException::withMessages([
+                'selected' => 'One or more selected rows are unavailable in the current table scope.',
+            ]);
+        }
+
+        $ordered = new Collection;
+
+        foreach ($keys as $key) {
+            $record = $records->get($key);
+
+            if (! $record instanceof Model) {
+                throw ValidationException::withMessages([
+                    'selected' => 'One or more selected rows are unavailable in the current table scope.',
+                ]);
+            }
+
+            $ordered->push($record);
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * @param  list<int|string>  $keys
+     * @return list<string>
+     */
+    private function normalizeKeys(array $keys): array
+    {
+        if (! array_is_list($keys)) {
+            throw new InvalidArgumentException('Selected row IDs must be a list.');
+        }
+
+        $normalized = [];
+
+        foreach ($keys as $key) {
+            if ((! is_int($key) && ! is_string($key)) || (string) $key === '') {
+                throw ValidationException::withMessages([
+                    'selected' => 'Selected row IDs must be non-empty integers or strings.',
+                ]);
+            }
+
+            $normalized[] = (string) $key;
+        }
+
+        $unique = array_values(array_unique($normalized, SORT_STRING));
+
+        if (count($unique) !== count($normalized)) {
+            throw ValidationException::withMessages([
+                'selected' => 'Selected row IDs must not contain duplicates.',
+            ]);
+        }
+
+        return $unique;
+    }
+}

--- a/src/Livewire/Table/Traits/BulkActions.php
+++ b/src/Livewire/Table/Traits/BulkActions.php
@@ -27,6 +27,10 @@ trait BulkActions
 
         foreach ($records as $item) {
             if (str_starts_with($action, 'callFlow.')) {
+                if (! method_exists($item, 'callFlow')) {
+                    continue;
+                }
+
                 $item->callFlow(explode('.', $action)[1]);
             } elseif (method_exists($item, $action)) {
                 $item->{$action}();

--- a/src/Livewire/Table/Traits/BulkActions.php
+++ b/src/Livewire/Table/Traits/BulkActions.php
@@ -2,7 +2,7 @@
 
 namespace Aura\Base\Livewire\Table\Traits;
 
-use Illuminate\Support\Facades\Gate;
+use Aura\Base\Livewire\Table\TableMutationAuthorizer;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -17,43 +17,39 @@ trait BulkActions
      */
     public function bulkAction(string $action)
     {
-        $this->ensureBulkActionAllowed($action);
+        $records = $this->tableMutationAuthorizer()->authorizeBulk(
+            scope: clone $this->query(),
+            action: $action,
+            declared: (array) $this->getBulkActionsProperty(),
+            selected: $this->selected,
+            selectAll: (bool) $this->selectAll,
+        );
 
-        $ability = $this->bulkActionAbility($action);
-
-        $this->selectedRowsQuery->each(function ($item, $key) use ($action, $ability) {
-            // Authorize the action against each selected model before running it.
-            Gate::authorize($ability, $item);
-
+        foreach ($records as $item) {
             if (str_starts_with($action, 'callFlow.')) {
                 $item->callFlow(explode('.', $action)[1]);
-            } elseif (str_starts_with($action, 'multiple')) {
-                $posts = $this->selectedRowsQuery->get();
-                $response = $item->{$action}($posts);
-
             } elseif (method_exists($item, $action)) {
                 $item->{$action}();
             }
-        });
+        }
 
-        // Clear the selected array
         $this->selected = [];
+        $this->selectAll = false;
 
         $this->notify('Success: '.$action);
     }
 
     public function bulkCollectionAction($action)
     {
-        $this->ensureBulkActionAllowed($action);
+        $records = $this->tableMutationAuthorizer()->authorizeBulk(
+            scope: clone $this->query(),
+            action: $action,
+            declared: (array) $this->getBulkActionsProperty(),
+            selected: $this->selected,
+            selectAll: (bool) $this->selectAll,
+        );
 
-        $ability = $this->bulkActionAbility($action);
-
-        // Authorize the action against every selected model before running it.
-        $this->selectedRowsQuery->each(function ($item) use ($ability) {
-            Gate::authorize($ability, $item);
-        });
-
-        $ids = $this->selectedRowsQuery->pluck('id')->toArray();
+        $ids = $records->map(fn ($item) => $item->getKey())->all();
 
         $response = $this->model->{$action}($ids);
 
@@ -61,8 +57,8 @@ trait BulkActions
             return $response;
         }
 
-        // reset selected rows
         $this->selected = [];
+        $this->selectAll = false;
 
         $this->notify('Success: '.$action);
 
@@ -79,43 +75,8 @@ trait BulkActions
         return $this->model->getBulkActions();
     }
 
-    /**
-     * Map a declared bulk action to the policy ability it requires.
-     *
-     * Destructive actions are matched by name so they are authorized with the
-     * matching ability; anything else defaults to the mutating 'update' ability.
-     */
-    protected function bulkActionAbility(string $action): string
+    protected function tableMutationAuthorizer(): TableMutationAuthorizer
     {
-        $normalized = strtolower($action);
-
-        if (str_contains($normalized, 'forcedelete')) {
-            return 'forceDelete';
-        }
-
-        if (str_contains($normalized, 'restore')) {
-            return 'restore';
-        }
-
-        if (str_contains($normalized, 'delete') || str_contains($normalized, 'trash')) {
-            return 'delete';
-        }
-
-        return 'update';
-    }
-
-    /**
-     * Ensure the requested action is one the resource explicitly declares.
-     *
-     * This prevents a client from invoking arbitrary methods on the model by
-     * passing an unlisted action string to bulkAction()/bulkCollectionAction().
-     */
-    protected function ensureBulkActionAllowed(string $action): void
-    {
-        $allowed = array_keys((array) $this->getBulkActionsProperty());
-
-        if (! in_array($action, $allowed, true)) {
-            abort(403, 'This bulk action is not allowed.');
-        }
+        return app(TableMutationAuthorizer::class);
     }
 }

--- a/src/Policies/ResourcePolicy.php
+++ b/src/Policies/ResourcePolicy.php
@@ -3,14 +3,17 @@
 namespace Aura\Base\Policies;
 
 use App\Models\Post;
+use Aura\Base\Contracts\ScopesMediaVisibility;
 use Aura\Base\Resource;
 use Aura\Base\Resources\Role;
 use Aura\Base\Resources\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Illuminate\Auth\Access\Response;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
-class ResourcePolicy
+class ResourcePolicy implements ScopesMediaVisibility
 {
     use HandlesAuthorization;
 
@@ -127,6 +130,36 @@ class ResourcePolicy
         }
 
         return false;
+    }
+
+    /**
+     * Refuse authorization when actor and resource clearly live on different
+     * database connections. If either side is not an Eloquent model (or lacks
+     * connection info), allow the rest of the policy to decide — do not break
+     * non-model ability checks (e.g. class-level create/viewAny).
+     */
+    public function scopeMediaVisibility(Builder $query, Authenticatable $actor, Resource $resource): Builder
+    {
+        if (! $actor instanceof User
+            || ! $this->usesSameConnection($actor, $resource)
+            || config('aura.resource-view-enabled') === false
+            || $resource::$viewEnabled === false) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        if ($this->hasBlanketAccess($actor)) {
+            return $query;
+        }
+
+        if ($actor->hasPermissionTo('scope', $resource) && $actor->hasPermissionTo('view', $resource)) {
+            return $query->where($resource->getTable().'.user_id', $actor->getKey());
+        }
+
+        if ($actor->hasPermissionTo('view', $resource) || $actor->hasPermissionTo('viewAny', $resource)) {
+            return $query;
+        }
+
+        return $query->whereRaw('1 = 0');
     }
 
     /**
@@ -272,12 +305,6 @@ class ResourcePolicy
         return $user->isSuperAdmin() || $user->isAuraGlobalAdmin();
     }
 
-    /**
-     * Refuse authorization when actor and resource clearly live on different
-     * database connections. If either side is not an Eloquent model (or lacks
-     * connection info), allow the rest of the policy to decide — do not break
-     * non-model ability checks (e.g. class-level create/viewAny).
-     */
     private function usesSameConnection(mixed $user, mixed $resource): bool
     {
         if (! $user instanceof Model || ! $resource instanceof Model) {

--- a/src/Resources/Attachment.php
+++ b/src/Resources/Attachment.php
@@ -8,6 +8,7 @@ use Aura\Base\Resource;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
@@ -36,6 +37,7 @@ class Attachment extends Resource
             'confirm-content' => 'Are you sure you want to delete this post?',
             'confirm-button' => 'Delete',
             'confirm-button-class' => 'ml-3 bg-red-600 hover:bg-red-700',
+            'ability' => 'delete',
         ],
     ];
 
@@ -43,6 +45,7 @@ class Attachment extends Resource
         'deleteSelected' => [
             'label' => 'Delete',
             'method' => 'collection',
+            'ability' => 'delete',
         ],
     ];
 
@@ -70,6 +73,8 @@ class Attachment extends Resource
 
     public function deleteAttachment()
     {
+        Gate::authorize('delete', $this);
+
         parent::delete();
 
         return redirect()->route('aura.attachment.index');
@@ -77,8 +82,12 @@ class Attachment extends Resource
 
     public function deleteSelected($ids)
     {
-        self::whereIn('id', $ids)->delete();
+        $ids = array_values(array_filter((array) $ids, fn ($id) => $id !== null && $id !== ''));
 
+        foreach (self::query()->whereKey($ids)->get() as $attachment) {
+            Gate::authorize('delete', $attachment);
+            $attachment->delete();
+        }
     }
 
     public function filePath($size = null)

--- a/src/Resources/Role.php
+++ b/src/Resources/Role.php
@@ -20,11 +20,15 @@ class Role extends Resource
             'label' => 'Delete',
             'icon' => '<svg width="24" height="24" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>',
             'class' => 'hover:text-red-700 text-red-500 font-bold',
+            'ability' => 'delete',
         ],
     ];
 
     public array $bulkActions = [
-        'deleteSelected' => 'Delete',
+        'deleteSelected' => [
+            'label' => 'Delete',
+            'ability' => 'delete',
+        ],
     ];
 
     public static $customTable = true;
@@ -150,6 +154,12 @@ class Role extends Resource
     public static function currentTeamIdForResolution(): ?int
     {
         return optional(auth()->user())->current_team_id;
+    }
+
+    public function deleteSelected($ids = null)
+    {
+        Gate::authorize('delete', $this);
+        $this->delete();
     }
 
     /**

--- a/tests/Feature/Media/MediaAuthorizationTest.php
+++ b/tests/Feature/Media/MediaAuthorizationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use Aura\Base\Livewire\Media\InvalidMediaOwnerContext;
+use Aura\Base\Livewire\Media\MediaAuthorization;
+use Aura\Base\Resources\Attachment;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Illuminate\Auth\Access\AuthorizationException;
+
+beforeEach(function () {
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+function mediaAuthAttachment(string $name = 'photo.jpg'): Attachment
+{
+    return Attachment::create([
+        'url' => 'media/'.$name,
+        'name' => $name,
+        'title' => $name,
+        'size' => 1024,
+        'mime_type' => 'image/jpeg',
+    ]);
+}
+
+test('authorizeAttachments returns visible attachments for the actor', function () {
+    $attachment = mediaAuthAttachment();
+
+    $authorized = app(MediaAuthorization::class)
+        ->authorizeAttachments([(string) $attachment->id], $this->user);
+
+    expect($authorized)->toHaveCount(1)
+        ->and($authorized->first()->getKey())->toBe($attachment->id);
+});
+
+test('authorizeAttachments rejects foreign team attachment ids', function () {
+    $otherTeam = Team::factory()->createQuietly(['user_id' => $this->user->id]);
+
+    $foreign = Attachment::withoutGlobalScopes()->create([
+        'url' => 'media/foreign.jpg',
+        'name' => 'foreign.jpg',
+        'title' => 'foreign.jpg',
+        'size' => 1024,
+        'mime_type' => 'image/jpeg',
+        'team_id' => $otherTeam->id,
+        'user_id' => $this->user->id,
+        'type' => Attachment::$type,
+    ]);
+
+    expect(Attachment::whereKey($foreign->id)->exists())->toBeFalse();
+
+    expect(fn () => app(MediaAuthorization::class)
+        ->authorizeAttachments([(string) $foreign->id], $this->user))
+        ->toThrow(InvalidMediaOwnerContext::class);
+});
+
+test('authorizeAttachments rejects unviewable attachment ids', function () {
+    $user = createAdmin();
+    $role = Role::where('slug', 'editor')->firstOrFail();
+    $permissions = $role->permissions;
+    $permissions['view-attachment'] = false;
+    $permissions['viewAny-attachment'] = true;
+    $role->update(['permissions' => $permissions]);
+
+    $this->actingAs($user->refresh());
+
+    $attachment = mediaAuthAttachment('private.jpg');
+
+    expect(fn () => app(MediaAuthorization::class)
+        ->authorizeAttachments([(string) $attachment->id], $user->refresh()))
+        ->toThrow(AuthorizationException::class);
+});
+
+test('authorizeAttachments empty list requires viewAny', function () {
+    $user = createAdmin();
+    $role = Role::where('slug', 'editor')->firstOrFail();
+    $permissions = $role->permissions;
+    $permissions['viewAny-attachment'] = false;
+    $permissions['view-attachment'] = false;
+    $role->update(['permissions' => $permissions]);
+
+    $this->actingAs($user->refresh());
+
+    expect(fn () => app(MediaAuthorization::class)
+        ->authorizeAttachments([], $user->refresh()))
+        ->toThrow(AuthorizationException::class);
+});
+
+test('authorizeAttachments empty list succeeds with viewAny', function () {
+    $user = createAdmin();
+
+    $this->actingAs($user);
+
+    $authorized = app(MediaAuthorization::class)->authorizeAttachments([], $user);
+
+    expect($authorized)->toHaveCount(0);
+});
+
+test('deleteSelected requires delete permission', function () {
+    $user = createAdmin();
+    $role = Role::where('slug', 'editor')->firstOrFail();
+    $permissions = $role->permissions;
+    $permissions['delete-attachment'] = false;
+    $role->update(['permissions' => $permissions]);
+
+    $this->actingAs($user->refresh());
+
+    $attachment = mediaAuthAttachment('keep-me.jpg');
+
+    expect(fn () => (new Attachment)->deleteSelected([$attachment->id]))
+        ->toThrow(AuthorizationException::class);
+
+    expect(Attachment::whereKey($attachment->id)->exists())->toBeTrue();
+});
+
+test('deleteSelected deletes when the actor may delete', function () {
+    $attachment1 = mediaAuthAttachment('one.jpg');
+    $attachment2 = mediaAuthAttachment('two.jpg');
+
+    (new Attachment)->deleteSelected([$attachment1->id, $attachment2->id]);
+
+    expect(Attachment::whereKey($attachment1->id)->exists())->toBeFalse()
+        ->and(Attachment::whereKey($attachment2->id)->exists())->toBeFalse();
+});

--- a/tests/Feature/Media/MediaAuthorizationTest.php
+++ b/tests/Feature/Media/MediaAuthorizationTest.php
@@ -51,7 +51,7 @@ test('authorizeAttachments rejects foreign team attachment ids', function () {
     expect(fn () => app(MediaAuthorization::class)
         ->authorizeAttachments([(string) $foreign->id], $this->user))
         ->toThrow(InvalidMediaOwnerContext::class);
-});
+})->skip(fn () => ! config('aura.teams'), 'Requires teams');
 
 test('authorizeAttachments rejects unviewable attachment ids', function () {
     $user = createAdmin();

--- a/tests/Feature/Media/MediaManagerAuthorizationTest.php
+++ b/tests/Feature/Media/MediaManagerAuthorizationTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use Aura\Base\Livewire\Media\InvalidMediaOwnerContext;
+use Aura\Base\Livewire\MediaManager;
+use Aura\Base\Resources\Attachment;
+use Aura\Base\Resources\Role;
+use Aura\Base\Resources\Team;
+use Aura\Base\Resources\User;
+use Illuminate\Support\Facades\Cache;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+function managerAttachment(string $name = 'photo.jpg'): Attachment
+{
+    return Attachment::create([
+        'url' => 'media/'.$name,
+        'name' => $name,
+        'title' => $name,
+        'size' => 2048,
+        'mime_type' => 'image/jpeg',
+    ]);
+}
+
+function denyAttachmentViewForAdmin(): User
+{
+    $user = createAdmin();
+    $role = Role::where('slug', 'editor')
+        ->where('team_id', $user->current_team_id)
+        ->firstOrFail();
+    $permissions = $role->permissions;
+    $permissions['view-attachment'] = false;
+    $permissions['viewAny-attachment'] = true;
+    $role->update(['permissions' => $permissions]);
+    Cache::flush();
+
+    return $user->refresh();
+}
+
+test('mount does not leak all attachment ids via rowIds', function () {
+    managerAttachment('a.jpg');
+    managerAttachment('b.jpg');
+    managerAttachment('c.jpg');
+
+    livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [],
+        'modalAttributes' => null,
+    ])
+        ->assertSet('rowIds', [])
+        ->assertOk();
+});
+
+test('mount authorizes selected attachment ids', function () {
+    $attachment = managerAttachment('selected.jpg');
+
+    livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [(string) $attachment->id],
+        'modalAttributes' => null,
+    ])
+        ->assertSet('selected', [(string) $attachment->id])
+        ->assertOk();
+});
+
+test('mount rejects unauthorized selected ids', function () {
+    $user = denyAttachmentViewForAdmin();
+    $this->actingAs($user);
+
+    $attachment = managerAttachment('hidden.jpg');
+
+    // Livewire converts AuthorizationException on mount into a forbidden response.
+    livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [(string) $attachment->id],
+        'modalAttributes' => null,
+    ])->assertForbidden();
+});
+
+test('select rejects unauthorized attachment ids', function () {
+    $user = denyAttachmentViewForAdmin();
+    $this->actingAs($user);
+
+    $attachment = managerAttachment('not-mine.jpg');
+
+    // Mount with empty selection (requires viewAny only).
+    livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [],
+        'modalAttributes' => null,
+    ])
+        ->call('select', [(string) $attachment->id])
+        ->assertForbidden();
+});
+
+test('select rejects foreign team attachment ids', function () {
+    $otherTeam = Team::factory()->createQuietly(['user_id' => $this->user->id]);
+
+    $foreign = Attachment::withoutGlobalScopes()->create([
+        'url' => 'media/foreign.jpg',
+        'name' => 'foreign.jpg',
+        'title' => 'foreign.jpg',
+        'size' => 1024,
+        'mime_type' => 'image/jpeg',
+        'team_id' => $otherTeam->id,
+        'user_id' => $this->user->id,
+        'type' => Attachment::$type,
+    ]);
+
+    expect(fn () => livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [],
+        'modalAttributes' => null,
+    ])->call('select', [(string) $foreign->id]))->toThrow(InvalidMediaOwnerContext::class);
+});
+
+test('select accepts authorized attachment ids', function () {
+    $attachment = managerAttachment('ok.jpg');
+
+    livewire(MediaManager::class, [
+        'model' => User::class,
+        'slug' => 'avatar',
+        'selected' => [],
+        'modalAttributes' => null,
+    ])
+        ->call('select', [(string) $attachment->id])
+        ->assertDispatched('updateField');
+});

--- a/tests/Feature/Media/MediaManagerAuthorizationTest.php
+++ b/tests/Feature/Media/MediaManagerAuthorizationTest.php
@@ -28,9 +28,13 @@ function managerAttachment(string $name = 'photo.jpg'): Attachment
 function denyAttachmentViewForAdmin(): User
 {
     $user = createAdmin();
-    $role = Role::where('slug', 'editor')
-        ->where('team_id', $user->current_team_id)
-        ->firstOrFail();
+    $roleQuery = Role::where('slug', 'editor');
+
+    if (config('aura.teams')) {
+        $roleQuery->where('team_id', $user->current_team_id);
+    }
+
+    $role = $roleQuery->firstOrFail();
     $permissions = $role->permissions;
     $permissions['view-attachment'] = false;
     $permissions['viewAny-attachment'] = true;
@@ -120,7 +124,7 @@ test('select rejects foreign team attachment ids', function () {
         'selected' => [],
         'modalAttributes' => null,
     ])->call('select', [(string) $foreign->id]))->toThrow(InvalidMediaOwnerContext::class);
-});
+})->skip(fn () => ! config('aura.teams'), 'Requires teams');
 
 test('select accepts authorized attachment ids', function () {
     $attachment = managerAttachment('ok.jpg');

--- a/tests/Feature/Security/BulkActionsAuthorizationTest.php
+++ b/tests/Feature/Security/BulkActionsAuthorizationTest.php
@@ -110,3 +110,20 @@ test('bulkAction runs a declared action for an authorized user', function () {
 
     expect(SecurityBulkModel::count())->toBe(0);
 });
+
+test('bulkAction fails closed when a forged id is mixed into an otherwise valid selection', function () {
+    $this->actingAs(createSuperAdmin());
+
+    $keep = SecurityBulkModel::create(['title' => 'Keep me']);
+    $delete = SecurityBulkModel::create(['title' => 'Delete me']);
+
+    $model = SecurityBulkModel::first();
+
+    livewire(Table::class, ['query' => null, 'model' => $model])
+        ->set('selected', [(string) $delete->id, '999999999'])
+        ->call('bulkAction', 'deleteSelected')
+        ->assertHasErrors(['selected']);
+
+    expect(SecurityBulkModel::find($keep->id))->not->toBeNull()
+        ->and(SecurityBulkModel::find($delete->id))->not->toBeNull();
+});

--- a/tests/Feature/Security/GlobalSearchAuthorizationTest.php
+++ b/tests/Feature/Security/GlobalSearchAuthorizationTest.php
@@ -3,6 +3,7 @@
 use Aura\Base\Facades\Aura;
 use Aura\Base\Livewire\GlobalSearch;
 use Aura\Base\Resource;
+use Aura\Base\Resources\Role;
 use Aura\Base\Resources\User;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Livewire;
@@ -71,7 +72,12 @@ test('global search hides users when the current user cannot view users', functi
     // Build a role with viewAny-user explicitly denied, then search by email.
     $this->actingAs($admin = createAdmin());
 
-    $admin->roles->first()->update([
+    $role = $admin->roles()->first()
+        ?? Role::where('slug', 'editor')
+            ->where('team_id', $admin->current_team_id)
+            ->firstOrFail();
+
+    $role->update([
         'permissions' => ['view-user' => false, 'viewAny-user' => false],
     ]);
 

--- a/tests/Feature/Security/TableRowActionAuthorizationTest.php
+++ b/tests/Feature/Security/TableRowActionAuthorizationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+use Aura\Base\Facades\Aura;
+use Aura\Base\Livewire\Table\Table;
+use Aura\Base\Resource;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Cache;
+
+use function Pest\Livewire\livewire;
+
+/**
+ * Test resource that declares a single legitimate row action.
+ */
+class SecurityRowActionModel extends Resource
+{
+    public array $actions = [
+        'delete' => [
+            'label' => 'Delete',
+            'ability' => 'delete',
+        ],
+    ];
+
+    public static $singularName = 'SecurityRow';
+
+    public static ?string $slug = 'securityrow';
+
+    public static string $type = 'SecurityRow';
+
+    public static function getFields()
+    {
+        return [
+            [
+                'name' => 'Title',
+                'type' => 'Aura\\Base\\Fields\\Text',
+                'validation' => 'required',
+                'searchable' => true,
+                'slug' => 'title',
+            ],
+        ];
+    }
+}
+
+beforeEach(function () {
+    Aura::fake();
+    Aura::registerResources([SecurityRowActionModel::class]);
+    Aura::setModel(new SecurityRowActionModel);
+    Cache::clear();
+});
+
+test('table row action rejects a forged undeclared action name', function () {
+    $this->actingAs(createSuperAdmin());
+
+    $record = SecurityRowActionModel::create(['title' => 'Stay put']);
+
+    livewire(Table::class, ['query' => null, 'model' => $record])
+        ->call('action', ['action' => 'forceDelete', 'id' => $record->id])
+        ->assertStatus(403);
+
+    expect(SecurityRowActionModel::whereKey($record->id)->exists())->toBeTrue();
+});
+
+test('table row action blocks delete when the user is not authorized', function () {
+    // Limited admin (Editor role) has no delete permission for this resource.
+    $this->actingAs(createAdmin());
+
+    $record = SecurityRowActionModel::create(['title' => 'Protected']);
+
+    livewire(Table::class, ['query' => null, 'model' => $record])
+        ->call('action', ['action' => 'delete', 'id' => $record->id])
+        ->assertStatus(403);
+
+    expect(SecurityRowActionModel::whereKey($record->id)->exists())->toBeTrue();
+});
+
+test('table row action resolves the record only inside the current table scope', function () {
+    // Cross-team record must not be reachable via bare model find — the table
+    // scope (TeamScope + type) has to own the lookup.
+    $this->actingAs(createSuperAdmin());
+
+    $own = SecurityRowActionModel::create(['title' => 'Own team row']);
+
+    $otherTeam = foreignTeam();
+
+    $foreign = SecurityRowActionModel::withoutGlobalScopes()->create([
+        'title' => 'Foreign team row',
+        'team_id' => $otherTeam->id,
+        'type' => SecurityRowActionModel::$type,
+    ]);
+
+    expect(SecurityRowActionModel::whereKey($own->id)->exists())->toBeTrue();
+    // Foreign row is invisible under the acting team's TeamScope.
+    expect(SecurityRowActionModel::whereKey($foreign->id)->exists())->toBeFalse();
+
+    // Custom row action: exact selection inside scope fails closed.
+    livewire(Table::class, ['query' => null, 'model' => $own])
+        ->call('action', ['action' => 'delete', 'id' => $foreign->id])
+        ->assertHasErrors(['selected']);
+
+    expect(SecurityRowActionModel::withoutGlobalScopes()->whereKey($foreign->id)->exists())->toBeTrue();
+    expect(SecurityRowActionModel::whereKey($own->id)->exists())->toBeTrue();
+})->skip(fn () => ! config('aura.teams'), 'Cross-team scoped find requires teams.');
+
+test('table view action uses scoped find and never bare model find', function () {
+    $this->actingAs(createSuperAdmin());
+
+    $own = SecurityRowActionModel::create(['title' => 'Visible']);
+
+    $otherTeam = foreignTeam();
+
+    $foreign = SecurityRowActionModel::withoutGlobalScopes()->create([
+        'title' => 'Hidden',
+        'team_id' => $otherTeam->id,
+        'type' => SecurityRowActionModel::$type,
+    ]);
+
+    // Out-of-scope id must 404 via firstOrFail on the scoped query.
+    expect(fn () => livewire(Table::class, ['query' => null, 'model' => $own])
+        ->call('action', ['action' => 'view', 'id' => $foreign->id]))
+        ->toThrow(ModelNotFoundException::class);
+
+    // In-scope id is authorized and redirects.
+    livewire(Table::class, ['query' => null, 'model' => $own])
+        ->call('action', ['action' => 'view', 'id' => $own->id])
+        ->assertRedirect(route('aura.securityrow.view', ['id' => $own->id]));
+})->skip(fn () => ! config('aura.teams'), 'Cross-team scoped find requires teams.');
+
+test('table row action runs a declared delete for an authorized user', function () {
+    $this->actingAs(createSuperAdmin());
+
+    $record = SecurityRowActionModel::create(['title' => 'Delete me']);
+
+    livewire(Table::class, ['query' => null, 'model' => $record])
+        ->call('action', ['action' => 'delete', 'id' => $record->id])
+        ->assertHasNoErrors();
+
+    expect(SecurityRowActionModel::whereKey($record->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- Replaces closed #76 after #75 landed and its base branch was deleted
- Slim media IDOR fixes + table mutation auth (no mega-branch fortress)
- `MediaAuthorization`, `TableMutationAuthorizer`, Attachment/Role Gate deletes
- Feature tests for media + table row/bulk auth

## Test plan
- [x] MediaAuthorization / MediaManagerAuthorization / TableRowAction / BulkActions Pest suites
- [ ] CI matrix green
- [ ] Manual smoke: media picker select foreign ID, upload without create, bulk delete


Made with [Cursor](https://cursor.com)