### PR TITLE
test(modals): use teams-agnostic stub in ModalsTest

### DIFF
--- a/tests/Feature/Livewire/ModalsTest.php
+++ b/tests/Feature/Livewire/ModalsTest.php
@@ -1,16 +1,19 @@
 <?php
 
 use Aura\Base\Livewire\Modals;
+use Aura\Base\Tests\Fixtures\Modals\ModalStub;
 use Livewire\Livewire;
 
 beforeEach(function () {
     $this->actingAs($this->user = createSuperAdmin());
+
+    Livewire::component('modals-test-stub', ModalStub::class);
 });
 
 test('openModal accepts a single array payload with component key', function () {
     Livewire::test(Modals::class)
         ->call('openModal', [
-            'component' => 'aura::invite-user',
+            'component' => 'modals-test-stub',
             'arguments' => ['foo' => 'bar'],
             'modalAttributes' => ['slideOver' => true],
         ])
@@ -19,7 +22,7 @@ test('openModal accepts a single array payload with component key', function () 
 
             $modal = array_values($modals)[0];
 
-            expect($modal['name'])->toBe('aura::invite-user')
+            expect($modal['name'])->toBe('modals-test-stub')
                 ->and($modal['arguments'])->toBe(['foo' => 'bar'])
                 ->and($modal['modalAttributes']['slideOver'])->toBeTrue()
                 ->and($modal['active'])->toBeTrue();
@@ -30,13 +33,13 @@ test('openModal accepts a single array payload with component key', function () 
 
 test('openModal still accepts positional component arguments', function () {
     Livewire::test(Modals::class)
-        ->call('openModal', 'aura::invite-user', ['id' => 1], ['persistent' => true])
+        ->call('openModal', 'modals-test-stub', ['id' => 1], ['persistent' => true])
         ->assertSet('modals', function (array $modals) {
             expect($modals)->toHaveCount(1);
 
             $modal = array_values($modals)[0];
 
-            expect($modal['name'])->toBe('aura::invite-user')
+            expect($modal['name'])->toBe('modals-test-stub')
                 ->and($modal['arguments'])->toBe(['id' => 1])
                 ->and($modal['modalAttributes']['persistent'])->toBeTrue()
                 ->and($modal['active'])->toBeTrue();
@@ -47,6 +50,6 @@ test('openModal still accepts positional component arguments', function () {
 
 test('modals view passes open state into the dialog component', function () {
     Livewire::test(Modals::class)
-        ->call('openModal', 'aura::invite-user')
+        ->call('openModal', 'modals-test-stub')
         ->assertSeeHtml('x-data="{ dialogOpen: true }"');
 });

--- a/tests/Fixtures/Modals/ModalStub.php
+++ b/tests/Fixtures/Modals/ModalStub.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Aura\Base\Tests\Fixtures\Modals;
+
+use Livewire\Component;
+
+class ModalStub extends Component
+{
+    public function render(): string
+    {
+        return '<div data-test-modal-stub>Modal stub</div>';
+    }
+}


### PR DESCRIPTION
## Why

Teams-off CI fails `ModalsTest` because the cases nest `aura::invite-user`. That component aborts 404 when `AURA_TEAMS=false`, and Livewire's test harness then keeps a null component so `assertSet('modals', …)` TypeErrors. The suite should cover `openModal` and dialog open state without a teams-gated child.

## Scope

- Add `tests/Fixtures/Modals/ModalStub.php`
- Register it as `modals-test-stub` in `ModalsTest` and point all three cases at it
- Leave `InviteUser` teams gating and production `Modals` code unchanged

## Tradeoffs

A dedicated stub is a little more fixture surface than reusing `invite-user`, but it keeps teams-off honest and avoids weakening the invite gate.

## Blast radius

Test-only. Main stays red on Teams-off until this lands. Callers of invite-user and modal open behavior are untouched.

## Verification

- `./vendor/bin/pest tests/Feature/Livewire/ModalsTest.php --no-coverage` — 3 passed
- `./vendor/bin/pest -c phpunit-without-teams.xml tests/Feature/Livewire/ModalsTest.php --no-coverage` — 3 passed
- Pre-fix teams-off repro: nested invite-user returned 404 via `assertStatus(404)`


Made with [Cursor](https://cursor.com)