### PR TITLE
docs: align install examples with PHP 8.4 support matrix

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -285,7 +285,7 @@ volumes:
 Create `Dockerfile`:
 
 ```dockerfile
-FROM php:8.2-fpm
+FROM php:8.4-fpm
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
@@ -610,10 +610,10 @@ DB_ENGINE=InnoDB
 php -m | grep -E 'bcmath|gd|imagick'
 
 # Install missing extensions (Ubuntu/Debian)
-sudo apt-get install php8.2-bcmath php8.2-gd php8.2-imagick
+sudo apt-get install php8.4-bcmath php8.4-gd php8.4-imagick
 
 # Install missing extensions (macOS with Homebrew)
-brew install php@8.2-gd php@8.2-imagick
+brew install php@8.4-gd php@8.4-imagick
 ```
 
 #### 5. Assets Not Loading
@@ -736,7 +736,7 @@ php artisan view:cache
 
 # 5. Restart services
 php artisan queue:restart
-sudo service php8.2-fpm restart
+sudo service php8.4-fpm restart
 sudo service nginx restart
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -215,12 +215,12 @@ Your requirements could not be resolved to an installable set of packages.
 **Ubuntu/Debian:**
 ```bash
 sudo apt-get update
-sudo apt-get install php8.2-bcmath php8.2-gd php8.2-mbstring php8.2-xml php8.2-curl php8.2-zip
+sudo apt-get install php8.4-bcmath php8.4-gd php8.4-mbstring php8.4-xml php8.4-curl php8.4-zip
 ```
 
 **macOS (Homebrew):**
 ```bash
-brew install php@8.2
+brew install php@8.4
 pecl install imagick
 ```
 
@@ -512,8 +512,8 @@ php artisan livewire:discover
 php artisan livewire:list
 
 # Ensure proper namespace
-namespace App\Http\Livewire; // Default
-namespace App\Livewire; // Laravel 11+
+namespace App\Http\Livewire; // Legacy apps
+namespace App\Livewire; // Laravel 12+ default
 ```
 
 ### Wire:model Not Updating


### PR DESCRIPTION
## Why

Package install and troubleshooting docs still showed PHP 8.2 Docker/apt/brew/FPM commands and a Laravel 11 Livewire namespace note. That drifts from `composer.json` (`php: ^8.4`, Laravel 12|13, Livewire 4) and from the requirements tables that already advertise the V1 matrix.

## Scope

- `docs/installation.md`: Docker base image, extension install commands, and `php-fpm` service name → 8.4
- `docs/troubleshooting.md`: extension install commands → 8.4; Livewire namespace comment → Laravel 12+
- Left `docs/adr/0001-v1-support-matrix.md` historical mentions of PHP 8.2 / Laravel 10–11 intact (they justify the narrowed matrix)
- No `CHANGELOG.md` edits
- README requirements were already correct

## Tradeoffs

None. Example commands only.

## Blast Radius

Docs readers who copy install snippets. Safe: no runtime code.

## Verification

- `rg -n 'PHP 8\.2|Laravel 10|Laravel 11' docs README.md` → only ADR historical context
- `composer.json` remains source of truth (`^8.4`, `^12.0|^13.0`, Livewire `^4.0`)


Made with [Cursor](https://cursor.com)