### PR TITLE
docs: require 1.0 beta constraint in install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ Drop it in `app/Aura/Resources` and `/admin/article` serves a full CRUD interfac
 
 ## Installation
 
+Aura 1.0 is on Packagist as a beta release. Default Composer stability resolves `eminiarts/aura-cms` to `0.2.x`, so require the 1.0 beta channel explicitly:
+
 ```bash
-composer require eminiarts/aura-cms
+composer require eminiarts/aura-cms:^1.0@beta
 php artisan aura:install
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,7 +42,9 @@ php -m | grep -E 'bcmath|ctype|json|mbstring|openssl|pdo|tokenizer|xml|gd|imagic
 <a name="quick-installation"></a>
 ## Quick Installation
 
-For experienced Laravel developers, here's the fastest way to get started:
+For experienced Laravel developers, here's the fastest way to get started.
+
+Aura 1.0 is published as a beta on Packagist. Use `^1.0@beta` so Composer does not resolve the stable `0.2.x` line.
 
 ```bash
 # Create new Laravel project
@@ -55,8 +57,8 @@ cd my-aura-project
 # DB_USERNAME=root
 # DB_PASSWORD=
 
-# Install Aura CMS
-composer require eminiarts/aura-cms
+# Install Aura CMS (1.0 beta channel)
+composer require eminiarts/aura-cms:^1.0@beta
 
 # Publish, configure, migrate, and create the first administrator
 php artisan aura:install
@@ -130,10 +132,10 @@ php artisan db:show
 
 ```bash
 # Install via Composer
-composer require eminiarts/aura-cms
+composer require eminiarts/aura-cms:^1.0@beta
 
 # If you encounter memory issues
-COMPOSER_MEMORY_LIMIT=-1 composer require eminiarts/aura-cms
+COMPOSER_MEMORY_LIMIT=-1 composer require eminiarts/aura-cms:^1.0@beta
 ```
 
 ### Step 4: Publish and Configure Aura
@@ -350,7 +352,7 @@ cp .env.example .env
 docker-compose up -d --build
 
 # Install Aura CMS in container
-docker-compose exec app composer require eminiarts/aura-cms
+docker-compose exec app composer require eminiarts/aura-cms:^1.0@beta
 docker-compose exec app php artisan vendor:publish --tag=aura-config
 docker-compose exec app php artisan aura:install-config
 docker-compose exec app php artisan aura:extend-user-model
@@ -579,7 +581,7 @@ add_header Referrer-Policy "strict-origin-when-cross-origin";
 
 ```bash
 # Error: Allowed memory size exhausted
-COMPOSER_MEMORY_LIMIT=-1 composer require eminiarts/aura-cms
+COMPOSER_MEMORY_LIMIT=-1 composer require eminiarts/aura-cms:^1.0@beta
 ```
 
 #### 2. Permission Denied Errors

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -180,7 +180,7 @@ Fatal error: Allowed memory size of X bytes exhausted
 **Solution:**
 ```bash
 # Increase memory limit for composer
-COMPOSER_MEMORY_LIMIT=-1 composer require eminiarts/aura-cms
+COMPOSER_MEMORY_LIMIT=-1 composer require eminiarts/aura-cms:^1.0@beta
 ```
 
 ### Package Discovery Failed


### PR DESCRIPTION
## Why

Packagist latest is `v1.0.0-beta.4`, and the README support matrix matches that release (`PHP ^8.4`, Laravel `^12|^13`, Livewire `^4`). Under default Composer stability, bare `composer require eminiarts/aura-cms` still resolves to `^0.2.0`, so new installs miss the documented matrix.

## Scope

- `README.md` install command and a one-line beta note
- `docs/installation.md` and `docs/troubleshooting.md` require lines updated to `eminiarts/aura-cms:^1.0@beta`

Out of scope: tagging, Packagist publish, stable 1.0 release.

## Blast Radius

Docs only. Installers who copy the old command keep getting `0.2.x` until this lands.

## Verification

- `curl` Packagist `p2/eminiarts/aura-cms.json`: latest `v1.0.0-beta.4`
- `composer require eminiarts/aura-cms --dry-run` → `Using version ^0.2.0`
- `composer require eminiarts/aura-cms:^1.0@beta --dry-run` → locks `v1.0.0-beta.4`
- README Requirements vs `composer.json` require: match (pass after this install-command fix)

Explicit: this unit does not tag and does not publish.


Made with [Cursor](https://cursor.com)