### PR TITLE
fix: stop upload badge race on refreshTable

### DIFF
--- a/resources/views/livewire/media-uploader.blade.php
+++ b/resources/views/livewire/media-uploader.blade.php
@@ -379,7 +379,7 @@
                     </h1>
                 </div>
 
-                <livewire:aura::table :model="$model" :field="$field" />
+                <livewire:aura::table wire:key="media-uploader-table" :model="$model" :field="$field" />
             </div>
         @endif
     </div>

--- a/src/Livewire/MediaUploader.php
+++ b/src/Livewire/MediaUploader.php
@@ -175,6 +175,9 @@ class MediaUploader extends Component
 
         // Notify consumers (grid highlight, picker auto-select) about the freshly
         // created attachments. Only dispatch when at least one was created.
+        // media-uploaded already refreshes the table rows — do not also dispatch
+        // refreshTable, or two concurrent Table updates race and the later
+        // response can wipe recentUploadIds (badge disappears in the browser).
         if (! empty($attachments)) {
             $ids = collect($attachments)->pluck('id')->all();
 
@@ -184,6 +187,8 @@ class MediaUploader extends Component
                 'ids' => $ids,
             ];
             $this->dispatch('media-uploaded', ids: $ids);
+
+            return;
         }
 
         $this->dispatch('refreshTable');

--- a/src/Livewire/Table/Table.php
+++ b/src/Livewire/Table/Table.php
@@ -269,8 +269,11 @@ class Table extends Component
     #[On('media-uploaded')]
     public function mediaUploaded($ids = [])
     {
-        $this->recentUploadIds = collect($ids)
+        // Sequential uploads dispatch one event per file — accumulate.
+        $this->recentUploadIds = collect($this->recentUploadIds)
+            ->merge($ids)
             ->map(fn ($id) => (string) $id)
+            ->unique()
             ->values()
             ->all();
 

--- a/tests/Browser/UploadTest.php
+++ b/tests/Browser/UploadTest.php
@@ -17,11 +17,9 @@ test('uploading a single image shows per-file progress and an uploaded indicator
 
     expect(Attachment::query()->count())->toBe(1);
 
-    // Grid card is the stable post-upload signal. The green badge depends on a
-    // follow-up Livewire media-uploaded round-trip and remains flaky in CI;
-    // coverage for recentUploadIds + data-uploaded-badge lives in feature tests.
     $page->assertSee('photo.jpg')
-        ->assertVisible('[data-attachment-card]');
+        ->assertVisible('[data-attachment-card]')
+        ->assertVisible('[data-uploaded-badge]');
 });
 
 test('uploading mixed file types succeeds for each file', function () {

--- a/tests/Feature/Media/BasicMediaTest.php
+++ b/tests/Feature/Media/BasicMediaTest.php
@@ -96,7 +96,7 @@ test('media uploader stores file size correctly', function () {
     expect($attachment->size)->toBeGreaterThan(0);
 });
 
-test('media uploader dispatches refreshTable event after upload', function () {
+test('media uploader dispatches media-uploaded after a successful upload', function () {
     Storage::fake('public');
     Storage::fake('tmp-for-tests');
 
@@ -104,7 +104,8 @@ test('media uploader dispatches refreshTable event after upload', function () {
 
     Livewire::test(MediaUploader::class)
         ->set('media', [$file])
-        ->assertDispatched('refreshTable');
+        ->assertDispatched('media-uploaded')
+        ->assertNotDispatched('refreshTable');
 });
 
 test('media uploader stores correct mime type for jpg', function () {

--- a/tests/Feature/Media/MediaUploaderEventsTest.php
+++ b/tests/Feature/Media/MediaUploaderEventsTest.php
@@ -39,23 +39,35 @@ test('does not dispatch media-uploaded when every file in the batch is blocked',
     expect(Attachment::count())->toBe(0);
 });
 
-test('refreshTable is still dispatched on successful upload', function () {
+test('refreshTable is still dispatched when the batch creates no attachments', function () {
+    livewire(MediaUploader::class)
+        ->set('media', [])
+        ->assertHasNoErrors()
+        ->assertDispatched('refreshTable')
+        ->assertNotDispatched('media-uploaded');
+});
+
+test('successful upload dispatches media-uploaded without a racing refreshTable', function () {
     livewire(MediaUploader::class)
         ->set('media', [UploadedFile::fake()->image('photo.jpg')])
         ->assertHasNoErrors()
-        ->assertDispatched('refreshTable');
+        ->assertDispatched('media-uploaded')
+        ->assertNotDispatched('refreshTable');
 
     expect(Attachment::count())->toBe(1);
 });
 
 test('table keeps recent upload ids after media-uploaded so the grid badge survives refresh', function () {
-    $attachment = Attachment::factory()->create();
+    $first = Attachment::factory()->create();
+    $second = Attachment::factory()->create();
 
     livewire(Table::class, [
         'query' => null,
         'model' => new Attachment,
     ])
-        ->dispatch('media-uploaded', ids: [$attachment->id])
-        ->assertSet('recentUploadIds', [(string) $attachment->id])
+        ->dispatch('media-uploaded', ids: [$first->id])
+        ->assertSet('recentUploadIds', [(string) $first->id])
+        ->dispatch('media-uploaded', ids: [$second->id])
+        ->assertSet('recentUploadIds', [(string) $first->id, (string) $second->id])
         ->assertSeeHtml('data-uploaded-badge');
 });


### PR DESCRIPTION
## Summary
- Successful uploads now dispatch only `media-uploaded` (which already refreshes rows), not a racing `refreshTable`.
- `recentUploadIds` accumulate across sequential uploads.
- Nested media table gets a stable `wire:key`.
- Browser test again asserts `[data-uploaded-badge]`.

## Test plan
- [x] `pest tests/Feature/Media/MediaUploaderEventsTest.php`
- [x] `pest tests/Feature/Media/BasicMediaTest.php`
- [ ] CI browser suite (Playwright not installed locally)

Made with [Cursor](https://cursor.com)