### PR TITLE
style: use bare RuntimeException in AssetsAreCurrentTest

### DIFF
--- a/tests/Feature/Aura/AssetsAreCurrentTest.php
+++ b/tests/Feature/Aura/AssetsAreCurrentTest.php
@@ -134,12 +134,12 @@ it('throws for a malformed published manifest', function () {
     File::put($this->publishedRoot.'/manifest.json', '{not-json');
 
     expect(fn () => PublishedAssets::areCurrent($this->publishedRoot, $this->packageDist))
-        ->toThrow(\RuntimeException::class, 'invalid JSON');
+        ->toThrow(RuntimeException::class, 'invalid JSON');
 });
 
 it('throws when no published manifest exists', function () {
     expect(fn () => PublishedAssets::areCurrent($this->publishedRoot, $this->packageDist))
-        ->toThrow(\RuntimeException::class, 'not published');
+        ->toThrow(RuntimeException::class, 'not published');
 });
 
 it('repairs an incomplete tree via aura:publish', function () {


### PR DESCRIPTION
## Why

The code-style job fails `vendor/bin/pint --test` on `AssetsAreCurrentTest.php`. That blocks green CI for the v1 package train.

## Scope

- Pint auto-fix on `tests/Feature/Aura/AssetsAreCurrentTest.php` (`fully_qualified_strict_types` and related spacing): `\RuntimeException` becomes `RuntimeException` in this non-namespaced Pest file
- No behavior change
- Independent of #85

## Blast radius

Test file only. Safe for main.

## Verification

- `vendor/bin/pint --test tests/Feature/Aura/AssetsAreCurrentTest.php` — pass
- `./vendor/bin/pest tests/Feature/Aura/AssetsAreCurrentTest.php --no-coverage` — 10 passed