### PR TITLE
fix: modal open state + invite validation labels (from develop)

### DIFF
--- a/resources/views/components/dialog/index.blade.php
+++ b/resources/views/components/dialog/index.blade.php
@@ -1,6 +1,15 @@
+@props(['open' => false])
+
 <div
-    x-data="{ dialogOpen: false }"
+    x-data="{ dialogOpen: @js($open) }"
     x-modelable="dialogOpen"
+    x-init="$watch('dialogOpen', value => {
+        if (value) {
+            document.body.classList.add('overflow-hidden')
+        } else {
+            document.body.classList.remove('overflow-hidden')
+        }
+    })"
     {{ $attributes }}
     tabindex="-1"
 >

--- a/resources/views/livewire/modals.blade.php
+++ b/resources/views/livewire/modals.blade.php
@@ -1,6 +1,6 @@
 <div>
     @forelse($modals as $id => $modal)
-        <x-aura::dialog wire:model="modals.{{ $id }}.active">
+        <x-aura::dialog wire:model="modals.{{ $id }}.active" :open="$modal['active']">
             @if ($modal['modalAttributes']['slideOver'])
                 <x-aura::dialog.slideover wire:key="slideover-{{ $id }}">
                     {{-- @dump($activeModals) --}}

--- a/resources/views/livewire/user/invite-user.blade.php
+++ b/resources/views/livewire/user/invite-user.blade.php
@@ -1,6 +1,6 @@
 <div class="">
 
-    <form wire:submit="save">
+    <form wire:submit.prevent="save">
         <x-aura::dialog.title>{{ __('Invite User') }}</x-aura::dialog.title>
 
         <div class="flex flex-wrap">

--- a/src/Livewire/InviteUser.php
+++ b/src/Livewire/InviteUser.php
@@ -129,4 +129,12 @@ class InviteUser extends Component
         $this->dispatch('closeModal');
         $this->dispatch('refreshTable');
     }
+
+    protected function validationAttributes(): array
+    {
+        return [
+            'form.fields.email' => 'email',
+            'form.fields.role' => 'role',
+        ];
+    }
 }

--- a/src/Livewire/Modals.php
+++ b/src/Livewire/Modals.php
@@ -26,8 +26,15 @@ class Modals extends Component
     }
 
     #[On('openModal')]
-    public function openModal($component, $arguments = [], $modalAttributes = []): void
+    public function openModal($component = null, $arguments = [], $modalAttributes = []): void
     {
+        // Alpine/Livewire may deliver named params as a single array payload.
+        if (is_array($component) && isset($component['component'])) {
+            $modalAttributes = $component['modalAttributes'] ?? [];
+            $arguments = $component['arguments'] ?? [];
+            $component = $component['component'];
+        }
+
         $id = md5($component.serialize($arguments));
 
         // Resolve component class - handle both namespaced and non-namespaced components

--- a/tests/Feature/Livewire/ModalsTest.php
+++ b/tests/Feature/Livewire/ModalsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Aura\Base\Livewire\Modals;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->actingAs($this->user = createSuperAdmin());
+});
+
+test('openModal accepts a single array payload with component key', function () {
+    Livewire::test(Modals::class)
+        ->call('openModal', [
+            'component' => 'aura::invite-user',
+            'arguments' => ['foo' => 'bar'],
+            'modalAttributes' => ['slideOver' => true],
+        ])
+        ->assertSet('modals', function (array $modals) {
+            expect($modals)->toHaveCount(1);
+
+            $modal = array_values($modals)[0];
+
+            expect($modal['name'])->toBe('aura::invite-user')
+                ->and($modal['arguments'])->toBe(['foo' => 'bar'])
+                ->and($modal['modalAttributes']['slideOver'])->toBeTrue()
+                ->and($modal['active'])->toBeTrue();
+
+            return true;
+        });
+});
+
+test('openModal still accepts positional component arguments', function () {
+    Livewire::test(Modals::class)
+        ->call('openModal', 'aura::invite-user', ['id' => 1], ['persistent' => true])
+        ->assertSet('modals', function (array $modals) {
+            expect($modals)->toHaveCount(1);
+
+            $modal = array_values($modals)[0];
+
+            expect($modal['name'])->toBe('aura::invite-user')
+                ->and($modal['arguments'])->toBe(['id' => 1])
+                ->and($modal['modalAttributes']['persistent'])->toBeTrue()
+                ->and($modal['active'])->toBeTrue();
+
+            return true;
+        });
+});
+
+test('modals view passes open state into the dialog component', function () {
+    Livewire::test(Modals::class)
+        ->call('openModal', 'aura::invite-user')
+        ->assertSeeHtml('x-data="{ dialogOpen: true }"');
+});

--- a/tests/Feature/Team/InviteUserExtensiveTest.php
+++ b/tests/Feature/Team/InviteUserExtensiveTest.php
@@ -731,6 +731,25 @@ describe('InviteUser Livewire Component', function () {
             ->assertDispatched('refreshTable');
     });
 
+    it('does not dispatch closeModal when validation fails', function () {
+        Livewire::test(InviteUser::class)
+            ->set('form.fields.email', '')
+            ->set('form.fields.role', '')
+            ->call('save')
+            ->assertHasErrors(['form.fields.email', 'form.fields.role'])
+            ->assertNotDispatched('closeModal');
+    });
+
+    it('shows friendly validation attribute names', function () {
+        Livewire::test(InviteUser::class)
+            ->set('form.fields.email', '')
+            ->set('form.fields.role', '')
+            ->call('save')
+            ->assertHasErrors(['form.fields.email', 'form.fields.role'])
+            ->assertSee('The email field is required.')
+            ->assertSee('The role field is required.');
+    });
+
     it('stores invitation with correct team_id', function () {
         Mail::fake();
 


### PR DESCRIPTION
## Summary
- Port the useful leftover work from `origin/develop` onto current `main`.
- Dynamic modals get an initial `:open` / `dialogOpen` value and body scroll lock.
- `Modals::openModal` accepts a single `{ component, arguments, modalAttributes }` payload.
- Invite form shows friendly `email` / `role` validation labels and uses `wire:submit.prevent`.
- Intentionally **not** ported: Jetstream-era invitation controller diffs (already superseded), Table-owned CSS invite modal, and orphan `Livewire/Teams/*` forms (conflict with Role Catalog / Team resource UX).

## Test plan
- [x] `vendor/bin/pest tests/Feature/Livewire/ModalsTest.php`
- [x] `vendor/bin/pest tests/Feature/Team/InviteUser*.php`
- [ ] Smoke: open Invite User from Users index and confirm modal appears open on first paint
- [ ] After merge: delete `origin/develop` (remaining delta is obsolete / high-conflict)


Made with [Cursor](https://cursor.com)