### PR TITLE
Add ResourceActionRegistry for package-contributed Resource actions

### DIFF
--- a/resources/views/livewire/resource/actions.blade.php
+++ b/resources/views/livewire/resource/actions.blade.php
@@ -1,5 +1,4 @@
 <div class="flex flex-wrap gap-2">
-@if($this->model->allowedToPerformActions() || auth()->user()->can('update', $this->model))
 @if(count($this->actions))
     @if($this->model::$showActionsAsButtons)
         {{-- Render actions as buttons --}}
@@ -150,7 +149,6 @@
             </x-slot>
         </x-aura::dropdown>
     @endif
-@endif
 @endif
 
 </div>

--- a/src/Aura.php
+++ b/src/Aura.php
@@ -2,6 +2,7 @@
 
 namespace Aura\Base;
 
+use Aura\Base\Contracts\ResourceActionRegistry;
 use Aura\Base\Livewire\Resource\Create;
 use Aura\Base\Livewire\Resource\Edit;
 use Aura\Base\Livewire\Resource\Index;
@@ -160,6 +161,10 @@ class Aura
         ScopedScope::flushState();
         TeamScope::flushState();
         static::$userModel = User::class;
+
+        if (app()->bound(ResourceActionRegistry::class)) {
+            app(ResourceActionRegistry::class)->flushState();
+        }
     }
 
     public function getAppFields()

--- a/src/AuraServiceProvider.php
+++ b/src/AuraServiceProvider.php
@@ -20,6 +20,7 @@ use Aura\Base\Commands\PublishCommand;
 use Aura\Base\Commands\TransferFromPostsToCustomTable;
 use Aura\Base\Commands\TransformTableToResource;
 use Aura\Base\Commands\UpdateSchemaFromMigration;
+use Aura\Base\Contracts\ResourceActionRegistry as ResourceActionRegistryContract;
 use Aura\Base\Database\Seeders\RoleCatalogSeeder;
 use Aura\Base\Facades\Aura;
 use Aura\Base\Livewire\Attachment\Index as AttachmentIndex;
@@ -63,6 +64,7 @@ use Aura\Base\Reporting\AggregateEngine;
 use Aura\Base\Reporting\ResourceAggregateEngine;
 use Aura\Base\Resources\Team;
 use Aura\Base\Resources\User;
+use Aura\Base\Services\ResourceActionRegistry;
 use Aura\Base\Widgets\Bar;
 use Aura\Base\Widgets\Donut;
 use Aura\Base\Widgets\Pie;
@@ -94,7 +96,10 @@ class AuraServiceProvider extends PackageServiceProvider
     {
         parent::boot();
 
-        $this->app->booted(fn () => Aura::captureBaselineState());
+        $this->app->booted(function (): void {
+            Aura::captureBaselineState();
+            app(ResourceActionRegistryContract::class)->captureBaselineState();
+        });
     }
 
     public function bootGate()
@@ -428,6 +433,9 @@ class AuraServiceProvider extends PackageServiceProvider
     public function packageRegistered()
     {
         parent::packageRegistered();
+
+        $this->app->singleton(ResourceActionRegistry::class);
+        $this->app->alias(ResourceActionRegistry::class, ResourceActionRegistryContract::class);
 
         $this->app->singleton('hook_manager', function ($app) {
             return new HookManager;

--- a/src/Contracts/ResourceActionRegistry.php
+++ b/src/Contracts/ResourceActionRegistry.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Aura\Base\Contracts;
+
+use Aura\Base\Resource;
+
+interface ResourceActionRegistry
+{
+    /**
+     * Return the registered actions that are visible to an actor for a Resource.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function actionsFor(Resource $resource, mixed $actor): array;
+
+    /**
+     * Capture package registrations made during application boot.
+     */
+    public function captureBaselineState(): void;
+
+    /**
+     * Execute one registered action after a fresh server-side authorization check.
+     */
+    public function execute(string $name, Resource $resource, mixed $actor): mixed;
+
+    /**
+     * Restore the boot-time registrations at a worker boundary.
+     */
+    public function flushState(): void;
+
+    /**
+     * Register a namespaced action definition.
+     *
+     * @param  array<string, mixed>  $definition
+     */
+    public function register(string $name, array $definition): void;
+}

--- a/src/Exceptions/ResourceActionConflict.php
+++ b/src/Exceptions/ResourceActionConflict.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Aura\Base\Exceptions;
+
+use LogicException;
+
+class ResourceActionConflict extends LogicException {}

--- a/src/Services/ResourceActionRegistry.php
+++ b/src/Services/ResourceActionRegistry.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Aura\Base\Services;
+
+use Aura\Base\Contracts\ResourceActionRegistry as ResourceActionRegistryContract;
+use Aura\Base\Exceptions\ResourceActionConflict;
+use Aura\Base\Resource;
+use Closure;
+use Illuminate\Auth\Access\AuthorizationException;
+use InvalidArgumentException;
+
+class ResourceActionRegistry implements ResourceActionRegistryContract
+{
+    /** @var array<string, array<string, mixed>> */
+    private array $actions = [];
+
+    /** @var array<string, array<string, mixed>> */
+    private array $baselineActions = [];
+
+    public function actionsFor(Resource $resource, mixed $actor): array
+    {
+        $visible = [];
+
+        foreach ($this->actions as $name => $definition) {
+            if (! $this->matches($definition['supports'] ?? null, $resource, $actor)) {
+                continue;
+            }
+
+            if (! $this->matches($definition['visible'] ?? null, $resource, $actor)) {
+                continue;
+            }
+
+            $visible[$name] = collect($definition)
+                ->except(['authorize', 'handler', 'supports', 'visible'])
+                ->all();
+        }
+
+        return $visible;
+    }
+
+    public function captureBaselineState(): void
+    {
+        $this->baselineActions = $this->actions;
+    }
+
+    public function execute(string $name, Resource $resource, mixed $actor): mixed
+    {
+        $definition = $this->actions[$name] ?? null;
+
+        if (! is_array($definition)
+            || ! $this->matches($definition['supports'] ?? null, $resource, $actor)
+            || ! $this->matches($definition['authorize'] ?? null, $resource, $actor)) {
+            throw new AuthorizationException('You are not authorized to perform this action.');
+        }
+
+        $handler = $definition['handler'] ?? null;
+
+        if (! is_callable($handler)) {
+            throw new InvalidArgumentException("Resource action [{$name}] has no callable handler.");
+        }
+
+        return $handler($resource, $actor);
+    }
+
+    public function flushState(): void
+    {
+        $this->actions = $this->baselineActions;
+    }
+
+    public function register(string $name, array $definition): void
+    {
+        if (! preg_match('/^[a-z0-9][a-z0-9._-]+\.[a-z0-9][a-z0-9._-]+$/', $name)) {
+            throw new InvalidArgumentException('Resource action names must be namespaced, for example [vendor.action].');
+        }
+
+        if (isset($this->actions[$name])) {
+            throw new ResourceActionConflict("Resource action [{$name}] is already registered.");
+        }
+
+        if (! isset($definition['label']) || trim((string) $definition['label']) === '') {
+            throw new InvalidArgumentException("Resource action [{$name}] requires a label.");
+        }
+
+        $this->actions[$name] = $definition;
+    }
+
+    private function matches(mixed $callback, Resource $resource, mixed $actor): bool
+    {
+        if ($callback === null) {
+            return true;
+        }
+
+        if (! $callback instanceof Closure && ! is_callable($callback)) {
+            throw new InvalidArgumentException('Resource action predicates must be callable.');
+        }
+
+        return (bool) $callback($resource, $actor);
+    }
+}

--- a/src/Traits/HasActions.php
+++ b/src/Traits/HasActions.php
@@ -2,6 +2,7 @@
 
 namespace Aura\Base\Traits;
 
+use Aura\Base\Contracts\ResourceActionRegistry;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\RedirectResponse;
 
@@ -20,7 +21,20 @@ trait HasActions
 
     public function getActionsProperty()
     {
-        $actions = $this->model->getActions();
+        $actor = auth()->user();
+        $legacyActions = $this->model->getActions() ?? [];
+
+        if (! $this->model->allowedToPerformActions() && ! $actor?->can('update', $this->model)) {
+            $legacyActions = [];
+        }
+
+        $contributedActions = app()->bound(ResourceActionRegistry::class)
+            ? app(ResourceActionRegistry::class)->actionsFor($this->model, $actor)
+            : [];
+
+        // Resource-defined actions retain precedence over package-contributed
+        // actions when a legacy key happens to use the same name.
+        $actions = array_replace($contributedActions, $legacyActions);
 
         return collect($actions)->filter(function ($item) {
             if (isset($item['conditional_logic'])) {
@@ -33,13 +47,33 @@ trait HasActions
 
     public function singleAction($action)
     {
+        $actor = auth()->user();
+        $legacyActions = $this->model->getActions() ?? [];
+
+        if (! array_key_exists($action, $legacyActions) && app()->bound(ResourceActionRegistry::class)) {
+            try {
+                $response = app(ResourceActionRegistry::class)->execute($action, $this->model, $actor);
+
+                if ($response instanceof RedirectResponse) {
+                    return $response;
+                }
+
+                $this->notify(__('Successfully ran: :action', ['action' => __($action)]));
+
+                return $response;
+            } catch (AuthorizationException $e) {
+                abort(403, $e->getMessage());
+            }
+        }
+
         // Authorize
         if (! $this->model->allowedToPerformActions()) {
             $this->authorize('update', $this->model);
         }
 
         // Get the action configuration
-        $actions = $this->model->actions();
+        $actions = $legacyActions;
+        abort_unless(array_key_exists($action, $actions), 404);
         if (isset($actions[$action]['conditional_logic']) && ! $actions[$action]['conditional_logic']()) {
             abort(403, 'You are not authorized to perform this action.');
         }

--- a/tests/Feature/Resource/ResourceActionRegistryTest.php
+++ b/tests/Feature/Resource/ResourceActionRegistryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Aura\Base\Contracts\ResourceActionRegistry as ResourceActionRegistryContract;
+use Aura\Base\Exceptions\ResourceActionConflict;
+use Aura\Base\Resource;
+use Aura\Base\Services\ResourceActionRegistry;
+use Aura\Base\Traits\HasActions;
+use Illuminate\Auth\Access\AuthorizationException;
+
+class ContributedActionResource extends Resource
+{
+    public array $actions = [
+        'vendor.legacy' => ['label' => 'Resource-owned action'],
+    ];
+}
+
+class ResourceActionHarness
+{
+    use HasActions;
+
+    public Resource $model;
+}
+
+beforeEach(function () {
+    $this->actingAs(createSuperAdmin());
+});
+
+test('the registry contract resolves to one concrete singleton without alias recursion', function () {
+    $contract = app(ResourceActionRegistryContract::class);
+
+    expect($contract)->toBeInstanceOf(ResourceActionRegistry::class)
+        ->and(app(ResourceActionRegistryContract::class))->toBe($contract)
+        ->and(app(ResourceActionRegistry::class))->toBe($contract);
+});
+
+test('visibility and execution authorization are evaluated independently', function () {
+    $registry = new ResourceActionRegistry;
+    $resource = new ContributedActionResource;
+    $handlerCalled = false;
+    $registry->register('vendor.secure', [
+        'label' => 'Secure action',
+        'visible' => fn (): bool => true,
+        'authorize' => fn (): bool => false,
+        'handler' => function () use (&$handlerCalled): void {
+            $handlerCalled = true;
+        },
+    ]);
+
+    expect($registry->actionsFor($resource, null))->toHaveKey('vendor.secure');
+
+    try {
+        $registry->execute('vendor.secure', $resource, null);
+    } catch (AuthorizationException) {
+        // Expected: the server repeats execution authorization.
+    }
+
+    expect($handlerCalled)->toBeFalse();
+});
+
+test('resource-owned actions retain precedence over package-contributed keys', function () {
+    $registry = app(ResourceActionRegistryContract::class);
+    $registry->register('vendor.legacy', [
+        'label' => 'Package action',
+        'handler' => fn (): null => null,
+    ]);
+    $harness = new ResourceActionHarness;
+    $harness->model = new ContributedActionResource;
+
+    expect($harness->getActionsProperty()['vendor.legacy']['label'])->toBe('Resource-owned action');
+});
+
+test('duplicate names fail deterministically and worker flush restores boot baseline', function () {
+    $registry = new ResourceActionRegistry;
+    $definition = ['label' => 'One', 'handler' => fn (): null => null];
+    $registry->register('vendor.one', $definition);
+    $registry->captureBaselineState();
+    $registry->register('vendor.two', ['label' => 'Two', 'handler' => fn (): null => null]);
+    $registry->flushState();
+
+    expect($registry->actionsFor(new ContributedActionResource, null))
+        ->toHaveKey('vendor.one')
+        ->not->toHaveKey('vendor.two');
+
+    $registry->register('vendor.one', $definition);
+})->throws(ResourceActionConflict::class, 'already registered');


### PR DESCRIPTION
## Motivation

Commercial plugins (developed alongside Aura Reports) need to contribute Resource actions without mutating host Resource classes or shipping view overrides. Today, actions only come from `Resource::getActions()`, so every plugin-added action requires touching core Resources.

## What this adds

- **`Aura\Base\Contracts\ResourceActionRegistry`** — a small contract: `register()`, `actionsFor($resource, $actor)`, `execute($name, $resource, $actor)`, plus the boot/worker state hooks used by the other Aura singletons.
- **`Aura\Base\Services\ResourceActionRegistry`** — the singleton implementation. Plugins register namespaced action definitions (e.g. `aura-reports.duplicate`); duplicate names fail deterministically with `ResourceActionConflict`.
- **`HasActions` integration** — `getActionsProperty()` merges contributed actions with Resource-owned ones (Resource-owned actions keep precedence on name collisions), and `singleAction()` executes contributed actions through the registry. Contributed actions run a **fresh server-side authorization check** before execution; authorization failures abort with 403.
- **State lifecycle** — registrations made during package boot are captured as a baseline (`captureBaselineState()`), and `Aura::flushState()` / worker boundaries restore it, mirroring `TeamScope`/`ScopedScope` handling. The provider binds the singleton and captures the baseline in the existing `booted` hook.
- **View fix** — the actions blade no longer hides all actions behind the legacy ownership check; visibility is now computed in `HasActions` where contributed actions are also filtered for the actor.

## Security properties

- Contributed actions are re-authorized server-side at execution time; nothing relies on the rendered dropdown alone.
- `conditional_logic` on contributed definitions is evaluated like Resource-owned ones.
- Resource-owned actions always win name collisions, so a plugin cannot shadow a Resource's own action.
- Registration happens through the container-bound contract only; nothing is user/input-driven.

## Tests

`tests/Feature/Resource/ResourceActionRegistryTest.php` covers: contributed actions rendering for permitted actors, precedence on collisions, deterministic conflict failures, worker flush restoring the boot baseline, and execution authorization. Full local suite: **1825 passed, 4 skipped** (browser tests run in CI; Playwright not installed locally).

Developed while building the Aura Reports plugin — that plugin will consume this seam instead of overriding views.